### PR TITLE
ENH: Add random_state to NNOP/NNPOM

### DIFF
--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -6,6 +6,7 @@ from numbers import Integral, Real
 import numpy as np
 import scipy
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.utils import check_random_state
 from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
@@ -44,6 +45,10 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
     alpha : float, default=0.01
         Regularization parameter.
+
+    random_state : int, RandomState instance, default=None
+        Determines random number generation for weight initialization.
+        Pass an int for reproducible results across multiple function calls.
 
     Attributes
     ----------
@@ -111,13 +116,17 @@ class NNOP(ClassifierMixin, BaseEstimator):
         "n_hidden": [Interval(Integral, 1, None, closed="left")],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
         "alpha": [Interval(Real, 0.0, None, closed="neither")],
+        "random_state": ["random_state"],
     }
 
-    def __init__(self, epsilon_init=0.5, n_hidden=50, max_iter=500, alpha=0.01):
+    def __init__(
+        self, epsilon_init=0.5, n_hidden=50, max_iter=500, alpha=0.01, random_state=None
+    ):
         self.epsilon_init = epsilon_init
         self.n_hidden = n_hidden
         self.max_iter = max_iter
         self.alpha = alpha
+        self.random_state = random_state
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y):
@@ -144,6 +153,7 @@ class NNOP(ClassifierMixin, BaseEstimator):
         """
         X, y = validate_data(self, X, y)
         self.classes_, y_encoded = check_ordinal_targets(y)
+        rng = check_random_state(self.random_state)
 
         # Aux variables
         y_1indexed = (y_encoded + 1)[:, np.newaxis]
@@ -159,10 +169,12 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
         # Hidden layer weights (with bias)
         initial_theta1 = self._rand_initialize_weights(
-            self.n_features_in_ + 1, self.n_hidden
+            self.n_features_in_ + 1, self.n_hidden, rng
         )
         # Output layer weights
-        initial_theta2 = self._rand_initialize_weights(self.n_hidden + 1, n_classes - 1)
+        initial_theta2 = self._rand_initialize_weights(
+            self.n_hidden + 1, n_classes - 1, rng
+        )
 
         # Pack parameters
         initial_nn_params = np.concatenate(
@@ -287,7 +299,7 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
         return theta1, theta2
 
-    def _rand_initialize_weights(self, L_in, L_out):
+    def _rand_initialize_weights(self, L_in, L_out, rng):
         """Initialize layer weights randomly.
 
         Randomly initialize the weights of a layer with L_in incoming connections and
@@ -301,13 +313,16 @@ class NNOP(ClassifierMixin, BaseEstimator):
         L_out : int
             Number of outputs of the layer.
 
+        rng : numpy.random.RandomState
+            Random number generator used for weight initialization.
+
         Returns
         -------
         W : ndarray of shape (L_out, L_in)
             Array with the weights of each synaptic relationship between nodes.
 
         """
-        W = np.random.rand(L_out, L_in) * 2 * self.epsilon_init - self.epsilon_init
+        W = rng.rand(L_out, L_in) * 2 * self.epsilon_init - self.epsilon_init
 
         return W
 

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -6,6 +6,7 @@ from numbers import Integral, Real
 import numpy as np
 import scipy
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.utils import check_random_state
 from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
@@ -43,6 +44,10 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
     alpha : float, default=0.01
         Regularization parameter.
+
+    random_state : int, RandomState instance, default=None
+        Determines random number generation for weight initialization.
+        Pass an int for reproducible results across multiple function calls.
 
     Attributes
     ----------
@@ -112,13 +117,17 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         "n_hidden": [Interval(Integral, 1, None, closed="left")],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
         "alpha": [Interval(Real, 0.0, None, closed="neither")],
+        "random_state": ["random_state"],
     }
 
-    def __init__(self, epsilon_init=0.5, n_hidden=50, max_iter=500, alpha=0.01):
+    def __init__(
+        self, epsilon_init=0.5, n_hidden=50, max_iter=500, alpha=0.01, random_state=None
+    ):
         self.epsilon_init = epsilon_init
         self.n_hidden = n_hidden
         self.max_iter = max_iter
         self.alpha = alpha
+        self.random_state = random_state
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y):
@@ -145,6 +154,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         """
         X, y = validate_data(self, X, y)
         self.classes_, y_encoded = check_ordinal_targets(y)
+        rng = check_random_state(self.random_state)
 
         # Aux variables
         y_1indexed = (y_encoded + 1)[:, np.newaxis]
@@ -159,12 +169,12 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         # Hidden layer weigths (with bias)
         initial_theta1 = self._rand_initialize_weights(
-            self.n_features_in_ + 1, self.n_hidden
+            self.n_features_in_ + 1, self.n_hidden, rng
         )
         # Output layer weigths (without bias, the biases will be the thresholds)
-        initial_theta2 = self._rand_initialize_weights(self.n_hidden, 1)
+        initial_theta2 = self._rand_initialize_weights(self.n_hidden, 1, rng)
         # Class thresholds parameters
-        initial_thresholds = self._rand_initialize_weights((n_classes - 1), 1)
+        initial_thresholds = self._rand_initialize_weights((n_classes - 1), 1, rng)
 
         # Pack parameters
         initial_nn_params = np.concatenate(
@@ -303,7 +313,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         return theta1, theta2, thresholds_param
 
-    def _rand_initialize_weights(self, L_in, L_out):
+    def _rand_initialize_weights(self, L_in, L_out, rng):
         """Initialize layer weights randomly.
 
         Randomly initialize the weights of a layer with L_in incoming connections and
@@ -317,13 +327,16 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         L_out : int
             Number of outputs of the layer.
 
+        rng : numpy.random.RandomState
+            Random number generator used for weight initialization.
+
         Returns
         -------
         W : ndarray of shape (L_out, L_in)
             Array with the weights of each synaptic relationship between nodes.
 
         """
-        W = np.random.rand(L_out, L_in) * 2 * self.epsilon_init - self.epsilon_init
+        W = rng.rand(L_out, L_in) * 2 * self.epsilon_init - self.epsilon_init
 
         return W
 

--- a/skordinal/classifiers/tests/test_nnop.py
+++ b/skordinal/classifiers/tests/test_nnop.py
@@ -47,6 +47,8 @@ def test_nnop_hyperparameter_value_validation(X, y, param_name, invalid_value):
         ("n_hidden", 5.5),
         ("max_iter", 2.5),
         ("alpha", "tight"),
+        ("random_state", "seed"),
+        ("random_state", 1.5),
     ],
 )
 def test_nnop_hyperparameter_type_validation(X, y, param_name, invalid_value):
@@ -174,3 +176,31 @@ def test_nnop_label_roundtrip(labels):
 
     assert np.array_equal(classifier.classes_, np.unique(labels_array))
     assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_nnop_random_state_reproducibility(X, y):
+    """Two fits with the same seed produce identical theta1_, theta2_, n_iter_."""
+    clf_a = NNOP(n_hidden=4, max_iter=10, random_state=0).fit(X, y)
+    clf_b = NNOP(n_hidden=4, max_iter=10, random_state=0).fit(X, y)
+
+    np.testing.assert_array_equal(clf_a.theta1_, clf_b.theta1_)
+    np.testing.assert_array_equal(clf_a.theta2_, clf_b.theta2_)
+    assert clf_a.n_iter_ == clf_b.n_iter_
+
+
+def test_nnop_random_state_different_seeds_differ(X, y):
+    """Different seeds produce different initial weights."""
+    clf_a = NNOP(n_hidden=4, max_iter=10, random_state=0).fit(X, y)
+    clf_b = NNOP(n_hidden=4, max_iter=10, random_state=1).fit(X, y)
+
+    assert not np.array_equal(clf_a.theta1_, clf_b.theta1_)
+
+
+def test_nnop_random_state_accepts_random_state_instance(X, y):
+    """RandomState instance gives the same result as the equivalent seed."""
+    rs_seed = NNOP(n_hidden=4, max_iter=10, random_state=42).fit(X, y)
+    rs_instance = NNOP(
+        n_hidden=4, max_iter=10, random_state=np.random.RandomState(42)
+    ).fit(X, y)
+
+    np.testing.assert_array_equal(rs_seed.theta1_, rs_instance.theta1_)

--- a/skordinal/classifiers/tests/test_nnpom.py
+++ b/skordinal/classifiers/tests/test_nnpom.py
@@ -47,6 +47,8 @@ def test_nnpom_hyperparameter_value_validation(X, y, param_name, invalid_value):
         ("n_hidden", 5.5),
         ("max_iter", 2.5),
         ("alpha", "tight"),
+        ("random_state", "seed"),
+        ("random_state", 1.5),
     ],
 )
 def test_nnpom_hyperparameter_type_validation(X, y, param_name, invalid_value):
@@ -174,3 +176,31 @@ def test_nnpom_label_roundtrip(labels):
 
     assert np.array_equal(classifier.classes_, np.unique(labels_array))
     assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_nnpom_random_state_reproducibility(X, y):
+    """Two fits with the same seed produce identical theta1_, theta2_, n_iter_."""
+    clf_a = NNPOM(n_hidden=4, max_iter=10, random_state=0).fit(X, y)
+    clf_b = NNPOM(n_hidden=4, max_iter=10, random_state=0).fit(X, y)
+
+    np.testing.assert_array_equal(clf_a.theta1_, clf_b.theta1_)
+    np.testing.assert_array_equal(clf_a.theta2_, clf_b.theta2_)
+    assert clf_a.n_iter_ == clf_b.n_iter_
+
+
+def test_nnpom_random_state_different_seeds_differ(X, y):
+    """Different seeds produce different initial weights."""
+    clf_a = NNPOM(n_hidden=4, max_iter=10, random_state=0).fit(X, y)
+    clf_b = NNPOM(n_hidden=4, max_iter=10, random_state=1).fit(X, y)
+
+    assert not np.array_equal(clf_a.theta1_, clf_b.theta1_)
+
+
+def test_nnpom_random_state_accepts_random_state_instance(X, y):
+    """RandomState instance gives the same result as the equivalent seed."""
+    rs_seed = NNPOM(n_hidden=4, max_iter=10, random_state=42).fit(X, y)
+    rs_instance = NNPOM(
+        n_hidden=4, max_iter=10, random_state=np.random.RandomState(42)
+    ).fit(X, y)
+
+    np.testing.assert_array_equal(rs_seed.theta1_, rs_instance.theta1_)

--- a/skordinal/model_selection/tests/test_validation.py
+++ b/skordinal/model_selection/tests/test_validation.py
@@ -27,8 +27,8 @@ from skordinal.utils._testing import TEST_RANDOM_STATE
     "estimator, expected",
     [
         (None, False),
-        (NNOP, False),
-        (NNPOM, False),
+        (NNOP, True),
+        (NNPOM, True),
         (OrdinalDecomposition, False),
         (REDSVM, False),
         (SVOREX, False),
@@ -258,7 +258,7 @@ def test_add_random_state():
 
     param_grid = {"C": 1.0}
     updated = _add_random_state(NNOP, param_grid.copy(), TEST_RANDOM_STATE)
-    assert "random_state" not in updated
+    assert updated["random_state"] == TEST_RANDOM_STATE
 
 
 def test_normalize_param_grid():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

NNOP and NNPOM now accept `random_state` (int, RandomState instance, or None), threaded through `check_random_state` and consumed by the local RNG used in weight initialization. Two `fit` calls with the same seed
produce identical weights and iteration counts, restoring  reproducibility for downstream model selection.

The only existing classifiers with internal randomness are these two neural networks. The SVM-based ones are deterministic by construction and remain unchanged.