### PR TITLE
BUG: Fix SVOREX non-determinism and wrong poly-kernel predictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ ext-modules = [
             "skordinal/classifiers/src/svorex/smo_model_python.c",
             "skordinal/classifiers/src/svorex/smo_loadproblem_python.c",
             "skordinal/classifiers/src/svorex/smo_routine_python.c",
-        ], extra-compile-args = ["-Wno-unused-result"], libraries = ["m"]}
+        ], extra-compile-args = ["-Wno-unused-result", "-ffp-contract=off"], libraries = ["m"]}
 ]
 
 [tool.pytest.ini_options]

--- a/skordinal/classifiers/src/svorex/smo_kernel.c
+++ b/skordinal/classifiers/src/svorex/smo_kernel.c
@@ -61,8 +61,12 @@ double Calculate_Kernel( double * pi, double * pj, smo_Settings * settings )
 					kernel = kernel + settings->ard[dimen] ;
 			}
 		}
-		if ((double) P > 1.0)
-			kernel = pow( (kernel + 1.0), (double) P ) ;
+		if ((double) P > 1.0) {
+			double base = kernel + 1.0 ;
+			unsigned int k ;
+			kernel = 1.0 ;
+			for (k = 0 ; k < P ; k++) kernel *= base ;
+		}
 	}
 	else if ( GAUSSIAN == KERNEL )
 	{

--- a/skordinal/classifiers/src/svorex/smo_model_python.c
+++ b/skordinal/classifiers/src/svorex/smo_model_python.c
@@ -161,6 +161,7 @@ PyObject* modelToPython(smo_Settings* model){
 								"{"
 								"s:O,"
 								"s:i,"
+								"s:I,"
 								"s:d,"
 								"s:O,"
 								"s:O,"
@@ -169,6 +170,7 @@ PyObject* modelToPython(smo_Settings* model){
 								"}",
 								"ard", ard_list,
 								"kernel", model->kernel,
+								"p", model->p,
 								"kappa", model->kappa,
 								"alpha", alpha_list,
 								"pairs", pairs_data_list_dict,
@@ -201,8 +203,9 @@ smo_Settings* pythonToModel(PyObject* model){
 	if(model_out == NULL)
 		return NULL;
 
-	//kernel, kappa, bias
+	//kernel, p, kappa, bias
 	model_out->kernel = (int) PyLong_AsLong(PyDict_GetItemString(model, "kernel"));
+	model_out->p = (unsigned int) PyLong_AsUnsignedLong(PyDict_GetItemString(model, "p"));
 	model_out->kappa = PyFloat_AsDouble(PyDict_GetItemString(model, "kappa"));
 	model_out->bias = PyFloat_AsDouble(PyDict_GetItemString(model, "bias"));
 

--- a/skordinal/classifiers/src/svorex/smo_settings.c
+++ b/skordinal/classifiers/src/svorex/smo_settings.c
@@ -142,10 +142,10 @@ smo_Settings * Create_smo_Settings ( def_Settings * settings )
 			psetting->bj_up = (double *) malloc((settings->pairs.classes-1)*sizeof(double)) ;
 			psetting->biasj = (double *) malloc((settings->pairs.classes-1)*sizeof(double)) ;
 			psetting->mu = (double *) calloc((settings->pairs.classes-1),sizeof(double)) ;
-			psetting->bmu_low = (double *) malloc((settings->pairs.classes-1)*sizeof(double)) ;
-			psetting->bmu_up = (double *) malloc((settings->pairs.classes-1)*sizeof(double)) ;
-			psetting->imu_low = (long unsigned int *) malloc((settings->pairs.classes-1)*sizeof(long unsigned int)) ;
-			psetting->imu_up = (long unsigned int *) malloc((settings->pairs.classes-1)*sizeof(long unsigned int)) ;
+			psetting->bmu_low = (double *) calloc((settings->pairs.classes-1),sizeof(double)) ;
+			psetting->bmu_up = (double *) calloc((settings->pairs.classes-1),sizeof(double)) ;
+			psetting->imu_low = (long unsigned int *) calloc((settings->pairs.classes-1),sizeof(long unsigned int)) ;
+			psetting->imu_up = (long unsigned int *) calloc((settings->pairs.classes-1),sizeof(long unsigned int)) ;
 		}
 			
 		psetting->duration = 0 ;
@@ -242,10 +242,10 @@ smo_Settings * Create_smo_Settings_Python ( def_Settings * settings )
 			psetting->bj_up = (double *) malloc((settings->pairs.classes-1)*sizeof(double)) ;
 			psetting->biasj = (double *) malloc((settings->pairs.classes-1)*sizeof(double)) ;
 			psetting->mu = (double *) calloc((settings->pairs.classes-1),sizeof(double)) ;
-			psetting->bmu_low = (double *) malloc((settings->pairs.classes-1)*sizeof(double)) ;
-			psetting->bmu_up = (double *) malloc((settings->pairs.classes-1)*sizeof(double)) ;
-			psetting->imu_low = (long unsigned int *) malloc((settings->pairs.classes-1)*sizeof(long unsigned int)) ;
-			psetting->imu_up = (long unsigned int *) malloc((settings->pairs.classes-1)*sizeof(long unsigned int)) ;
+			psetting->bmu_low = (double *) calloc((settings->pairs.classes-1),sizeof(double)) ;
+			psetting->bmu_up = (double *) calloc((settings->pairs.classes-1),sizeof(double)) ;
+			psetting->imu_low = (long unsigned int *) calloc((settings->pairs.classes-1),sizeof(long unsigned int)) ;
+			psetting->imu_up = (long unsigned int *) calloc((settings->pairs.classes-1),sizeof(long unsigned int)) ;
 		}
 			
 		psetting->duration = 0 ;

--- a/skordinal/classifiers/src/svorex/svorex_train.c
+++ b/skordinal/classifiers/src/svorex/svorex_train.c
@@ -37,8 +37,11 @@ PyObject* fit(PyObject* self, PyObject* args)
 	/* Put options in argv[]*/
 	int argc = 0;
 	char *argv[CMD_LEN/2];
+	char options_copy[CMD_LEN];
+	strncpy(options_copy, options, CMD_LEN - 1);
+	options_copy[CMD_LEN - 1] = '\0';
 
-	if((argv[argc] = strtok(options, " ")) != NULL)
+	if((argv[argc] = strtok(options_copy, " ")) != NULL)
 		while((argv[++argc] = strtok(NULL, " ")) != NULL)
 			;
 
@@ -200,6 +203,7 @@ PyObject* fit(PyObject* self, PyObject* args)
 		defsetting->beta = 1.0;
 
 	if ( FALSE == smo_Loadproblem_Python (&(defsetting->pairs), features, labels) ){
+		Clear_def_Settings( defsetting );
 		return NULL;
 	}
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Fix four bugs in the SVOREX C extension affecting result reproducibility and prediction correctness.

`bmu_low`, `bmu_up`, `imu_low`, and `imu_up` were allocated with `malloc` and could be read before being written in the first SMO iteration; replaced with `calloc`. `strtok` received a direct pointer to a Python string's internal buffer, mutating it in place and corrupting subsequent calls on the same string object; fixed by copying to a local buffer first.

`modelToPython` omitted the polynomial degree field `p` from the serialised dict, so `pythonToModel` left `model->p` as uninitialised heap garbage during `predict()`. The field is now included in the round-trip. A compiler flag (`-ffp-contract=off`) and an integer-loop replacement for `pow()` prevent fused-multiply-add contraction from producing different last-bit results across platforms.

#### Any other comments?

The `model->p` bug produced wrong predictions with the polynomial kernel on macOS ARM64 while Linux tests passed silently.