### PR TITLE
ENH: Add validation and sklearn compatibility utilities

### DIFF
--- a/skordinal/utils/__init__.py
+++ b/skordinal/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Utilities for ordinal classification."""
+
+from skordinal.utils.validation import (
+    check_monotonic_probabilities,
+    check_ordinal_targets,
+    validate_thresholds,
+)
+
+__all__ = [
+    "check_monotonic_probabilities",
+    "check_ordinal_targets",
+    "validate_thresholds",
+]

--- a/skordinal/utils/_sklearn_compat.py
+++ b/skordinal/utils/_sklearn_compat.py
@@ -1,0 +1,65 @@
+"""scikit-learn cross-version compatibility helpers."""
+
+from __future__ import annotations
+
+try:
+    from sklearn.utils.validation import validate_data as _sk_validate_data
+
+    _HAS_VALIDATE_DATA = True
+except ImportError:  # scikit-learn < 1.6
+    _HAS_VALIDATE_DATA = False
+
+
+def validate_data(estimator, X, y=None, *, reset=True, **check_params):
+    """Validate ``X`` (and optionally ``y``) for a scikit-learn estimator.
+
+    Thin wrapper around the API split introduced in scikit-learn 1.6.
+    On 1.6+ it forwards to :func:`sklearn.utils.validation.validate_data`;
+    on 1.3-1.5 it falls back to ``estimator._validate_data``. The helper
+    lives in a dedicated module so it can be removed in one place once
+    the minimum supported scikit-learn version is bumped to 1.6.
+
+    Parameters
+    ----------
+    estimator : estimator instance
+        The estimator to validate the input for. Mutates the estimator
+        and sets ``n_features_in_`` (and ``feature_names_in_`` when
+        applicable) when ``reset=True``.
+
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        The input samples.
+
+    y : array-like of shape (n_samples,), default=None
+        The target vector. If ``None``, only ``X`` is validated.
+
+    reset : bool, default=True
+        Whether to reset the ``n_features_in_`` attribute. If ``False``,
+        the input will be checked for consistency with data provided when
+        ``reset`` was last ``True``. Set to ``False`` at predict /
+        transform time.
+
+    **check_params : kwargs
+        Parameters passed to :func:`~sklearn.utils.check_array` or
+        :func:`~sklearn.utils.check_X_y`. Ignored if ``validate_separately``
+        is not False.
+
+    Returns
+    -------
+    out : {ndarray, sparse matrix} or tuple of these
+        The validated input. A ``(X, y)`` tuple is returned when ``y``
+        is provided, otherwise the validated ``X`` alone.
+
+    Notes
+    -----
+    Passing ``y=None`` is rewritten internally to scikit-learn's
+    ``"no_validation"`` sentinel before forwarding to the upstream
+    validator on scikit-learn 1.6+. This means the estimator's
+    ``requires_y`` tag is silently bypassed; classifiers that need a
+    target should pass ``y`` explicitly during ``fit``.
+    """
+    if _HAS_VALIDATE_DATA:
+        y_arg = "no_validation" if y is None else y
+        return _sk_validate_data(estimator, X, y_arg, reset=reset, **check_params)
+    if y is None:
+        return estimator._validate_data(X, reset=reset, **check_params)
+    return estimator._validate_data(X, y, reset=reset, **check_params)

--- a/skordinal/utils/tests/__init__.py
+++ b/skordinal/utils/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the utils module."""
+
+__all__: list[str] = []

--- a/skordinal/utils/tests/test_sklearn_compat.py
+++ b/skordinal/utils/tests/test_sklearn_compat.py
@@ -1,0 +1,100 @@
+"""Tests for the scikit-learn cross-version compatibility helpers."""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from sklearn.base import BaseEstimator
+
+from skordinal.utils import _sklearn_compat
+from skordinal.utils._sklearn_compat import validate_data
+
+
+class _DummyEstimator(BaseEstimator):
+    """Minimal estimator used to exercise the compat shim's modern path."""
+
+
+class _LegacyEstimator(BaseEstimator):
+    """Estimator exposing the pre-1.6 ``_validate_data`` and recording calls."""
+
+    def _validate_data(self, X, y=None, *, reset=True, **check_params):
+        self._last_call = {
+            "X": np.asarray(X),
+            "y": None if y is None else np.asarray(y),
+            "reset": reset,
+            "check_params": check_params,
+        }
+        if y is None:
+            return self._last_call["X"]
+        return self._last_call["X"], self._last_call["y"]
+
+
+@pytest.fixture
+def estimator():
+    """Return a fresh dummy estimator without fitted attributes."""
+    return _DummyEstimator()
+
+
+@pytest.fixture
+def X():
+    """Two-feature, four-sample float matrix."""
+    return np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+
+
+@pytest.fixture
+def y():
+    """Three-class ordinal target matching ``X``."""
+    return np.array([0, 1, 2, 1])
+
+
+def test_validate_data_returns_X_alone_when_y_is_none(estimator, X):
+    """When ``y`` is omitted, only the validated ``X`` is returned."""
+    out = validate_data(estimator, X)
+    assert isinstance(out, np.ndarray)
+    npt.assert_array_equal(out, X)
+
+
+def test_validate_data_returns_X_y_tuple(estimator, X, y):
+    """When ``y`` is given, a ``(X, y)`` tuple is returned."""
+    X_out, y_out = validate_data(estimator, X, y)
+    npt.assert_array_equal(X_out, X)
+    npt.assert_array_equal(y_out, y)
+
+
+def test_validate_data_reset_records_and_checks_n_features_in(estimator, X):
+    """``reset=True`` records ``n_features_in_``; ``reset=False`` enforces it."""
+    validate_data(estimator, X, reset=True)
+    assert estimator.n_features_in_ == X.shape[1]
+
+    with pytest.raises(ValueError):
+        validate_data(estimator, X[:, :1], reset=False)
+
+
+def test_validate_data_forwards_check_params(estimator):
+    """Extra ``check_params`` reach the underlying validator (dtype applied)."""
+    out = validate_data(estimator, np.array([[1, 2], [3, 4]]), dtype=np.float64)
+    assert out.dtype == np.float64
+
+
+def test_validate_data_falls_back_to_legacy_method_with_y(monkeypatch, X, y):
+    """The pre-1.6 path delegates to ``estimator._validate_data(X, y, ...)``."""
+    monkeypatch.setattr(_sklearn_compat, "_HAS_VALIDATE_DATA", False)
+    legacy = _LegacyEstimator()
+
+    X_out, y_out = validate_data(legacy, X, y, dtype=np.float64)
+
+    npt.assert_array_equal(X_out, X)
+    npt.assert_array_equal(y_out, y)
+    assert legacy._last_call["reset"] is True
+    assert legacy._last_call["check_params"] == {"dtype": np.float64}
+
+
+def test_validate_data_falls_back_to_legacy_method_without_y(monkeypatch, X):
+    """The pre-1.6 path delegates to ``estimator._validate_data(X, ...)`` only."""
+    monkeypatch.setattr(_sklearn_compat, "_HAS_VALIDATE_DATA", False)
+    legacy = _LegacyEstimator()
+
+    out = validate_data(legacy, X, reset=False)
+
+    npt.assert_array_equal(out, X)
+    assert legacy._last_call["y"] is None
+    assert legacy._last_call["reset"] is False

--- a/skordinal/utils/tests/test_validation.py
+++ b/skordinal/utils/tests/test_validation.py
@@ -1,0 +1,197 @@
+"""Tests for the validation utilities."""
+
+import inspect
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+import skordinal.utils.validation as val_mod
+from skordinal.utils.validation import (
+    check_monotonic_probabilities,
+    check_ordinal_targets,
+    validate_thresholds,
+)
+
+_ALL_HELPERS = [
+    check_ordinal_targets,
+    validate_thresholds,
+    check_monotonic_probabilities,
+]
+_HELPER_NAMES = [f.__name__ for f in _ALL_HELPERS]
+
+
+@pytest.mark.parametrize("func", _ALL_HELPERS, ids=_HELPER_NAMES)
+def test_api_no_mutable_defaults(func):
+    """No helper has a mutable default argument."""
+    for default in func.__defaults__ or ():
+        assert not isinstance(default, (list, dict, np.ndarray)), (
+            f"{func.__name__} has a mutable default: {default!r}"
+        )
+
+
+def test_api_check_monotonic_probabilities_default_repair():
+    """The default value of ``repair`` is True."""
+    sig = inspect.signature(check_monotonic_probabilities)
+    assert sig.parameters["repair"].default is True
+
+
+def test_integration_all_names_in_module_all():
+    """``__all__`` lists exactly the three public helpers and is re-exported."""
+    import skordinal.utils as utils_pkg
+
+    expected = set(_HELPER_NAMES)
+    # Canonical module: skordinal.utils.validation
+    assert set(val_mod.__all__) == expected
+    for name in expected:
+        assert callable(getattr(val_mod, name))
+    # Subpackage shortcut: skordinal.utils re-exports the same surface.
+    assert set(utils_pkg.__all__) == expected
+    for name in expected:
+        assert getattr(utils_pkg, name) is getattr(val_mod, name)
+
+
+def test_cot_known_encoding():
+    """Exact encoding, class order, dtype, round-trip, and contiguity."""
+    y = [3, 1, 2, 1, 3]
+    classes, y_encoded = check_ordinal_targets(y)
+    assert_array_equal(classes, [1, 2, 3])
+    assert_array_equal(y_encoded, [2, 0, 1, 0, 2])
+    assert y_encoded.dtype == np.intp
+    assert_array_equal(classes[y_encoded], y)
+    assert set(y_encoded.tolist()) == set(range(len(classes)))
+    assert np.all(np.diff(classes) > 0)
+
+
+def test_cot_integer_valued_floats_accepted():
+    """Float labels with integer values are accepted; classes dtype stays float."""
+    classes, y_encoded = check_ordinal_targets(np.array([1.0, 2.0, 3.0]))
+    assert classes.dtype.kind == "f"
+    assert y_encoded.dtype == np.intp
+
+
+def test_cot_non_contiguous_labels():
+    """Gap labels are allowed; encoding is still 0-based."""
+    classes, y_encoded = check_ordinal_targets([10, 20, 30])
+    assert_array_equal(y_encoded, [0, 1, 2])
+    assert_array_equal(classes, [10, 20, 30])
+
+
+@pytest.mark.parametrize(
+    "y, match",
+    [
+        ([], None),
+        (np.array([[1, 2], [3, 4]]), r"y must be a 1D array"),
+        ([1, 1, 1], r"y must contain at least 2 unique classes"),
+        (np.array(["a", "b"], dtype=object), None),
+        ([np.nan, 1.0, 2.0], None),
+    ],
+    ids=["empty", "2d", "single-class", "object-dtype", "nan"],
+)
+def test_cot_invalid_input_raises(y, match):
+    """Each invalid-input shape / dtype / cardinality raises ValueError."""
+    expected = ValueError if match is not None else (ValueError, TypeError)
+    with pytest.raises(expected, match=match):
+        check_ordinal_targets(y)
+
+
+@pytest.mark.parametrize(
+    "thresholds",
+    [
+        [-1.0, 0.0, 1.0, 2.0],
+        [0.0],
+        [0.0, np.nextafter(0.0, 1.0)],
+    ],
+    ids=["generic", "binary-edge", "smallest-gap"],
+)
+def test_vt_valid_returns_none(thresholds):
+    """Valid threshold vectors return None."""
+    assert validate_thresholds(thresholds) is None
+
+
+@pytest.mark.parametrize(
+    "thresholds, match",
+    [
+        ([0.0, 0.0, 1.0], r"strictly increasing"),
+        ([1.0, 0.0], r"strictly increasing"),
+        ([0.0, np.inf], r"finite"),
+        ([np.nan, 1.0], r"finite"),
+        ([], r"length >= 1"),
+        ([[0.0, 1.0]], r"1D array"),
+    ],
+    ids=["equal", "decreasing", "inf", "nan", "empty", "2d"],
+)
+def test_vt_invalid_raises(thresholds, match):
+    """Each invalid threshold vector raises ValueError with a specific message."""
+    with pytest.raises(ValueError, match=match):
+        validate_thresholds(thresholds)
+
+
+def test_cmp_valid_input_output_values():
+    """Output values, row sums, and non-negativity for a valid monotonic input."""
+    cumproba = np.array([[0.2, 0.5, 0.9]])
+    class_proba = check_monotonic_probabilities(cumproba)
+    assert_allclose(class_proba, [[0.2, 0.3, 0.4, 0.1]], atol=1e-12)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+    assert np.all(class_proba >= 0.0)
+
+
+def test_cmp_repair_true_repairs_violation():
+    """Monotonicity violations are repaired silently when ``repair=True``."""
+    cumproba = np.array([[0.5, 0.3, 0.9]])
+    class_proba = check_monotonic_probabilities(cumproba, repair=True)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+    assert np.all(class_proba >= 0.0)
+
+
+def test_cmp_repair_false_valid_input():
+    """``repair=False`` happy path with multiple rows."""
+    cumproba = np.array([[0.2, 0.5, 0.9], [0.1, 0.4, 0.8]])
+    class_proba = check_monotonic_probabilities(cumproba, repair=False)
+    assert class_proba.shape == (2, 4)
+    assert_allclose(class_proba[0], [0.2, 0.3, 0.4, 0.1], atol=1e-12)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+    assert np.all(class_proba >= 0.0)
+
+
+def test_cmp_repair_false_raises_on_violation():
+    """A non-monotonic row raises ValueError when ``repair=False``."""
+    with pytest.raises(ValueError, match=r"cumproba rows must be non-decreasing"):
+        check_monotonic_probabilities(np.array([[0.5, 0.3]]), repair=False)
+
+
+@pytest.mark.parametrize("repair", [True, False])
+def test_cmp_k2_single_column(repair):
+    """K=2 (single input column) produces a 2-column output for both branches."""
+    cumproba = np.array([[0.3], [0.7]])
+    class_proba = check_monotonic_probabilities(cumproba, repair=repair)
+    assert class_proba.shape == (2, 2)
+    assert_allclose(class_proba[0], [0.3, 0.7], atol=1e-12)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "cumproba",
+    [np.array([[-0.1, 0.5]]), np.array([[0.5, 1.2]])],
+    ids=["negative-entry", "above-one-entry"],
+)
+def test_cmp_out_of_range_raises(cumproba):
+    """Entries outside [0, 1] raise ValueError."""
+    with pytest.raises(ValueError, match=r"cumproba entries must lie in \[0, 1\]"):
+        check_monotonic_probabilities(cumproba)
+
+
+@pytest.mark.parametrize(
+    "cumproba, mass_index",
+    [
+        (np.array([[0.0, 0.0, 0.0]]), -1),
+        (np.array([[1.0, 1.0, 1.0]]), 0),
+    ],
+    ids=["all-zero-row", "all-one-row"],
+)
+def test_cmp_special_rows_concentrate_mass(cumproba, mass_index):
+    """All-zero and all-one rows place all mass on a single class."""
+    class_proba = check_monotonic_probabilities(cumproba)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+    assert np.all(class_proba >= 0.0)
+    assert class_proba[0, mass_index] == pytest.approx(1.0)

--- a/skordinal/utils/validation.py
+++ b/skordinal/utils/validation.py
@@ -1,0 +1,226 @@
+"""Validation utilities for ordinal classification."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from sklearn.isotonic import isotonic_regression
+from sklearn.utils import check_array
+from sklearn.utils.multiclass import check_classification_targets
+
+__all__ = [
+    "check_ordinal_targets",
+    "validate_thresholds",
+    "check_monotonic_probabilities",
+]
+
+
+def check_ordinal_targets(
+    y,
+) -> tuple[NDArray, NDArray[np.intp]]:
+    """Validate an ordinal target vector and return its integer encoding.
+
+    Accepts integer or integer-valued float labels. Rejects string/object
+    arrays, continuous floats, arrays with fewer than 2 unique classes,
+    and empty or multi-dimensional inputs.
+
+    The return order ``(classes, y_encoded)`` mirrors
+    ``np.unique(y, return_inverse=True)`` so callers can write
+    ``self.classes_, y_enc = check_ordinal_targets(y)`` in ``fit()``.
+
+    Parameters
+    ----------
+    y : array-like of shape (n_samples,)
+        Target labels. Must be 1-D and have a numeric dtype. Labels need
+        not form a contiguous range; gaps are allowed (e.g. ``[3, 5, 7]``
+        is mapped to ``[0, 1, 2]``). Integer-valued floats (e.g.
+        ``[1.0, 2.0]``) are accepted; continuous floats (e.g.
+        ``[0.5, 1.5]``) are rejected by the upstream sklearn check.
+
+    Returns
+    -------
+    classes : ndarray of shape (n_classes,)
+        Unique labels sorted in ascending order. Dtype matches the
+        original dtype of ``y``.
+
+    y_encoded : ndarray of shape (n_samples,), dtype np.intp
+        Zero-based contiguous encoding such that
+        ``classes[y_encoded[i]] == y[i]`` for every sample ``i``.
+
+    Raises
+    ------
+    ValueError
+        If ``y`` is empty, multi-dimensional, has a non-numeric dtype,
+        or contains fewer than 2 unique classes. Upstream ``ValueError``
+        from ``check_array`` (e.g. NaN inputs, object arrays) and from
+        ``check_classification_targets`` (e.g. continuous targets) are
+        propagated unchanged.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.validation import check_ordinal_targets
+    >>> classes, y_enc = check_ordinal_targets(np.array([3, 1, 2, 1, 3]))
+    >>> classes
+    array([1, 2, 3])
+    >>> y_enc
+    array([2, 0, 1, 0, 2])
+    """
+    y = check_array(
+        y, ensure_2d=False, dtype="numeric", ensure_min_samples=1, input_name="y"
+    )
+
+    if y.ndim != 1:
+        raise ValueError(f"y must be a 1D array, got shape {y.shape}")
+
+    check_classification_targets(y)
+
+    classes, y_encoded = np.unique(y, return_inverse=True)
+
+    if classes.size < 2:
+        raise ValueError(
+            f"y must contain at least 2 unique classes, got {classes.size}"
+        )
+
+    return classes, y_encoded.astype(np.intp)
+
+
+def validate_thresholds(thresholds: ArrayLike) -> None:
+    """Check that thresholds are strictly increasing and finite.
+
+    A valid threshold vector must be 1-D, contain only finite values,
+    have at least one entry, and have strictly positive consecutive
+    differences.
+
+    Parameters
+    ----------
+    thresholds : array-like of shape (n_classes - 1,)
+        Threshold values defining the boundaries between ordinal classes.
+        Must be strictly increasing. Length must be at least 1, i.e.
+        ``n_classes >= 2``. Length 1 (binary case) trivially satisfies
+        the monotonicity check.
+
+    Raises
+    ------
+    ValueError
+        If ``thresholds`` is not 1-D, is empty, contains non-finite
+        values, or is not strictly increasing.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.validation import validate_thresholds
+    >>> validate_thresholds(np.array([-1.0, 0.0, 1.0]))  # returns None
+    """
+    thresholds = np.asarray(thresholds, dtype=float)
+
+    if thresholds.ndim != 1:
+        raise ValueError(f"thresholds must be a 1D array, got shape {thresholds.shape}")
+
+    if thresholds.size < 1:
+        raise ValueError("thresholds must have length >= 1, got 0")
+
+    if not np.isfinite(thresholds).all():
+        raise ValueError("thresholds must be finite, got non-finite values")
+
+    diffs = np.diff(thresholds)
+    if (diffs <= 0).any():
+        raise ValueError(
+            f"thresholds must be strictly increasing, got differences {diffs!r}"
+        )
+
+
+def check_monotonic_probabilities(
+    cumproba: ArrayLike,
+    repair: bool = True,
+) -> NDArray[np.float64]:
+    """Convert cumulative class probabilities to class-wise probabilities.
+
+    Takes a matrix of cumulative probabilities ``P(Y <= k | x)`` for
+    ``k = 1, ..., n_classes - 1`` and returns a matrix of class-wise
+    probabilities ``P(Y = k | x)`` for ``k = 1, ..., n_classes``.
+
+    When ``repair=True``, monotonicity violations in each row are
+    silently fixed via isotonic regression before differencing. When
+    ``repair=False``, any non-monotonic row triggers a ``ValueError``.
+
+    Special row behaviors:
+
+    - An all-zero row becomes ``[0, 0, ..., 1]``; the final class absorbs
+      all probability mass.
+    - An all-one row becomes ``[1, 0, ..., 0]``; the first class absorbs
+      all probability mass.
+
+    Parameters
+    ----------
+    cumproba : array-like of shape (n_samples, n_classes - 1)
+        Cumulative probabilities. Each row should be a non-decreasing
+        sequence of values in ``[0, 1]``.
+
+    repair : bool, default=True
+        If ``True``, apply isotonic regression row-wise to enforce
+        monotonicity before differencing, then clip and renormalise.
+        If ``False``, raise ``ValueError`` when any row is non-monotonic.
+
+    Returns
+    -------
+    class_proba : ndarray of shape (n_samples, n_classes), dtype np.float64
+        Class-wise probabilities. Each row is non-negative and sums to
+        exactly ``1.0``.
+
+    Raises
+    ------
+    ValueError
+        If ``cumproba`` is not 2-D, has zero columns, contains NaN / inf
+        values, contains values outside ``[0, 1]``, or — when
+        ``repair=False`` — has any row whose entries are not
+        non-decreasing. Upstream ``ValueError`` from ``check_array``
+        (e.g. NaN inputs) is propagated unchanged.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.validation import check_monotonic_probabilities
+    >>> cumproba = np.array([[0.2, 0.5, 0.9]])
+    >>> check_monotonic_probabilities(cumproba)
+    array([[0.2, 0.3, 0.4, 0.1]])
+    """
+    cumproba = check_array(
+        cumproba, ensure_2d=True, dtype=np.float64, input_name="cumproba"
+    )
+
+    if cumproba.min() < 0.0 or cumproba.max() > 1.0:
+        raise ValueError(
+            f"cumproba entries must lie in [0, 1], got range "
+            f"[{cumproba.min():.4g}, {cumproba.max():.4g}]"
+        )
+
+    n_samples, n_thresholds = cumproba.shape
+    class_proba = np.empty((n_samples, n_thresholds + 1), dtype=np.float64)
+
+    if not repair:
+        diffs = np.diff(cumproba, axis=1)
+        if (diffs < 0.0).any():
+            raise ValueError(
+                f"cumproba rows must be non-decreasing, got minimum diff "
+                f"{diffs.min():.4g}"
+            )
+        class_proba[:, 0] = cumproba[:, 0]
+        class_proba[:, 1:-1] = diffs
+        class_proba[:, -1] = 1.0 - cumproba[:, -1]
+        return class_proba
+
+    for i in range(n_samples):
+        row_iso = isotonic_regression(
+            cumproba[i], y_min=0.0, y_max=1.0, increasing=True
+        )
+        class_proba[i, 0] = row_iso[0]
+        class_proba[i, 1:-1] = np.diff(row_iso)
+        class_proba[i, -1] = 1.0 - row_iso[-1]
+
+    np.clip(class_proba, 0.0, None, out=class_proba)
+    row_sums = class_proba.sum(axis=1, keepdims=True)
+    # Defensive: y_min=0 prevents all-zero rows; clip is a safety net.
+    row_sums = np.where(row_sums == 0.0, 1.0, row_sums)
+    class_proba /= row_sums
+    return class_proba


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Add `skordinal.utils.validation` with three ordinal-data integrity helpers: `check_ordinal_targets`, `validate_thresholds`, and `check_monotonic_probabilities` (the last optionally repairs cumulative-probability monotonicity violations via isotonic regression).

Add a private `skordinal.utils._sklearn_compat.validate_data` shim resolving the API split introduced in scikit-learn 1.6 so estimator code targets a single call site regardless of the installed version.

#### Any other comments?

No production code in `skordinal/` consumes these helpers yet; this PR lays the foundation for the upcoming classifier refactors.