### PR TITLE
REF: Fix sklearn-incompatible label encoding in existing classifiers

### DIFF
--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -143,17 +143,17 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
         """
         X, y = validate_data(self, X, y)
-        self.classes_, _ = check_ordinal_targets(y)
+        self.classes_, y_encoded = check_ordinal_targets(y)
 
         # Aux variables
-        y = y[:, np.newaxis]
+        y_1indexed = (y_encoded + 1)[:, np.newaxis]
         n_classes = len(self.classes_)
         n_samples = X.shape[0]
         # n_features_in_ is set by validate_data; do not assign manually.
 
         # Recode y to Y using ordinalPartitions coding
         Y = 1 * (
-            np.tile(y, (1, n_classes))
+            np.tile(y_1indexed, (1, n_classes))
             <= np.tile(np.arange(1, n_classes + 1)[np.newaxis, :], (n_samples, 1))
         )
 
@@ -243,7 +243,7 @@ class NNOP(ClassifierMixin, BaseEstimator):
             np.tile(np.arange(1, n_classes + 1), (n_samples, 1)),
         )
         a3[np.where(a3 == 0)] = n_classes + 1
-        y_pred = a3.min(axis=1)
+        y_pred = self.classes_[a3.min(axis=1).astype(int) - 1]
 
         return y_pred
 

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -144,16 +144,16 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         """
         X, y = validate_data(self, X, y)
-        self.classes_, _ = check_ordinal_targets(y)
+        self.classes_, y_encoded = check_ordinal_targets(y)
 
         # Aux variables
-        y = y[:, np.newaxis]
+        y_1indexed = (y_encoded + 1)[:, np.newaxis]
         n_classes = len(self.classes_)
         n_samples = X.shape[0]
 
         # Recode y to Y using nominal coding
         Y = 1 * (
-            np.tile(y, (1, n_classes))
+            np.tile(y_1indexed, (1, n_classes))
             == np.tile(np.arange(1, n_classes + 1)[np.newaxis, :], (n_samples, 1))
         )
 
@@ -250,7 +250,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         a3T = 1.0 / (1.0 + np.exp(-z3))
         a3 = np.append(a3T, np.ones((n_samples, 1)), axis=1)
         a3[:, 1:] = a3[:, 1:] - a3[:, 0:-1]
-        y_pred = a3.argmax(1) + 1
+        y_pred = self.classes_[a3.argmax(1)]
 
         return y_pred
 

--- a/skordinal/classifiers/_redsvm.py
+++ b/skordinal/classifiers/_redsvm.py
@@ -153,7 +153,7 @@ class REDSVM(ClassifierMixin, BaseEstimator):
 
         """
         X, y = validate_data(self, X, y)
-        self.classes_, _ = check_ordinal_targets(y)
+        self.classes_, y_encoded = check_ordinal_targets(y)
 
         # Set default gamma value if not specified
         gamma_value = self.gamma
@@ -187,7 +187,7 @@ class REDSVM(ClassifierMixin, BaseEstimator):
             str(self.tol),
             str(1 if self.shrinking else 0),
         )
-        self.model_ = svm.fit(y.tolist(), X.tolist(), options)
+        self.model_ = svm.fit((y_encoded + 1).tolist(), X.tolist(), options)
 
         return self
 
@@ -217,4 +217,4 @@ class REDSVM(ClassifierMixin, BaseEstimator):
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
         y_pred = np.array(svm.predict(X.tolist(), self.model_))
-        return y_pred
+        return self.classes_[y_pred.astype(int) - 1]

--- a/skordinal/classifiers/_svorex.py
+++ b/skordinal/classifiers/_svorex.py
@@ -101,7 +101,7 @@ class SVOREX(ClassifierMixin, BaseEstimator):
 
         """
         X, y = validate_data(self, X, y)
-        self.classes_, _ = check_ordinal_targets(y)
+        self.classes_, y_encoded = check_ordinal_targets(y)
 
         arg = ""
         if self.kernel == "linear":
@@ -113,7 +113,7 @@ class SVOREX(ClassifierMixin, BaseEstimator):
         options = "svorex {} -T {} -K {} -C {}".format(
             arg, str(self.tol), str(self.gamma), str(self.C)
         )
-        self.model_ = svorex.fit(y.tolist(), X.tolist(), options)
+        self.model_ = svorex.fit((y_encoded + 1).tolist(), X.tolist(), options)
         return self
 
     def predict(self, X):
@@ -142,4 +142,4 @@ class SVOREX(ClassifierMixin, BaseEstimator):
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
         y_pred = np.array(svorex.predict(X.tolist(), self.model_))
-        return y_pred
+        return self.classes_[y_pred.astype(int) - 1]

--- a/skordinal/classifiers/tests/test_nnop.py
+++ b/skordinal/classifiers/tests/test_nnop.py
@@ -150,3 +150,27 @@ def test_nnop_predict_rejects_wrong_n_features(X, y):
     classifier = NNOP(n_hidden=4, max_iter=5).fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_nnop_label_roundtrip(labels):
+    """Test that NNOP preserves arbitrary ordinal label sets through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = NNOP(n_hidden=4, max_iter=10)
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))

--- a/skordinal/classifiers/tests/test_nnpom.py
+++ b/skordinal/classifiers/tests/test_nnpom.py
@@ -150,3 +150,27 @@ def test_nnpom_predict_rejects_wrong_n_features(X, y):
     classifier = NNPOM(n_hidden=4, max_iter=5).fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_nnpom_label_roundtrip(labels):
+    """Test that NNPOM preserves arbitrary ordinal label sets through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = NNPOM(n_hidden=4, max_iter=10)
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))

--- a/skordinal/classifiers/tests/test_ordinal_decomposition.py
+++ b/skordinal/classifiers/tests/test_ordinal_decomposition.py
@@ -401,3 +401,29 @@ def test_ordinal_decomposition_predict_rejects_wrong_n_features(X, y):
     classifier = OrdinalDecomposition().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],
+        [0, 1, 2],
+        [-1, 0, 1],
+        [3, 5, 7],
+    ],
+)
+def test_ordinal_decomposition_label_roundtrip(labels):
+    """Test that arbitrary ordinal label sets round-trip through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = OrdinalDecomposition(
+        base_classifier="SVC",
+        parameters={"C": 1.0, "gamma": "scale", "probability": True},
+    ).fit(X, y)
+
+    np.testing.assert_array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))

--- a/skordinal/classifiers/tests/test_redsvm.py
+++ b/skordinal/classifiers/tests/test_redsvm.py
@@ -179,3 +179,27 @@ def test_redsvm_predict_rejects_wrong_n_features(X, y):
     classifier = REDSVM().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_redsvm_label_roundtrip(labels):
+    """Test that REDSVM preserves arbitrary ordinal label sets through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = REDSVM(C=0.1, kernel="linear")
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))

--- a/skordinal/classifiers/tests/test_svorex.py
+++ b/skordinal/classifiers/tests/test_svorex.py
@@ -17,13 +17,13 @@ PREDICTIONS_DIR = Path(__file__).parent / "data" / "SVOREX"
 @pytest.fixture
 def X():
     """Create sample feature patterns for testing."""
-    return np.array([[1, 2], [2, 1], [2, 2], [1, 1], [2, 3]])
+    return np.array([[0, 1], [1, 0], [1, 1], [0, 0], [1, 2]])
 
 
 @pytest.fixture
 def y():
     """Create sample target variables for testing."""
-    return np.array([1, 2, 2, 1, 2])
+    return np.array([0, 1, 1, 0, 1])
 
 
 @pytest.mark.parametrize(
@@ -160,3 +160,27 @@ def test_svorex_predict_rejects_wrong_n_features(X, y):
     classifier = SVOREX().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_svorex_label_roundtrip(labels):
+    """Test that SVOREX preserves arbitrary ordinal label sets through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = SVOREX(C=0.5, kernel="linear")
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

NNOP, NNPOM, SVOREX and REDSVM passed raw user labels directly to their C/C++ cores and NN cost functions, which assume 1-indexed contiguous labels `{1, ..., K}`. This caused silent misbehaviour on any other label set such as `{0, 1}`, `{-1, 1}` or `{3, 5, 7}`.

Each classifier now translates `y` to a 0-based ordinal encoding before passing it to the core (shifted to 1-based where the core requires it) and maps predictions back through `self.classes_` at predict time. Original label values are preserved end-to-end.

Round-trip tests are added for all four classifiers and for `OrdinalDecomposition`, which already handled arbitrary labels correctly via `np.digitize` but lacked tests documenting that behaviour.

#### Any other comments?

The C/C++ extension cores are untouched; only the Python wrappers change.