### PR TITLE
REF: Use string-based kernel identifiers in SVOREX and REDSVM

### DIFF
--- a/orca_python/classifiers/REDSVM.py
+++ b/orca_python/classifiers/REDSVM.py
@@ -77,7 +77,7 @@ class REDSVM(BaseEstimator, ClassifierMixin):
     def __init__(
         self,
         C=1,
-        kernel=2,
+        kernel="rbf",
         degree=3,
         gamma=None,
         coef0=0,
@@ -126,9 +126,23 @@ class REDSVM(BaseEstimator, ClassifierMixin):
         if self.gamma is None:
             self.gamma = 1 / np.size(X, 1)
 
+        # Map kernel type
+        kernel_type_mapping = {
+            "linear": 0,
+            "poly": 1,
+            "rbf": 2,
+            "sigmoid": 3,
+            "stump": 4,
+            "perceptron": 5,
+            "laplacian": 6,
+            "exponential": 7,
+            "precomputed": 8,
+        }
+        kernel_type = kernel_type_mapping.get(self.kernel, -1)
+
         # Fit the model
         options = "-s 5 -t {} -d {} -g {} -r {} -c {} -m {} -e {} -h {} -q".format(
-            str(self.kernel),
+            str(kernel_type),
             str(self.degree),
             str(self.gamma),
             str(self.coef0),

--- a/orca_python/classifiers/REDSVM.py
+++ b/orca_python/classifiers/REDSVM.py
@@ -22,17 +22,17 @@ class REDSVM(BaseEstimator, ClassifierMixin):
     C : float, default=1
         Set the parameter C.
 
-    kernel : int, default=2
+    kernel : str, default="rbf"
         Set type of kernel function.
-        0 -- linear: u'*v
-        1 -- polynomial: (gamma*u'*v + coef0)^degree
-        2 -- radial basis function: exp(-gamma*|u-v|^2)
-        3 -- sigmoid: tanh(gamma*u'*v + coef0)
-        4 -- stump: -|u-v|_1 + coef0
-        5 -- perceptron: -|u-v|_2 + coef0
-        6 -- laplacian: exp(-gamma*|u-v|_1)
-        7 -- exponential: exp(-gamma*|u-v|_2)
-        8 -- precomputed kernel (kernel values in training_instance_matrix)
+        - linear: u'*v
+        - polynomial: (gamma*u'*v + coef0)^degree
+        - rbf: exp(-gamma*|u-v|^2)
+        - sigmoid: tanh(gamma*u'*v + coef0)
+        - stump: -|u-v|_1 + coef0
+        - perceptron: -|u-v|_2 + coef0
+        - laplacian: exp(-gamma*|u-v|_1)
+        - exponential: exp(-gamma*|u-v|_2)
+        - precomputed: kernel values in training_instance_matrix
 
     degree : int, default=3
         Set degree in kernel function.

--- a/orca_python/classifiers/SVOREX.py
+++ b/orca_python/classifiers/SVOREX.py
@@ -56,7 +56,7 @@ class SVOREX(BaseEstimator, ClassifierMixin):
 
     """
 
-    def __init__(self, C=1.0, kernel=0, degree=2, tol=0.001, kappa=1):
+    def __init__(self, C=1.0, kernel="gaussian", degree=2, tol=0.001, kappa=1):
         self.C = C
         self.kernel = kernel
         self.degree = degree
@@ -93,9 +93,9 @@ class SVOREX(BaseEstimator, ClassifierMixin):
 
         arg = ""
         # Prepare the kernel type arguments
-        if self.kernel == 1:
+        if self.kernel == "linear":
             arg = "-L"
-        elif self.kernel == 2:
+        elif self.kernel == "poly":
             arg = "-P {}".format(self.degree)
 
         # Fit the model

--- a/orca_python/classifiers/SVOREX.py
+++ b/orca_python/classifiers/SVOREX.py
@@ -20,11 +20,11 @@ class SVOREX(BaseEstimator, ClassifierMixin):
     C : float, default=1
         Set the parameter C.
 
-    kernel : int, default=0
+    kernel : str, default="gaussian"
         Set type of kernel function.
-        0 -- gaussian: use gaussian kernel
-        1 -- linear: use imbalanced Linear kernel
-        2 -- polynomial: use Polynomial kernel with order p
+        - gaussian: use gaussian kernel
+        - linear: use imbalanced Linear kernel
+        - poly: use Polynomial kernel with order p
 
     degree : int, default=2
         Set degree in kernel function.

--- a/orca_python/classifiers/tests/test_redsvm.py
+++ b/orca_python/classifiers/tests/test_redsvm.py
@@ -24,14 +24,14 @@ def y():
 @pytest.mark.parametrize(
     "kernel, expected_file",
     [
-        (0, "predictions_linear_0.csv"),
-        (1, "predictions_poly_0.csv"),
-        (2, "predictions_rbf_0.csv"),
-        (3, "predictions_sigmoid_0.csv"),
-        (4, "predictions_stump_0.csv"),
-        (5, "predictions_perceptron_0.csv"),
-        (6, "predictions_laplacian_0.csv"),
-        (7, "predictions_exponential_0.csv"),
+        ("linear", "predictions_linear_0.csv"),
+        ("poly", "predictions_poly_0.csv"),
+        ("rbf", "predictions_rbf_0.csv"),
+        ("sigmoid", "predictions_sigmoid_0.csv"),
+        ("stump", "predictions_stump_0.csv"),
+        ("perceptron", "predictions_perceptron_0.csv"),
+        ("laplacian", "predictions_laplacian_0.csv"),
+        ("exponential", "predictions_exponential_0.csv"),
     ],
 )
 def test_redsvm_predict_matches_expected(kernel, expected_file):
@@ -65,11 +65,15 @@ def test_redsvm_predict_matches_expected(kernel, expected_file):
 @pytest.mark.parametrize(
     "param_name, invalid_value, error_msg",
     [
-        ("kernel", -1, "unknown kernel type"),
+        ("kernel", "unknown", "unknown kernel type"),
         ("cache_size", -1, "cache_size <= 0"),
         ("tol", -1, "eps <= 0"),
         ("shrinking", 2, "shrinking != 0 and shrinking != 1"),
-        ("kernel", 8, "Wrong input format: sample_serial_number out of range"),
+        (
+            "kernel",
+            "precomputed",
+            "Wrong input format: sample_serial_number out of range",
+        ),
     ],
 )
 def test_redsvm_fit_hyperparameters_validation(

--- a/orca_python/classifiers/tests/test_svorex.py
+++ b/orca_python/classifiers/tests/test_svorex.py
@@ -24,9 +24,9 @@ def y():
 @pytest.mark.parametrize(
     "kernel, expected_file",
     [
-        (0, "predictions_gaussian_0.csv"),
-        (1, "predictions_linear_0.csv"),
-        (2, "predictions_poly_0.csv"),
+        ("gaussian", "predictions_gaussian_0.csv"),
+        ("linear", "predictions_linear_0.csv"),
+        ("poly", "predictions_poly_0.csv"),
     ],
 )
 def test_svorex_predict_matches_expected(kernel, expected_file):
@@ -53,7 +53,7 @@ def test_svorex_predict_matches_expected(kernel, expected_file):
         ({"tol": 0}, "- T is invalid"),
         ({"C": 0}, "- C is invalid"),
         ({"kappa": 0}, "- K is invalid"),
-        ({"kernel": 2, "degree": 0}, "- P is invalid"),
+        ({"kernel": "poly", "degree": 0}, "- P is invalid"),
         ({"kappa": -1}, "-1 is invalid"),
     ],
 )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Refactors the kernel parameter in SVOREX and REDSVM to accept string values instead of integers, improving clarity and consistency with scikit-learn conventions.
- `SVOREX.kernel` now accepts `gaussian`, `linear`, `poly`.
- `REDSVM.kernel` now accepts `linear`, `poly`, `rbf`, `sigmoid`, `stump`, `perceptron`, `laplacian`, `exponential`, `precomputed`.
