### PR TITLE
CI: Update lint tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
       actions:
         patterns:
           - "*"
+    labels:
+      - "Build / CI"
+      - "dependencies"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -36,4 +37,4 @@ jobs:
         run: ruff format --check orca_python/
 
       - name: mypy
-        run: mypy orca_python/ || true
+        run: mypy orca_python/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.pyd
 
 # Distribution / packaging
 .Python
@@ -130,3 +131,13 @@ dmypy.json
 
 # macOS
 .DS_Store
+
+# Editor temp files
+*~
+.#*
+*.swp
+*.swo
+
+# Profiling
+*.lprof
+*.prof

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,15 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.12
     hooks:
-      - id: ruff
-        args: ["--fix"]
+      - id: ruff-check
+        args: ["--fix", "--output-format=full"]
       - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        files: orca_python/
 
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.9.1

--- a/orca_python/__init__.py
+++ b/orca_python/__init__.py
@@ -1,4 +1,4 @@
 """orca-python."""
 
-__all__ = []
+__all__: list[str] = []
 __version__ = "0.0.1"

--- a/orca_python/classifiers/REDSVM.py
+++ b/orca_python/classifiers/REDSVM.py
@@ -8,7 +8,7 @@ from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
 
-from orca_python.classifiers.libsvmRank.python import svm
+from orca_python.classifiers.libsvmRank.python import svm  # type: ignore[attr-defined]
 
 
 class REDSVM(BaseEstimator, ClassifierMixin):

--- a/orca_python/classifiers/SVOREX.py
+++ b/orca_python/classifiers/SVOREX.py
@@ -8,7 +8,7 @@ from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
 
-from orca_python.classifiers.svorex import svorex
+from orca_python.classifiers.svorex import svorex  # type: ignore[attr-defined]
 
 
 class SVOREX(BaseEstimator, ClassifierMixin):

--- a/orca_python/classifiers/tests/__init__.py
+++ b/orca_python/classifiers/tests/__init__.py
@@ -1,3 +1,3 @@
 """Ordinal classification tests."""
 
-__all__ = []
+__all__: list[str] = []

--- a/orca_python/datasets/data/__init__.py
+++ b/orca_python/datasets/data/__init__.py
@@ -1,3 +1,3 @@
 """Datasets storage."""
 
-__all__ = []
+__all__: list[str] = []

--- a/orca_python/datasets/tests/__init__.py
+++ b/orca_python/datasets/tests/__init__.py
@@ -1,3 +1,3 @@
 """Tests for the datasets module."""
 
-__all__ = []
+__all__: list[str] = []

--- a/orca_python/metrics/tests/__init__.py
+++ b/orca_python/metrics/tests/__init__.py
@@ -1,3 +1,3 @@
 """Tests for metrics module."""
 
-__all__ = []
+__all__: list[str] = []

--- a/orca_python/model_selection/tests/__init__.py
+++ b/orca_python/model_selection/tests/__init__.py
@@ -1,3 +1,3 @@
 """Tests for model selection module."""
 
-__all__ = []
+__all__: list[str] = []

--- a/orca_python/preprocessing/tests/__init__.py
+++ b/orca_python/preprocessing/tests/__init__.py
@@ -1,3 +1,3 @@
 """Tests for the preprocessing module."""
 
-__all__ = []
+__all__: list[str] = []

--- a/orca_python/results/tests/__init__.py
+++ b/orca_python/results/tests/__init__.py
@@ -1,3 +1,3 @@
 """Tests for results handling module."""
 
-__all__ = []
+__all__: list[str] = []

--- a/orca_python/utilities/tests/__init__.py
+++ b/orca_python/utilities/tests/__init__.py
@@ -1,3 +1,3 @@
 """Tests for experiment handling."""
 
-__all__ = []
+__all__: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,4 @@ ignore = ["E501"]
 [tool.mypy]
 ignore_missing_imports = true
 allow_redefinition = true
+exclude = ["orca_python/classifiers/libsvmRank/", "orca_python/classifiers/svorex/"]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Updates the project's lint tooling to align with modern scikit-learn conventions: renames the ruff hook to `ruff-check` and adds `mirrors-mypy` (v1.15.0) to pre-commit; removes the mypy soft-fail (`|| true`) from the lint workflow and adds `workflow_dispatch`; fixes pre-existing mypy errors by annotating `__all__` in `__init__` files, suppressing `attr-defined` on uncompiled C-extension imports, and excluding the C-extension directories from `[tool.mypy]`; extends `.gitignore` with `*.pyd` and editor temp files; and adds labels to the Dependabot config.
