### PR TITLE
TST: Refactor and expand classifiers test suite

### DIFF
--- a/orca_python/classifiers/tests/test_nnop.py
+++ b/orca_python/classifiers/tests/test_nnop.py
@@ -18,16 +18,19 @@ def y():
     return np.array([0, 1, 1, 0, 1])
 
 
-def test_nnop_fit_hyperparameters_validation(X, y):
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("n_hidden", -1),
+        ("max_iter", -1),
+    ],
+)
+def test_nnop_fit_hyperparameters_validation(X, y, param_name, invalid_value):
     """Test that hyperparameters are validated."""
-    classifiers = [
-        NNOP(n_hidden=-1),
-        NNOP(max_iter=-1),
-    ]
+    classifier = NNOP(**{param_name: invalid_value})
+    model = classifier.fit(X, y)
 
-    for classifier in classifiers:
-        model = classifier.fit(X, y)
-        assert model is None, "The NNOP fit method doesnt return Null on error"
+    assert model is None, "The NNOP fit method doesnt return Null on error"
 
 
 def test_nnop_fit_input_validation(X, y):

--- a/orca_python/classifiers/tests/test_nnpom.py
+++ b/orca_python/classifiers/tests/test_nnpom.py
@@ -18,16 +18,19 @@ def y():
     return np.array([0, 1, 1, 0, 1])
 
 
-def test_nnpom_fit_hyperparameters_validation(X, y):
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("n_hidden", -1),
+        ("max_iter", -1),
+    ],
+)
+def test_nnpom_fit_hyperparameters_validation(X, y, param_name, invalid_value):
     """Test that hyperparameters are validated."""
-    classifiers = [
-        NNPOM(n_hidden=-1),
-        NNPOM(max_iter=-1),
-    ]
+    classifier = NNPOM(**{param_name: invalid_value})
+    model = classifier.fit(X, y)
 
-    for classifier in classifiers:
-        model = classifier.fit(X, y)
-        assert model is None, "The NNPOM fit method doesnt return Null on error"
+    assert model is None, "The NNPOM fit method doesnt return Null on error"
 
 
 def test_nnpom_fit_input_validation(X, y):

--- a/orca_python/classifiers/tests/test_ordinal_decomposition.py
+++ b/orca_python/classifiers/tests/test_ordinal_decomposition.py
@@ -20,7 +20,7 @@ def y():
 
 
 def test_ordinal_decomposition(X, y):
-    """Test that the algorithm can correctly classify a toy problem."""
+    """Check if this algorithm can correctly classify a toy problem."""
     classifier = OrdinalDecomposition(
         dtype="ordered_partitions",
         decision_method="frank_hall",
@@ -55,47 +55,64 @@ def test_ordinal_decomposition_fit_input_validation(X, y):
         assert model is None, "The fit method doesnt return Null on error"
 
 
-def test_coding_matrix():
+@pytest.mark.parametrize(
+    "dtype, expected_cm",
+    [
+        (
+            "ordered_partitions",
+            np.array(
+                [
+                    [-1, -1, -1, -1],
+                    [1, -1, -1, -1],
+                    [1, 1, -1, -1],
+                    [1, 1, 1, -1],
+                    [1, 1, 1, 1],
+                ]
+            ),
+        ),
+        (
+            "one_vs_next",
+            np.array(
+                [
+                    [-1, 0, 0, 0],
+                    [1, -1, 0, 0],
+                    [0, 1, -1, 0],
+                    [0, 0, 1, -1],
+                    [0, 0, 0, 1],
+                ]
+            ),
+        ),
+        (
+            "one_vs_followers",
+            np.array(
+                [
+                    [-1, 0, 0, 0],
+                    [1, -1, 0, 0],
+                    [1, 1, -1, 0],
+                    [1, 1, 1, -1],
+                    [1, 1, 1, 1],
+                ]
+            ),
+        ),
+        (
+            "one_vs_previous",
+            np.array(
+                [
+                    [1, 1, 1, 1],
+                    [1, 1, 1, -1],
+                    [1, 1, -1, 0],
+                    [1, -1, 0, 0],
+                    [-1, 0, 0, 0],
+                ]
+            ),
+        ),
+    ],
+)
+def test_coding_matrix(dtype, expected_cm):
     """Test that the coding matrix is built properly for each type of ordinal
     decomposition."""
     classifier = OrdinalDecomposition()
-
-    # Checking ordered_partitions (with a 5 class, 4 classifiers example)
-    classifier.dtype = "ordered_partitions"
-    expected_cm = np.array(
-        [[-1, -1, -1, -1], [1, -1, -1, -1], [1, 1, -1, -1], [1, 1, 1, -1], [1, 1, 1, 1]]
-    )
-
-    cm = classifier._coding_matrix(classifier.dtype, 5)
-
-    npt.assert_array_equal(cm, expected_cm)
-
-    # Checking one_vs_next
-    classifier.dtype = "one_vs_next"
-    expected_cm = np.array(
-        [[-1, 0, 0, 0], [1, -1, 0, 0], [0, 1, -1, 0], [0, 0, 1, -1], [0, 0, 0, 1]]
-    )
-
-    cm = classifier._coding_matrix(classifier.dtype, 5)
-
-    npt.assert_array_equal(cm, expected_cm)
-
-    # Checking one_vs_followers
-    classifier.dtype = "one_vs_followers"
-    expected_cm = np.array(
-        [[-1, 0, 0, 0], [1, -1, 0, 0], [1, 1, -1, 0], [1, 1, 1, -1], [1, 1, 1, 1]]
-    )
-
-    cm = classifier._coding_matrix(classifier.dtype, 5)
-
-    npt.assert_array_equal(cm, expected_cm)
-
-    # Checking one_vs_previous
-    classifier.dtype = "one_vs_previous"
-    expected_cm = np.array(
-        [[1, 1, 1, 1], [1, 1, 1, -1], [1, 1, -1, 0], [1, -1, 0, 0], [-1, 0, 0, 0]]
-    )
-
+    classifier.dtype = dtype
     cm = classifier._coding_matrix(classifier.dtype, 5)
 
     npt.assert_array_equal(cm, expected_cm)
@@ -128,8 +145,8 @@ def test_frank_hall_method(X):
         ]
     )
 
-    y_prob = classifier._frank_hall_method(predictions)
-    expected_y_prob = np.array(
+    y_proba = classifier._frank_hall_method(predictions)
+    expected_y_proba = np.array(
         [
             [0.92505, 0.07492, -0.06858, 0.06856, 0.00005],
             [0.99983, 0.00017, -0.03174, 0.03163, 0.00011],
@@ -146,8 +163,8 @@ def test_frank_hall_method(X):
 
     # Asserting similarity
     npt.assert_allclose(
-        y_prob,
-        expected_y_prob,
+        y_proba,
+        expected_y_proba,
         rtol=1e-04,
         atol=0,
     )
@@ -178,8 +195,8 @@ def test_exponential_loss_method():
     # Interpoling values from [0, 1] range to [-1, 1]
     predictions = (2 * predictions) - 1
 
-    e_loss = classifier._exponential_loss(predictions)
-    expected_e_loss = np.array(
+    e_losses = classifier._exponential_loss(predictions)
+    expected_e_losses = np.array(
         [
             [1.5852, 3.49769, 5.8479, 7.79566, 10.14575],
             [1.49583, 3.84519, 6.19559, 8.35469, 10.70441],
@@ -195,7 +212,7 @@ def test_exponential_loss_method():
     )
 
     # Asserting similarity
-    npt.assert_allclose(e_loss, expected_e_loss, rtol=1e-04, atol=0)
+    npt.assert_allclose(e_losses, expected_e_losses, rtol=1e-04, atol=0)
 
 
 def test_logarithmic_loss_method():
@@ -223,8 +240,8 @@ def test_logarithmic_loss_method():
     # Interpoling values from [0, 1] range to [-1, 1]
     predictions = (2 * predictions) - 1
 
-    l_loss = classifier._logarithmic_loss(predictions)
-    expected_l_loss = np.array(
+    l_losses = classifier._logarithmic_loss(predictions)
+    expected_l_losses = np.array(
         [
             [0.58553, 2.28573, 4.28561, 6.01117, 8.01097],
             [0.52385, 2.52317, 4.52317, 6.39621, 8.39577],
@@ -240,7 +257,7 @@ def test_logarithmic_loss_method():
     )
 
     # Asserting similarity
-    npt.assert_allclose(l_loss, expected_l_loss, rtol=1e-04, atol=0)
+    npt.assert_allclose(l_losses, expected_l_losses, rtol=1e-04, atol=0)
 
 
 def test_hinge_loss_method():
@@ -268,8 +285,8 @@ def test_hinge_loss_method():
     # Interpoling values from [0, 1] range to [-1, 1]
     predictions = (2 * predictions) - 1
 
-    h_loss = classifier._hinge_loss(predictions)
-    expected_h_loss = np.array(
+    h_losses = classifier._hinge_loss(predictions)
+    expected_h_losses = np.array(
         [
             [0.28728, 1.98748, 3.98736, 5.71292, 7.71272],
             [0.06404, 2.06336, 4.06336, 5.9364, 7.93596],
@@ -285,7 +302,7 @@ def test_hinge_loss_method():
     )
 
     # Asserting similarity
-    npt.assert_allclose(h_loss, expected_h_loss, rtol=1e-04, atol=0)
+    npt.assert_allclose(h_losses, expected_h_losses, rtol=1e-04, atol=0)
 
 
 def test_ordinal_decomposition_predict_invalid_input_raises_error(X, y):

--- a/orca_python/classifiers/tests/test_redsvm.py
+++ b/orca_python/classifiers/tests/test_redsvm.py
@@ -21,139 +21,66 @@ def y():
     return np.array([0, 1, 1, 0, 1])
 
 
-def test_redsvm_predict_matches_expected():
+@pytest.mark.parametrize(
+    "kernel, degree, gamma, coef0, C, cache_size, tol, shrinking, expected_file",
+    [
+        (0, 2, 0.1, 0.5, 0.1, 150, 0.005, 0, "expectedPredictions.0"),
+        (1, 2, 0.1, 0.5, 0.1, 150, 0.005, 0, "expectedPredictions.1"),
+        (2, 2, 0.1, 0.5, 0.1, 150, 0.005, 0, "expectedPredictions.2"),
+        (3, 2, 0.1, 0.5, 0.1, 150, 0.005, 0, "expectedPredictions.3"),
+        (4, 2, 0.1, 0.5, 0.1, 150, 0.005, 0, "expectedPredictions.4"),
+        (5, 2, 0.1, 0.5, 0.1, 150, 0.005, 0, "expectedPredictions.5"),
+        (6, 2, 0.1, 0.5, 0.1, 150, 0.005, 0, "expectedPredictions.6"),
+        (7, 2, 0.1, 0.5, 0.1, 150, 0.005, 0, "expectedPredictions.7"),
+    ],
+)
+def test_redsvm_predict_matches_expected(
+    kernel, degree, gamma, coef0, C, cache_size, tol, shrinking, expected_file
+):
     """Test that predictions match expected values."""
     X_train, y_train, X_test, _ = load_dataset(
         dataset_name="balance-scale", data_path=TEST_DATASETS_DIR
     )
 
-    expected_files = [
-        TEST_PREDICTIONS_DIR / "REDSVM" / "expectedPredictions.0",
-        TEST_PREDICTIONS_DIR / "REDSVM" / "expectedPredictions.1",
-        TEST_PREDICTIONS_DIR / "REDSVM" / "expectedPredictions.2",
-        TEST_PREDICTIONS_DIR / "REDSVM" / "expectedPredictions.3",
-        TEST_PREDICTIONS_DIR / "REDSVM" / "expectedPredictions.4",
-        TEST_PREDICTIONS_DIR / "REDSVM" / "expectedPredictions.5",
-        TEST_PREDICTIONS_DIR / "REDSVM" / "expectedPredictions.6",
-        TEST_PREDICTIONS_DIR / "REDSVM" / "expectedPredictions.7",
-    ]
+    classifier = REDSVM(
+        kernel=kernel,
+        degree=degree,
+        gamma=gamma,
+        coef0=coef0,
+        C=C,
+        cache_size=cache_size,
+        tol=tol,
+        shrinking=shrinking,
+    )
 
-    classifiers = [
-        REDSVM(
-            kernel=0,
-            degree=2,
-            gamma=0.1,
-            coef0=0.5,
-            C=0.1,
-            cache_size=150,
-            tol=0.005,
-            shrinking=0,
-        ),
-        REDSVM(
-            kernel=1,
-            degree=2,
-            gamma=0.1,
-            coef0=0.5,
-            C=0.1,
-            cache_size=150,
-            tol=0.005,
-            shrinking=0,
-        ),
-        REDSVM(
-            kernel=2,
-            degree=2,
-            gamma=0.1,
-            coef0=0.5,
-            C=0.1,
-            cache_size=150,
-            tol=0.005,
-            shrinking=0,
-        ),
-        REDSVM(
-            kernel=3,
-            degree=2,
-            gamma=0.1,
-            coef0=0.5,
-            C=0.1,
-            cache_size=150,
-            tol=0.005,
-            shrinking=0,
-        ),
-        REDSVM(
-            kernel=4,
-            degree=2,
-            gamma=0.1,
-            coef0=0.5,
-            C=0.1,
-            cache_size=150,
-            tol=0.005,
-            shrinking=0,
-        ),
-        REDSVM(
-            kernel=5,
-            degree=2,
-            gamma=0.1,
-            coef0=0.5,
-            C=0.1,
-            cache_size=150,
-            tol=0.005,
-            shrinking=1,
-        ),
-        REDSVM(
-            kernel=6,
-            degree=2,
-            gamma=0.1,
-            coef0=0.5,
-            C=0.1,
-            cache_size=150,
-            tol=0.005,
-            shrinking=1,
-        ),
-        REDSVM(
-            kernel=7,
-            degree=2,
-            gamma=0.1,
-            coef0=0.5,
-            C=0.1,
-            cache_size=150,
-            tol=0.005,
-            shrinking=1,
-        ),
-    ]
+    classifier.fit(X_train, y_train)
+    y_pred = classifier.predict(X_test)
+    y_expected = np.loadtxt(TEST_PREDICTIONS_DIR / "REDSVM" / expected_file)
 
-    for expected_file, classifier in zip(expected_files, classifiers):
-        classifier.fit(X_train, y_train)
-        y_pred = classifier.predict(X_test)
-        y_expected = np.loadtxt(expected_file)
-        npt.assert_equal(
-            y_pred,
-            y_expected,
-            "The prediction doesnt match with the desired values",
-        )
+    npt.assert_equal(
+        y_pred, y_expected, "The prediction doesnt match with the desired values"
+    )
 
 
-def test_redsvm_fit_hyperparameters_validation(X, y):
+@pytest.mark.parametrize(
+    "param_name, invalid_value, error_msg",
+    [
+        ("kernel", -1, "unknown kernel type"),
+        ("cache_size", -1, "cache_size <= 0"),
+        ("tol", -1, "eps <= 0"),
+        ("shrinking", 2, "shrinking != 0 and shrinking != 1"),
+        ("kernel", 8, "Wrong input format: sample_serial_number out of range"),
+    ],
+)
+def test_redsvm_fit_hyperparameters_validation(
+    X, y, param_name, invalid_value, error_msg
+):
     """Test that hyperparameters are validated."""
-    classifiers = [
-        REDSVM(kernel=-1),
-        REDSVM(cache_size=-1),
-        REDSVM(tol=-1),
-        REDSVM(shrinking=2),
-        REDSVM(kernel=8),
-    ]
+    classifier = REDSVM(**{param_name: invalid_value})
 
-    error_msgs = [
-        "unknown kernel type",
-        "cache_size <= 0",
-        "eps <= 0",
-        "shrinking != 0 and shrinking != 1",
-        "Wrong input format: sample_serial_number out of range",
-    ]
-
-    for classifier, error_msg in zip(classifiers, error_msgs):
-        with pytest.raises(ValueError, match=error_msg):
-            model = classifier.fit(X, y)
-            assert model is None, "The REDSVM fit method doesnt return Null on error"
+    with pytest.raises(ValueError, match=error_msg):
+        model = classifier.fit(X, y)
+        assert model is None, "The REDSVM fit method doesnt return Null on error"
 
 
 def test_redsvm_fit_input_validation(X, y):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

This PR refactors the classifier test suite to improve code quality and expand test coverage.
- Add reusable `X` and `y` fixtures and `load_dataset` utility.
- Remove unused tests and fixtures.
- Parametrize tests with `pytest.mark.parametrize`.
- Simplify logic and rename test functions/variables for clarity.
- Add input validation tests for `OrdinalDecomposition`.
- Add docstrings and clean up comments.
