### PR TITLE
CI: Add release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
     labels:
       - "Build / CI"
       - "dependencies"
+    commit-message:
+      prefix: "MNT"

--- a/.github/scripts/check_version_consistency.py
+++ b/.github/scripts/check_version_consistency.py
@@ -1,0 +1,52 @@
+"""Check that the project version is consistent across all declarations."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def extract_version_from_pyproject() -> str | None:
+    content = Path("pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"(.+?)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def extract_version_from_init() -> str | None:
+    content = Path("skordinal/__init__.py").read_text(encoding="utf-8")
+    match = re.search(r'__version__\s*=\s*["\'](.+?)["\']', content)
+    return match.group(1) if match else None
+
+
+def extract_version_from_release_title(title: str) -> str | None:
+    match = re.search(r"([0-9]+\.[0-9]+\.[0-9]+(?:[a-zA-Z0-9.]+)?)", title)
+    return match.group(1) if match else None
+
+
+def main() -> int:
+    pyproject_version = extract_version_from_pyproject()
+    init_version = extract_version_from_init()
+
+    print(f"pyproject.toml : {pyproject_version}")
+    print(f"__init__.py    : {init_version}")
+
+    versions = {pyproject_version, init_version}
+
+    release_title = os.environ.get("RELEASE_TITLE")
+    if release_title:
+        release_version = extract_version_from_release_title(release_title)
+        print(f"release title  : {release_title!r} -> {release_version}")
+        versions.add(release_version)
+
+    if None in versions or len(versions) != 1:
+        print("Version mismatch detected.", file=sys.stderr)
+        return 1
+
+    print("All versions match.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check-sdist.yml
+++ b/.github/workflows/check-sdist.yml
@@ -1,0 +1,41 @@
+name: Check sdist
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "MANIFEST.in"
+      - "setup.py"
+      - "skordinal/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "MANIFEST.in"
+      - "setup.py"
+      - "skordinal/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-sdist:
+    name: Verify sdist contains every tracked file
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install check-sdist
+        run: |
+          python -m pip install --upgrade pip
+          pip install check-sdist
+      - name: Check sdist
+        run: check-sdist --inject-junk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  check-version:
+    name: Check version consistency
+    if: github.repository == 'ayrna/skordinal'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check versions match
+        env:
+          RELEASE_TITLE: ${{ github.event.release.name }}
+        run: python .github/scripts/check_version_consistency.py
+
+  build-sdist:
+    name: Build source distribution
+    needs: check-version
+    if: github.repository == 'ayrna/skordinal'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  build-wheels:
+    name: Build wheel cp${{ matrix.python-version }}-manylinux_x86_64
+    needs: check-version
+    if: github.repository == 'ayrna/skordinal'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["39", "310", "311", "312"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_BUILD: cp${{ matrix.python-version }}-manylinux_x86_64
+          CIBW_SKIP: "*-musllinux_*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_TEST_COMMAND: >
+            python -c "import skordinal;
+            print(f'skordinal {skordinal.__version__} imported');
+            from skordinal.classifiers.libsvmRank.python import svm;
+            from skordinal.classifiers.svorex import svorex;
+            print('C extensions loaded')"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-cp${{ matrix.python-version }}
+          path: wheelhouse/*.whl
+
+  publish:
+    name: Publish to PyPI
+    needs: [build-sdist, build-wheels]
+    if: github.repository == 'ayrna/skordinal'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/project/skordinal/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include skordinal/classifiers/libsvmRank *.h *.hpp
+recursive-include skordinal/classifiers/svorex *.h

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,3 +125,27 @@ ignore = ["E501"]
 ignore_missing_imports = true
 allow_redefinition = true
 exclude = ["skordinal/classifiers/libsvmRank/", "skordinal/classifiers/svorex/"]
+
+[tool.check-sdist]
+git-only = [
+    ".codecov.yml",
+    ".coveragerc",
+    ".gitignore",
+    "config.py",
+    "doc/**",
+    "skordinal/**/tests/**",
+    "skordinal/testing/**",
+    "skordinal/configurations/**",
+    "skordinal/classifiers/libsvmRank/grid.py",
+    "skordinal/classifiers/libsvmRank/svm-predict.c",
+    "skordinal/classifiers/libsvmRank/svm-train.c",
+    "skordinal/classifiers/libsvmRank/svm.cpp",
+    "skordinal/classifiers/libsvmRank/Makefile",
+    "skordinal/classifiers/libsvmRank/README",
+    "skordinal/classifiers/libsvmRank/python/setup.py",
+    "skordinal/classifiers/libsvmRank/python/makefile",
+    "skordinal/classifiers/svorex/main.c",
+    "skordinal/classifiers/svorex/Makefile",
+    "skordinal/classifiers/svorex/README.svorex",
+    "skordinal/classifiers/svorex/setup.py",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ exclude = ["*.tests"]
 namespaces = false
 
 [tool.setuptools.package-data]
-"skordinal.datasets" = ["data/*.csv"]
+"skordinal.datasets" = ["data/*/*.csv"]
 
 [tool.setuptools]
 ext-modules = [


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds the PyPI release pipeline: triggers on `release: published`, validates version consistency, builds sdist and Linux manylinux wheels (Python 3.9–3.12) via cibuildwheel, and publishes via OIDC trusted publishing. A companion workflow runs `check-sdist` on pull requests to catch packaging drift. Dependabot is realigned to prefix its commits with `MNT`.

Also fixes two pre-existing packaging bugs discovered while designing the pipeline: C/C++ headers were missing from the sdist (added via `MANIFEST.in`) and the bundled CSV datasets were missing from the wheel (glob corrected from `data/*.csv` to `data/*/*.csv`).

#### Any other comments?

Wheel scope is Linux x86_64 for this first release; Windows and macOS are deferred for a later PR. Publishing requires a one-time trusted publisher setup on pypi.org and a `pypi` environment in repo settings.
