### PR TITLE
ENH: Add preprocessing module with scaling functions

### DIFF
--- a/orca_python/preprocessing/__init__.py
+++ b/orca_python/preprocessing/__init__.py
@@ -1,0 +1,3 @@
+"""Preprocessing module."""
+
+__all__ = []

--- a/orca_python/preprocessing/__init__.py
+++ b/orca_python/preprocessing/__init__.py
@@ -1,5 +1,5 @@
 """Preprocessing module."""
 
-from .scalers import minmax_scale, standardize
+from .scalers import apply_scaling, minmax_scale, standardize
 
-__all__ = ["minmax_scale", "standardize"]
+__all__ = ["apply_scaling", "minmax_scale", "standardize"]

--- a/orca_python/preprocessing/__init__.py
+++ b/orca_python/preprocessing/__init__.py
@@ -1,3 +1,5 @@
 """Preprocessing module."""
 
-__all__ = []
+from .scalers import minmax_scale, standardize
+
+__all__ = ["minmax_scale", "standardize"]

--- a/orca_python/preprocessing/scalers.py
+++ b/orca_python/preprocessing/scalers.py
@@ -37,6 +37,78 @@ def _validate_and_align(X_train, X_test):
     return X_train, X_test
 
 
+def apply_scaling(X_train, X_test=None, method=None, return_transformer=False):
+    """Apply normalization or standardization to the input data.
+
+    The preprocessing is fit on the training data and then applied to both
+    training and test data (if provided).
+
+    Parameters
+    ----------
+    X_train : array-like of shape (n_samples, n_features)
+        Feature matrix used specifically for model training.
+
+    X_test : array-like of shape (m_samples, n_features), optional
+        Feature matrix used for model evaluation and prediction.
+
+    method : {"norm", "std", None}, optional
+        - "norm": Min-Max scaling to [0, 1]
+        - "std" : Standardization (mean=0, std=1)
+        - None  : No preprocessing
+
+    return_transformer : bool, default=False
+        If True, also return the fitted scaling object.
+
+    Returns
+    -------
+    (X_train_scaled, X_test_scaled) or (X_train_scaled, X_test_scaled, scaler)
+        Scaled arrays; X_test_scaled is None if X_test is None.
+        If return_transformer=True and method=None, scaler is None.
+
+    Raises
+    ------
+    ValueError
+        If an unknown scaling method is specified.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from preprocessing.scalers import apply_scaling
+    >>> X_train = np.array([[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]])
+    >>> X_test = np.array([[2.5, 5.0]])
+    >>> X_train_scaled, X_test_scaled = apply_scaling(X_train, X_test, method="norm")
+    >>> X_train_scaled
+    array([[0. , 0. ],
+           [0.5, 0.5],
+           [1. , 1. ]])
+    >>> X_test_scaled
+    array([[0.75, 0.75]])
+    >>> X_train_scaled, X_test_scaled = apply_scaling(X_train, X_test, method="std")
+    >>> X_train_scaled.round(3)
+    array([[-1.225, -1.225],
+           [ 0.   ,  0.   ],
+           [ 1.225,  1.225]])
+    >>> X_test_scaled.round(3)
+    array([[0.612, 0.612]])
+
+    """
+    if method is None:
+        return (X_train, X_test, None) if return_transformer else (X_train, X_test)
+
+    if not isinstance(method, str):
+        raise ValueError("Scaling method must be a string or None.")
+
+    key = method.lower()
+    if key == "norm":
+        return minmax_scale(X_train, X_test, return_transformer)
+    elif key == "std":
+        return standardize(X_train, X_test, return_transformer)
+    else:
+        raise ValueError(
+            f"Unknown scaling method '{method}'. Valid options: 'norm', 'std', None."
+        )
+
+
 def minmax_scale(X_train, X_test=None, return_transformer=False):
     """Scale features to a fixed range between 0 and 1.
 

--- a/orca_python/preprocessing/scalers.py
+++ b/orca_python/preprocessing/scalers.py
@@ -1,0 +1,150 @@
+"""Data scaling functions."""
+
+from scipy import sparse
+from sklearn.preprocessing import MinMaxScaler, StandardScaler
+from sklearn.utils.validation import check_array
+
+
+def _validate_and_align(X_train, X_test):
+    """Validate arrays as numeric 2D matrices and ensure matching feature counts.
+
+    Parameters
+    ----------
+    X_train : array-like of shape (n_samples, n_features)
+        Training feature matrix used for validation reference.
+
+    X_test : array-like of shape (m_samples, n_features), optional
+        Test feature matrix to validate against training matrix.
+
+    Returns
+    -------
+    (X_train_valid, X_test_valid) : tuple
+        Validated arrays. X_test_valid is None if X_test is None.
+
+    Raises
+    ------
+    ValueError
+        If X_test has different number of features than X_train.
+
+    """
+    X_train = check_array(X_train, accept_sparse=True, dtype="numeric")
+    if X_test is not None:
+        X_test = check_array(X_test, accept_sparse=True, dtype="numeric")
+        if X_test.shape[1] != X_train.shape[1]:
+            raise ValueError(
+                f"X_test has {X_test.shape[1]} features but X_train has {X_train.shape[1]}."
+            )
+    return X_train, X_test
+
+
+def minmax_scale(X_train, X_test=None, return_transformer=False):
+    """Scale features to a fixed range between 0 and 1.
+
+    Fits scaling parameters on training data and applies the same transformation
+    to both training and test sets.
+
+    Parameters
+    ----------
+    X_train : array-like of shape (n_samples, n_features)
+        Training feature matrix used to fit scaling parameters.
+
+    X_test : array-like of shape (m_samples, n_features), optional
+        Test feature matrix to transform using fitted parameters.
+
+    return_transformer : bool, default=False
+        If True, also return the fitted scaling object.
+
+    Returns
+    -------
+    (X_train_scaled, X_test_scaled) or (X_train_scaled, X_test_scaled, scaler)
+        Scaled arrays; X_test_scaled is None if X_test is None.
+
+    Raises
+    ------
+    ValueError
+        If X_test has a different number of features than X_train.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from preprocessing.scalers import minmax_scale
+    >>> X_train = np.array([[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]])
+    >>> X_test = np.array([[2.5, 5.0]])
+    >>> X_train_scaled, X_test_scaled = minmax_scale(X_train, X_test)
+    >>> X_train_scaled
+    array([[0. , 0. ],
+           [0.5, 0.5],
+           [1. , 1. ]])
+    >>> X_test_scaled
+    array([[0.75, 0.75]])
+
+    """
+    X_train, X_test = _validate_and_align(X_train, X_test)
+
+    scaler = MinMaxScaler(feature_range=(0.0, 1.0))
+    X_train_scaled = scaler.fit_transform(X_train)
+    X_test_scaled = scaler.transform(X_test) if X_test is not None else None
+
+    if return_transformer:
+        return X_train_scaled, X_test_scaled, scaler
+    else:
+        return X_train_scaled, X_test_scaled
+
+
+def standardize(X_train, X_test=None, return_transformer=False):
+    """Standardize features to have zero mean and unit variance.
+
+    Fits scaling parameters on training data and applies the same transformation
+    to both training and test sets. For sparse matrices, centering is disabled
+    to preserve sparsity.
+
+    Parameters
+    ----------
+    X_train : array-like of shape (n_samples, n_features)
+        Feature matrix used specifically for model training.
+
+    X_test : array-like of shape (m_samples, n_features), optional
+        Test feature matrix to transform using fitted parameters.
+
+    return_transformer: bool, default=False
+        If True, also return the fitted scaling object.
+
+    Returns
+    -------
+    (X_train_scaled, X_test_scaled) or (X_train_scaled, X_test_scaled, scaler)
+        Scaled arrays; X_test_scaled is None if X_test is None.
+
+    Raises
+    ------
+    ValueError
+        If X_test has a different number of features than X_train.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from preprocessing.scalers import standardize
+    >>> X_train = np.array([[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]])
+    >>> X_test = np.array([[2.5, 5.0]])
+    >>> X_train_scaled, X_test_scaled = standardize(X_train, X_test)
+    >>> X_train_scaled.round(3)
+    array([[-1.225, -1.225],
+           [ 0.   ,  0.   ],
+           [ 1.225,  1.225]])
+    >>> X_test_scaled.round(3)
+    array([[0.612, 0.612]])
+
+    """
+    X_train, X_test = _validate_and_align(X_train, X_test)
+
+    scaler = (
+        StandardScaler(with_mean=False)
+        if sparse.issparse(X_train)
+        else StandardScaler()
+    )
+    X_train_scaled = scaler.fit_transform(X_train)
+    X_test_scaled = scaler.transform(X_test) if X_test is not None else None
+
+    if return_transformer:
+        return X_train_scaled, X_test_scaled, scaler
+    else:
+        return X_train_scaled, X_test_scaled

--- a/orca_python/preprocessing/tests/__init__.py
+++ b/orca_python/preprocessing/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the preprocessing module."""
+
+__all__ = []

--- a/orca_python/preprocessing/tests/test_scalers.py
+++ b/orca_python/preprocessing/tests/test_scalers.py
@@ -1,0 +1,171 @@
+"""Tests for the scaling functions in the preprocessing module."""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from orca_python.preprocessing import apply_scaling, minmax_scale, standardize
+from orca_python.preprocessing.scalers import _validate_and_align
+from orca_python.testing import TEST_RANDOM_STATE
+
+
+@pytest.fixture
+def X_train():
+    """Create synthetic training data for testing."""
+    return np.random.RandomState(TEST_RANDOM_STATE).randn(100, 5)
+
+
+@pytest.fixture
+def X_test():
+    """Create synthetic test data for testing."""
+    return np.random.RandomState(TEST_RANDOM_STATE).randn(50, 5)
+
+
+def test_validate_and_align_valid_inputs(X_train, X_test):
+    """Test _validate_and_align with valid matching inputs."""
+    X_train_valid, X_test_valid = _validate_and_align(X_train, X_test)
+
+    assert X_train_valid.shape == X_train.shape
+    assert X_test_valid.shape == X_test.shape
+    npt.assert_array_equal(X_train_valid, X_train)
+    npt.assert_array_equal(X_test_valid, X_test)
+
+
+def test_validate_and_align_none_test(X_train):
+    """Test _validate_and_align with None test data."""
+    X_train_valid, X_test_valid = _validate_and_align(X_train, None)
+
+    assert X_train_valid.shape == X_train.shape
+    assert X_test_valid is None
+    npt.assert_array_equal(X_train_valid, X_train)
+
+
+def test_validate_and_align_mismatched_features(X_train, X_test):
+    """Test _validate_and_align raises error for mismatched feature counts."""
+    X_invalid = X_test[:, :-1]
+
+    error_msg = "X_test has 4 features but X_train has 5."
+    with pytest.raises(ValueError, match=error_msg):
+        _validate_and_align(X_train, X_invalid)
+
+
+def test_validate_and_align_invalid_input():
+    """Test _validate_and_align raises error for invalid input types."""
+    with pytest.raises((ValueError, TypeError)):
+        _validate_and_align("invalid", None)
+
+
+def test_minmax_scale_data(X_train, X_test):
+    """Test that minmax_scale function correctly scales input data to [0,1] range."""
+    X_train_scaled, X_test_scaled = minmax_scale(X_train, X_test)
+
+    assert np.all(X_train_scaled >= 0) and np.all(X_train_scaled <= 1)
+    assert np.all(X_test_scaled >= 0) and np.all(X_test_scaled <= 1)
+
+
+def test_minmax_scale_return_transformer(X_train, X_test):
+    """Test that minmax_scale returns transformer when requested."""
+    _, expected_X_test, scaler = minmax_scale(X_train, X_test, return_transformer=True)
+
+    X_test_scaled = scaler.transform(X_test)
+    npt.assert_array_almost_equal(X_test_scaled, expected_X_test)
+
+
+def test_standardize_data(X_train, X_test):
+    """Test that standardize function correctly produces output with zero mean
+    and unit variance."""
+    X_train_scaled, _ = standardize(X_train, X_test)
+
+    npt.assert_almost_equal(np.mean(X_train_scaled), 0, decimal=6)
+    npt.assert_almost_equal(np.std(X_train_scaled), 1, decimal=6)
+
+
+def test_standardize_return_transformer(X_train, X_test):
+    """Test that standardize returns transformer when requested."""
+    _, expected_X_test, scaler = standardize(X_train, X_test, return_transformer=True)
+
+    X_test_scaled = scaler.transform(X_test)
+    npt.assert_array_almost_equal(X_test_scaled, expected_X_test)
+
+
+@pytest.mark.parametrize(
+    "method, scaling_func", [("norm", minmax_scale), ("std", standardize)]
+)
+def test_apply_scaling_correctly(X_train, X_test, method, scaling_func):
+    """Test that different preprocessing methods work as expected."""
+    expected_X_train, expected_X_test = scaling_func(X_train, X_test)
+    X_train_scaled, X_test_scaled = apply_scaling(X_train, X_test, method)
+
+    npt.assert_array_almost_equal(X_train_scaled, expected_X_train)
+    npt.assert_array_almost_equal(X_test_scaled, expected_X_test)
+
+
+def test_apply_scaling_none_method(X_train, X_test):
+    """Test that scaling function handles None input correctly."""
+    post_X_train, post_X_test = apply_scaling(X_train, X_test, None)
+
+    npt.assert_array_equal(post_X_train, X_train)
+    npt.assert_array_equal(post_X_test, X_test)
+
+
+def test_apply_scaling_return_transformer(X_train, X_test):
+    """Test that the transformer returned by apply_scaling works as expected."""
+    _, _, scaler = apply_scaling(X_train, X_test, "norm", return_transformer=True)
+    X_test_scaled = scaler.transform(X_test)
+    _, expected_X_test = minmax_scale(X_train, X_test)
+    npt.assert_array_almost_equal(X_test_scaled, expected_X_test)
+
+    _, _, scaler = apply_scaling(X_train, X_test, "std", return_transformer=True)
+    X_test_scaled = scaler.transform(X_test)
+    _, expected_X_test = standardize(X_train, X_test)
+    npt.assert_array_almost_equal(X_test_scaled, expected_X_test)
+
+    _, _, scaler = apply_scaling(X_train, X_test, None, return_transformer=True)
+    assert scaler is None
+
+
+def test_apply_scaling_case_insensitive(X_train, X_test):
+    """Test that apply_scaling handles different case variations."""
+    X_train_lower, X_test_lower = apply_scaling(X_train, X_test, "norm")
+    X_train_upper, X_test_upper = apply_scaling(X_train, X_test, "NORM")
+
+    npt.assert_array_equal(X_train_lower, X_train_upper)
+    npt.assert_array_equal(X_test_lower, X_test_upper)
+
+
+def test_apply_scaling_invalid_method_type(X_train, X_test):
+    """Test that an invalid scaling method type raises a ValueError."""
+    error_msg = "Scaling method must be a string or None."
+    with pytest.raises(ValueError, match=error_msg):
+        apply_scaling(X_train, X_test, 123)
+
+
+def test_apply_scaling_unknown_method(X_train, X_test):
+    """Test that an unknown scaling method raises a ValueError."""
+    error_msg = "Unknown scaling method 'invalid'. Valid options: 'norm', 'std', None."
+    with pytest.raises(ValueError, match=error_msg):
+        apply_scaling(X_train, X_test, "invalid")
+
+
+def test_apply_scaling_inconsistent_features(X_train, X_test):
+    """Test that scaling with inconsistent feature dimensions raises ValueError."""
+    X_invalid = X_test[:, :-1]
+
+    with pytest.raises(ValueError):
+        apply_scaling(X_train, X_invalid, "norm")
+
+
+def test_minmax_scale_inconsistent_features(X_train, X_test):
+    """Test that minmax_scale raises ValueError for mismatched features."""
+    X_invalid = X_test[:, :-1]
+
+    with pytest.raises(ValueError):
+        minmax_scale(X_train, X_invalid)
+
+
+def test_standardize_inconsistent_features(X_train, X_test):
+    """Test that standardize raises ValueError for mismatched features."""
+    X_invalid = X_test[:, :-1]
+
+    with pytest.raises(ValueError):
+        standardize(X_train, X_invalid)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

This PR adds a `preprocessing`module with scaling utilities including min-max normalization, standardization, and a unified `apply_scaling` function that accepts string identifiers for easy transformation selection.