### PR TITLE
BLD: Modernise pyproject.toml for Python 3.9+ and sklearn 1.3

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,11 +1,6 @@
-from sacred import Experiment
-
 from orca_python.utilities import Utilities
 
-ex = Experiment("Experiment Configuration")
 
-
-@ex.automain
 def main(general_conf, configurations):
     if not general_conf["basedir"] or not general_conf["datasets"]:
         raise RuntimeError(

--- a/orca_python/classifiers/OrdinalDecomposition.py
+++ b/orca_python/classifiers/OrdinalDecomposition.py
@@ -170,8 +170,8 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
         decision = str(self.decision_method).lower()
         if decision == "frank_hall" and dtype != "ordered_partitions":
             raise ValueError(
-                "When using Frank and Hall decision method,\
-				ordered_partitions must be used"
+                "When using Frank and Hall decision method, "
+                "ordered_partitions must be used"
             )
 
         # Give each train input its corresponding output label

--- a/orca_python/results/tests/test_results.py
+++ b/orca_python/results/tests/test_results.py
@@ -154,9 +154,10 @@ def test_add_record(results):
     pdt.assert_frame_equal(actual_data_conf_2, expected_data_conf_2)
 
     # Checking if models have been saved successfully
-    with open(conf_1_path / "models" / "toy-conf_1.0", "rb") as model_0, open(
-        conf_1_path / "models" / "toy-conf_1.1", "rb"
-    ) as model_1:
+    with (
+        open(conf_1_path / "models" / "toy-conf_1.0", "rb") as model_0,
+        open(conf_1_path / "models" / "toy-conf_1.1", "rb") as model_1,
+    ):
         actual_data = [load(model_0), load(model_1)]
         npt.assert_equal(all(isinstance(model, SVC) for model in actual_data), True)
 
@@ -172,15 +173,12 @@ def test_add_record(results):
         },
     }
 
-    with open(
-        conf_1_path / "predictions" / "train_toy-conf_1.0", "rb"
-    ) as train_0, open(
-        conf_1_path / "predictions" / "test_toy-conf_1.0", "rb"
-    ) as test_0, open(
-        conf_1_path / "predictions" / "train_toy-conf_1.1", "rb"
-    ) as train_1, open(
-        conf_1_path / "predictions" / "test_toy-conf_1.1", "rb"
-    ) as test_1:
+    with (
+        open(conf_1_path / "predictions" / "train_toy-conf_1.0", "rb") as train_0,
+        open(conf_1_path / "predictions" / "test_toy-conf_1.0", "rb") as test_0,
+        open(conf_1_path / "predictions" / "train_toy-conf_1.1", "rb") as train_1,
+        open(conf_1_path / "predictions" / "test_toy-conf_1.1", "rb") as test_1,
+    ):
         actual_data = {
             "0": {"train": np.loadtxt(train_0), "test": np.loadtxt(test_0)},
             "1": {"train": np.loadtxt(train_1), "test": np.loadtxt(test_1)},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,61 +1,72 @@
 [build-system]
-requires = ["setuptools >= 74.1.0", "wheel", "toml", "build"]
+requires = ["setuptools>=74.1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "orca-python"
 version = "0.0.1"
-description = "Framework migration project from Matlab to Python"
+description = "Ordinal classification for Python, scikit-learn compatible"
 readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "BSD-3-Clause"}
 authors = [
     {name = "Francisco Bérchez-Moreno", email = "fberchez@uco.es"},
     {name = "Víctor Manuel Vargas", email = "vvargas@uco.es"},
     {name = "Javier Barbero-Gómez", email = "jbarbero@uco.es"},
     {name = "Rafael Ayllón-Gavilán", email = "rayllong@uco.es"},
     {name = "David Guijo-Rubio", email = "dguijo@uco.es"},
-    {name = "Ángel Sevilla Molina", email = "i42semoa@uco.es"}
+    {name = "Ángel Sevilla Molina", email = "asevilla@uco.es"},
 ]
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
-    "Operating System :: OS Independent",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Programming Language :: C",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
-    "Topic :: Software Development :: Libraries"
+    "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
 dependencies = [
-    "scikit-learn>=1.0.0",
+    "scikit-learn>=1.3.0",
     "numpy>=1.21",
     "pandas>=1.0.1",
     "scipy>=1.7",
-    "sacred>=0.8.1",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "black",
-    "mypy>=1.9",
-    "pre-commit",
-    "pytest",
+    "pytest>=7.0",
     "pytest-cov",
     "pytest-xdist[psutil]",
-    "ruff>=0.4"
+    "pytest-benchmark",
+    "ruff>=0.4",
+    "mypy>=1.9",
+    "pre-commit",
 ]
 
 [project.urls]
-Source = "https://github.com/ayrna/orca-python"
-
-[project.license]
-file = "LICENSE"
+Homepage = "https://github.com/ayrna/orca-python"
+Repository = "https://github.com/ayrna/orca-python"
+"Bug Tracker" = "https://github.com/ayrna/orca-python/issues"
 
 [tool.setuptools.packages.find]
 include = [
     "orca_python",
-    "orca_python.*"
+    "orca_python.*",
 ]
 exclude = ["*.tests"]
 namespaces = false
+
+[tool.setuptools.package-data]
+"orca_python.datasets" = ["data/*.csv"]
 
 [tool.setuptools]
 ext-modules = [
@@ -64,8 +75,8 @@ ext-modules = [
             "orca_python/classifiers/libsvmRank/python/svm-train.cpp",
             "orca_python/classifiers/libsvmRank/python/svm-predict.cpp",
             "orca_python/classifiers/libsvmRank/python/svm-model-python.cpp",
-            "orca_python/classifiers/libsvmRank/python/svm.cpp"
-        ], extra-compile-args = ["-lefence", "-Wno-unused-result"]},
+            "orca_python/classifiers/libsvmRank/python/svm.cpp",
+        ], extra-compile-args = ["-Wno-unused-result"]},
     {name = "orca_python.classifiers.svorex.svorex", language = "c", sources = [
             "orca_python/classifiers/svorex/svorex_module.c",
             "orca_python/classifiers/svorex/svorex_train.c",
@@ -84,22 +95,31 @@ ext-modules = [
             "orca_python/classifiers/svorex/svc_predict.c",
             "orca_python/classifiers/svorex/smo_model_python.c",
             "orca_python/classifiers/svorex/smo_loadproblem_python.c",
-            "orca_python/classifiers/svorex/smo_routine_python.c"
-        ], extra-compile-args = ["-lefence", "-Wno-unused-result"], libraries=["m"]}
+            "orca_python/classifiers/svorex/smo_routine_python.c",
+        ], extra-compile-args = ["-Wno-unused-result"], libraries = ["m"]}
 ]
 
-[tool.check-manifest]
-ignore = [
-    ".venv/**",
-    "venv/**",
-    "local/**",
-]
+[tool.pytest.ini_options]
+testpaths = ["orca_python"]
+addopts = ["--color=yes", "--import-mode=importlib"]
 
 [tool.ruff]
-fix = true
-exclude = ["orca_python/classifiers/libsvmRank/grid.py"]
-
-[tool.black]
 line-length = 88
-target-version = ["py38"]
-preview = true
+target-version = "py39"
+exclude = [
+    ".eggs",
+    ".git",
+    ".mypy_cache",
+    "__pycache__",
+    "build",
+    "dist",
+    "orca_python/classifiers/libsvmRank/",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]
+
+[tool.mypy]
+ignore_missing_imports = true
+allow_redefinition = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ exclude = [
     "build",
     "dist",
     "orca_python/classifiers/libsvmRank/",
+    "orca_python/classifiers/svorex/setup.py",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Updates `pyproject.toml` to align with the project's current tech stack: raises `requires-python` to `>=3.9` and `scikit-learn` to `>=1.3.0`, removes the `sacred` and `black` dependencies, adds `[dev]` extras with versioned bounds, introduces `[tool.mypy]`, `[tool.ruff.lint]`, and `[tool.pytest.ini_options]` sections, modernises classifiers and license declaration, removes `-lefence` from the C extension compile flags, and adds `[tool.setuptools.package-data]` for dataset CSV files.