### PR TITLE
BUG: AMAE and MMAE correction

### DIFF
--- a/orca_python/metrics/metrics.py
+++ b/orca_python/metrics/metrics.py
@@ -121,8 +121,13 @@ def amae(y_true, y_pred):
     costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
     costs = np.abs(costs - np.transpose(costs))
     errors = costs * cm
+
+    # Remove rows with all zeros in the confusion matrix
+    non_zero_cm_rows = ~np.all(cm == 0, axis=1)
+    errors = errors[non_zero_cm_rows]
+    cm = cm[non_zero_cm_rows]
+
     per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
-    per_class_maes = per_class_maes[~np.isnan(per_class_maes)]
     return np.mean(per_class_maes)
 
 
@@ -249,8 +254,13 @@ def mmae(y_true, y_pred):
     costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
     costs = np.abs(costs - np.transpose(costs))
     errors = costs * cm
+
+    # Remove rows with all zeros in the confusion matrix
+    non_zero_cm_rows = ~np.all(cm == 0, axis=1)
+    errors = errors[non_zero_cm_rows]
+    cm = cm[non_zero_cm_rows]
+
     per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
-    per_class_maes = per_class_maes[~np.isnan(per_class_maes)]
     return per_class_maes.max()
 
 

--- a/orca_python/metrics/tests/test_metrics.py
+++ b/orca_python/metrics/tests/test_metrics.py
@@ -81,6 +81,12 @@ def test_amae():
     actual = amae(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
+    y_true = np.array([0, 1, 2, 3, 3])
+    y_pred = np.array([0, 1, 2, 3, 4])
+    expected = 0.125
+    actual = amae(y_true, y_pred)
+    npt.assert_almost_equal(expected, actual, decimal=6)
+
 
 def test_gm():
     """Test the Geometric Mean (GM) metric."""
@@ -143,6 +149,12 @@ def test_mmae():
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
+    expected = 0.5
+    actual = mmae(y_true, y_pred)
+    npt.assert_almost_equal(expected, actual, decimal=6)
+
+    y_true = np.array([0, 1, 2, 3, 3])
+    y_pred = np.array([0, 1, 2, 3, 4])
     expected = 0.5
     actual = mmae(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Fix shape mismatch and division errors in AMAE and MMAE when `y_true` lacks one or more classes. Ensures confusion matrix and cost matrix remain aligned.