### PR TITLE
FIX: Fix import paths in release wheel test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,8 @@ jobs:
           CIBW_TEST_COMMAND: >
             python -c "import skordinal;
             print(f'skordinal {skordinal.__version__} imported');
-            from skordinal.classifiers.libsvmRank.python import svm;
-            from skordinal.classifiers.svorex import svorex;
+            import skordinal.classifiers._libsvmrank;
+            import skordinal.classifiers._libsvorex;
             print('C extensions loaded')"
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
#### Reference Issues/PRs

#47

#### What does this implement/fix? Explain your changes

Fix the `CIBW_TEST_COMMAND` in the release workflow: the module paths (`skordinal.classifiers._libsvmrank`, `skordinal.classifiers._libsvorex`) were outdated after the package restructure in #47.
