### PR TITLE
REF: Simplify metric implementations and align inputs

### DIFF
--- a/orca_python/metrics/metrics.py
+++ b/orca_python/metrics/metrics.py
@@ -42,7 +42,7 @@ def greater_is_better(metric_name):
         return False
 
 
-def ccr(y, ypred):
+def ccr(y_true, y_pred):
     """Calculate the Correctly Classified Ratio.
 
     Also named Accuracy, it's the percentage of well classified patterns among all
@@ -71,10 +71,10 @@ def ccr(y, ypred):
     0.5714285714285714
 
     """
-    return np.count_nonzero(y == ypred) / float(len(y))
+    return np.count_nonzero(y_true == y_pred) / float(len(y_true))
 
 
-def amae(y, ypred):
+def amae(y_true, y_pred):
     """Calculate the Average MAE.
 
     Mean of the MAE metric among classes.
@@ -104,17 +104,17 @@ def amae(y, ypred):
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cm = confusion_matrix(y, ypred)
+        cm = confusion_matrix(y_true, y_pred)
         n_class = cm.shape[0]
         costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
         costs = np.abs(costs - np.transpose(costs))
-        errores = costs * cm
-        amaes = np.sum(errores, axis=1) / np.sum(cm, axis=1).astype("double")
-        amaes = amaes[~np.isnan(amaes)]
-        return np.mean(amaes)
+        errors = costs * cm
+        per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
+        per_class_maes = per_class_maes[~np.isnan(per_class_maes)]
+        return np.mean(per_class_maes)
 
 
-def gm(y, ypred):
+def gm(y_true, y_pred):
     """Calculate the Geometric mean of the sensitivity (accuracy) for each class.
 
     Parameters
@@ -142,15 +142,15 @@ def gm(y, ypred):
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cm = confusion_matrix(y, ypred)
-        sum_byclass = np.sum(cm, axis=1)
-        sensitivities = np.diag(cm) / sum_byclass.astype("double")
-        sensitivities[sum_byclass == 0] = 1
-        gm_result = pow(np.prod(sensitivities), 1.0 / cm.shape[0])
-        return gm_result
+        cm = confusion_matrix(y_true, y_pred)
+        sum_by_class = np.sum(cm, axis=1)
+        sensitivities = np.diag(cm) / sum_by_class.astype("double")
+        sensitivities[sum_by_class == 0] = 1
+        gm = pow(np.prod(sensitivities), 1.0 / cm.shape[0])
+        return gm
 
 
-def mae(y, ypred):
+def mae(y_true, y_pred):
     """Calculate the Mean Absolute Error.
 
     Average absolute deviation of the predicted class from the actual true class.
@@ -180,12 +180,12 @@ def mae(y, ypred):
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        y = np.asarray(y)
-        ypred = np.asarray(ypred)
-        return abs(y - ypred).sum() / len(y)
+        y_true = np.asarray(y_true)
+        y_pred = np.asarray(y_pred)
+        return abs(y_true - y_pred).sum() / len(y_true)
 
 
-def mmae(y, ypred):
+def mmae(y_true, y_pred):
     """Calculate the Maximum Mean Absolute Error.
 
     MAE value of the class with higher distance from the true values to the predicted
@@ -216,17 +216,17 @@ def mmae(y, ypred):
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cm = confusion_matrix(y, ypred)
+        cm = confusion_matrix(y_true, y_pred)
         n_class = cm.shape[0]
-        costes = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
-        costes = np.abs(costes - np.transpose(costes))
-        errores = costes * cm
-        amaes = np.sum(errores, axis=1) / np.sum(cm, axis=1).astype("double")
-        amaes = amaes[~np.isnan(amaes)]
-        return amaes.max()
+        costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
+        costs = np.abs(costs - np.transpose(costs))
+        errors = costs * cm
+        per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
+        per_class_maes = per_class_maes[~np.isnan(per_class_maes)]
+        return per_class_maes.max()
 
 
-def ms(y, ypred):
+def ms(y_true, y_pred):
     """Calculate the Minimum Sensitivity.
 
     Lowest percentage of patterns correctly predicted as belonging to each class, with
@@ -257,16 +257,16 @@ def ms(y, ypred):
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        cm = confusion_matrix(y, ypred)
-        sum_byclass = np.sum(cm, axis=1)
-        sensitivities = np.diag(cm) / sum_byclass.astype("double")
-        sensitivities[sum_byclass == 0] = 1
+        cm = confusion_matrix(y_true, y_pred)
+        sum_by_class = np.sum(cm, axis=1)
+        sensitivities = np.diag(cm) / sum_by_class.astype("double")
+        sensitivities[sum_by_class == 0] = 1
         ms = np.min(sensitivities)
 
         return ms
 
 
-def mze(y, ypred):
+def mze(y_true, y_pred):
     """Calculate the Mean Zero-one Error.
 
     Better known as error rate, is the complementary measure of CCR.
@@ -297,11 +297,11 @@ def mze(y, ypred):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        confusion = confusion_matrix(y, ypred)
+        confusion = confusion_matrix(y_true, y_pred)
         return 1 - np.diagonal(confusion).sum() / confusion.sum()
 
 
-def tkendall(y, ypred):
+def tkendall(y_true, y_pred):
     """Calculate Kendall's tau.
 
     A statistic used to measure the association between two measured quantities. It is
@@ -333,11 +333,11 @@ def tkendall(y, ypred):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        corr, pvalue = scipy.stats.kendalltau(y, ypred)
+        corr, pvalue = scipy.stats.kendalltau(y_true, y_pred)
         return corr
 
 
-def wkappa(y, ypred):
+def wkappa(y_true, y_pred):
     """Calculate the Weighted Kappa.
 
     A modified version of the Kappa statistic calculated to allow assigning
@@ -369,11 +369,11 @@ def wkappa(y, ypred):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        cm = confusion_matrix(y, ypred)
+        cm = confusion_matrix(y_true, y_pred)
         n_class = cm.shape[0]
-        costes = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
-        costes = np.abs(costes - np.transpose(costes))
-        f = 1 - costes
+        costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
+        costs = np.abs(costs - np.transpose(costs))
+        f = 1 - costs
 
         n = cm.sum()
         x = cm / n
@@ -386,7 +386,7 @@ def wkappa(y, ypred):
         return (po - pe) / (1 - pe)
 
 
-def spearman(y, ypred):
+def spearman(y_true, y_pred):
     """Calculate the Spearman's rank correlation coefficient.
 
     A non-parametric measure of statistical dependence between two variables.
@@ -417,13 +417,14 @@ def spearman(y, ypred):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        n = len(y)
+        n = len(y_true)
         num = (
-            (y - np.repeat(np.mean(y), n)) * (ypred - np.repeat(np.mean(ypred), n))
+            (y_true - np.repeat(np.mean(y_true), n))
+            * (y_pred - np.repeat(np.mean(y_pred), n))
         ).sum()
         div = np.sqrt(
-            (pow(y - np.repeat(np.mean(y), n), 2)).sum()
-            * (pow(ypred - np.repeat(np.mean(ypred), n), 2)).sum()
+            (pow(y_true - np.repeat(np.mean(y_true), n), 2)).sum()
+            * (pow(y_pred - np.repeat(np.mean(y_pred), n), 2)).sum()
         )
 
         if num == 0:

--- a/orca_python/metrics/metrics.py
+++ b/orca_python/metrics/metrics.py
@@ -48,10 +48,10 @@ def ccr(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray, shape (n_samples,)
+    y_true : np.ndarray, shape (n_samples,)
         Ground truth labels.
 
-    ypred : np.ndarray, shape (n_samples,)
+    y_pred : np.ndarray, shape (n_samples,)
         Predicted labels.
 
     Returns
@@ -87,10 +87,10 @@ def amae(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray, shape (n_samples,)
+    y_true : np.ndarray, shape (n_samples,)
         Ground truth labels.
 
-    ypred : np.ndarray, shape (n_samples,)
+    y_pred : np.ndarray, shape (n_samples,)
         Predicted labels.
 
     Returns
@@ -131,10 +131,10 @@ def gm(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray, shape (n_samples,)
+    y_true : np.ndarray, shape (n_samples,)
         Ground truth labels.
 
-    ypred : np.ndarray, shape (n_samples,)
+    y_pred : np.ndarray, shape (n_samples,)
         Predicted labels.
 
     Returns
@@ -175,10 +175,10 @@ def mae(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray, shape (n_samples,)
+    y_true : np.ndarray, shape (n_samples,)
         Ground truth labels.
 
-    ypred : np.ndarray, shape (n_samples,)
+    y_pred : np.ndarray, shape (n_samples,)
         Predicted labels.
 
     Returns
@@ -215,10 +215,10 @@ def mmae(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray, shape (n_samples,)
+    y_true : np.ndarray, shape (n_samples,)
         Ground truth labels.
 
-    ypred : np.ndarray, shape (n_samples,)
+    y_pred : np.ndarray, shape (n_samples,)
         Predicted labels.
 
     Returns
@@ -262,10 +262,10 @@ def ms(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray, shape (n_samples,)
+    y_true : np.ndarray, shape (n_samples,)
         Ground truth labels.
 
-    ypred : np.ndarray, shape (n_samples,)
+    y_pred : np.ndarray, shape (n_samples,)
         Predicted labels.
 
     Returns
@@ -302,10 +302,10 @@ def mze(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray, shape (n_samples,)
+    y_true : np.ndarray, shape (n_samples,)
         Ground truth labels.
 
-    ypred : np.ndarray, shape (n_samples,)
+    y_pred : np.ndarray, shape (n_samples,)
         Predicted labels.
 
     Returns
@@ -343,10 +343,10 @@ def tkendall(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray
+    y_true : np.ndarray
         Ground truth labels.
 
-    ypred : np.ndarray
+    y_pred : np.ndarray
         Predicted labels.
 
     Returns
@@ -384,10 +384,10 @@ def wkappa(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray, shape (n_samples,)
+    y_true : np.ndarray, shape (n_samples,)
         Ground truth labels.
 
-    ypred : np.ndarray, shape (n_samples,)
+    y_pred : np.ndarray, shape (n_samples,)
         Predicted labels.
 
     Returns
@@ -437,10 +437,10 @@ def spearman(y_true, y_pred):
 
     Parameters
     ----------
-    y : np.ndarray, shape (n_samples,)
+    y_true : np.ndarray, shape (n_samples,)
         Ground truth labels.
 
-    ypred : np.ndarray, shape (n_samples,)
+    y_pred : np.ndarray, shape (n_samples,)
         Predicted labels.
 
     Returns

--- a/orca_python/metrics/metrics.py
+++ b/orca_python/metrics/metrics.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import numpy as np
 import scipy.stats
-from sklearn.metrics import confusion_matrix
+from sklearn.metrics import confusion_matrix, recall_score
 
 
 def greater_is_better(metric_name):
@@ -291,13 +291,8 @@ def ms(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    cm = confusion_matrix(y_true, y_pred)
-    sum_by_class = np.sum(cm, axis=1)
-    sensitivities = np.diag(cm) / sum_by_class.astype("double")
-    sensitivities[sum_by_class == 0] = 1
-    ms = np.min(sensitivities)
-
-    return ms
+    sensitivities = recall_score(y_true, y_pred, average=None)
+    return np.min(sensitivities)
 
 
 def mze(y_true, y_pred):

--- a/orca_python/metrics/metrics.py
+++ b/orca_python/metrics/metrics.py
@@ -71,6 +71,14 @@ def ccr(y_true, y_pred):
     0.5714285714285714
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     return np.count_nonzero(y_true == y_pred) / float(len(y_true))
 
 
@@ -102,6 +110,14 @@ def amae(y_true, y_pred):
     np.float64(0.125)
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         cm = confusion_matrix(y_true, y_pred)
@@ -140,6 +156,14 @@ def gm(y_true, y_pred):
     np.float64(0.8408964152537145)
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         cm = confusion_matrix(y_true, y_pred)
@@ -178,6 +202,14 @@ def mae(y_true, y_pred):
     np.float64(0.2857142857142857)
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         y_true = np.asarray(y_true)
@@ -214,6 +246,14 @@ def mmae(y_true, y_pred):
     np.float64(0.5)
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         cm = confusion_matrix(y_true, y_pred)
@@ -255,6 +295,14 @@ def ms(y_true, y_pred):
     np.float64(0.5)
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         cm = confusion_matrix(y_true, y_pred)
@@ -294,6 +342,14 @@ def mze(y_true, y_pred):
     np.float64(0.2857142857142857)
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
@@ -330,6 +386,14 @@ def tkendall(y_true, y_pred):
     np.float64(0.8140915784106943)
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
@@ -366,6 +430,14 @@ def wkappa(y_true, y_pred):
     np.float64(0.7586206896551724)
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
@@ -414,6 +486,14 @@ def spearman(y_true, y_pred):
     np.float64(0.9165444688834581)
 
     """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    if len(y_true.shape) > 1:
+        y_true = np.argmax(y_true, axis=1)
+    if len(y_pred.shape) > 1:
+        y_pred = np.argmax(y_pred, axis=1)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 

--- a/orca_python/metrics/metrics.py
+++ b/orca_python/metrics/metrics.py
@@ -2,8 +2,6 @@
 
 from __future__ import division
 
-import warnings
-
 import numpy as np
 import scipy.stats
 from sklearn.metrics import confusion_matrix
@@ -118,16 +116,14 @@ def amae(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        cm = confusion_matrix(y_true, y_pred)
-        n_class = cm.shape[0]
-        costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
-        costs = np.abs(costs - np.transpose(costs))
-        errors = costs * cm
-        per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
-        per_class_maes = per_class_maes[~np.isnan(per_class_maes)]
-        return np.mean(per_class_maes)
+    cm = confusion_matrix(y_true, y_pred)
+    n_class = cm.shape[0]
+    costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
+    costs = np.abs(costs - np.transpose(costs))
+    errors = costs * cm
+    per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
+    per_class_maes = per_class_maes[~np.isnan(per_class_maes)]
+    return np.mean(per_class_maes)
 
 
 def gm(y_true, y_pred):
@@ -164,14 +160,12 @@ def gm(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        cm = confusion_matrix(y_true, y_pred)
-        sum_by_class = np.sum(cm, axis=1)
-        sensitivities = np.diag(cm) / sum_by_class.astype("double")
-        sensitivities[sum_by_class == 0] = 1
-        gm = pow(np.prod(sensitivities), 1.0 / cm.shape[0])
-        return gm
+    cm = confusion_matrix(y_true, y_pred)
+    sum_by_class = np.sum(cm, axis=1)
+    sensitivities = np.diag(cm) / sum_by_class.astype("double")
+    sensitivities[sum_by_class == 0] = 1
+    gm = pow(np.prod(sensitivities), 1.0 / cm.shape[0])
+    return gm
 
 
 def mae(y_true, y_pred):
@@ -210,11 +204,7 @@ def mae(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        y_true = np.asarray(y_true)
-        y_pred = np.asarray(y_pred)
-        return abs(y_true - y_pred).sum() / len(y_true)
+    return abs(y_true - y_pred).sum() / len(y_true)
 
 
 def mmae(y_true, y_pred):
@@ -254,16 +244,14 @@ def mmae(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        cm = confusion_matrix(y_true, y_pred)
-        n_class = cm.shape[0]
-        costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
-        costs = np.abs(costs - np.transpose(costs))
-        errors = costs * cm
-        per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
-        per_class_maes = per_class_maes[~np.isnan(per_class_maes)]
-        return per_class_maes.max()
+    cm = confusion_matrix(y_true, y_pred)
+    n_class = cm.shape[0]
+    costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
+    costs = np.abs(costs - np.transpose(costs))
+    errors = costs * cm
+    per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
+    per_class_maes = per_class_maes[~np.isnan(per_class_maes)]
+    return per_class_maes.max()
 
 
 def ms(y_true, y_pred):
@@ -303,15 +291,13 @@ def ms(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        cm = confusion_matrix(y_true, y_pred)
-        sum_by_class = np.sum(cm, axis=1)
-        sensitivities = np.diag(cm) / sum_by_class.astype("double")
-        sensitivities[sum_by_class == 0] = 1
-        ms = np.min(sensitivities)
+    cm = confusion_matrix(y_true, y_pred)
+    sum_by_class = np.sum(cm, axis=1)
+    sensitivities = np.diag(cm) / sum_by_class.astype("double")
+    sensitivities[sum_by_class == 0] = 1
+    ms = np.min(sensitivities)
 
-        return ms
+    return ms
 
 
 def mze(y_true, y_pred):
@@ -350,11 +336,8 @@ def mze(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-
-        confusion = confusion_matrix(y_true, y_pred)
-        return 1 - np.diagonal(confusion).sum() / confusion.sum()
+    confusion = confusion_matrix(y_true, y_pred)
+    return 1 - np.diagonal(confusion).sum() / confusion.sum()
 
 
 def tkendall(y_true, y_pred):
@@ -394,11 +377,8 @@ def tkendall(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-
-        corr, pvalue = scipy.stats.kendalltau(y_true, y_pred)
-        return corr
+    corr, pvalue = scipy.stats.kendalltau(y_true, y_pred)
+    return corr
 
 
 def wkappa(y_true, y_pred):
@@ -438,24 +418,21 @@ def wkappa(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    cm = confusion_matrix(y_true, y_pred)
+    n_class = cm.shape[0]
+    costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
+    costs = np.abs(costs - np.transpose(costs))
+    f = 1 - costs
 
-        cm = confusion_matrix(y_true, y_pred)
-        n_class = cm.shape[0]
-        costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
-        costs = np.abs(costs - np.transpose(costs))
-        f = 1 - costs
+    n = cm.sum()
+    x = cm / n
 
-        n = cm.sum()
-        x = cm / n
-
-        r = x.sum(axis=1)  # Row sum
-        s = x.sum(axis=0)  # Col sum
-        Ex = r.reshape(-1, 1) * s
-        po = (x * f).sum()
-        pe = (Ex * f).sum()
-        return (po - pe) / (1 - pe)
+    r = x.sum(axis=1)  # Row sum
+    s = x.sum(axis=0)  # Col sum
+    Ex = r.reshape(-1, 1) * s
+    po = (x * f).sum()
+    pe = (Ex * f).sum()
+    return (po - pe) / (1 - pe)
 
 
 def spearman(y_true, y_pred):
@@ -494,20 +471,17 @@ def spearman(y_true, y_pred):
     if len(y_pred.shape) > 1:
         y_pred = np.argmax(y_pred, axis=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    n = len(y_true)
+    num = (
+        (y_true - np.repeat(np.mean(y_true), n))
+        * (y_pred - np.repeat(np.mean(y_pred), n))
+    ).sum()
+    div = np.sqrt(
+        (pow(y_true - np.repeat(np.mean(y_true), n), 2)).sum()
+        * (pow(y_pred - np.repeat(np.mean(y_pred), n), 2)).sum()
+    )
 
-        n = len(y_true)
-        num = (
-            (y_true - np.repeat(np.mean(y_true), n))
-            * (y_pred - np.repeat(np.mean(y_pred), n))
-        ).sum()
-        div = np.sqrt(
-            (pow(y_true - np.repeat(np.mean(y_true), n), 2)).sum()
-            * (pow(y_pred - np.repeat(np.mean(y_pred), n), 2)).sum()
-        )
-
-        if num == 0:
-            return 0
-        else:
-            return num / div
+    if num == 0:
+        return 0
+    else:
+        return num / div


### PR DESCRIPTION
- Use consistent variable naming (`y_pred`, `errors`, `per_class_maes`, etc.).
- Convert input lists to NumPy arrays at the start of each function.
- Ensure soft-to-hard label conversion using `argmax` when needed.
- Remove deprecated `warnings.catch_warnings` blocks.