### PR TITLE
REF: Rename metric functions to canonical names

### DIFF
--- a/skordinal/metrics/__init__.py
+++ b/skordinal/metrics/__init__.py
@@ -1,36 +1,69 @@
 """Metrics module."""
 
+from sklearn.metrics import accuracy_score, mean_absolute_error
+
 from ._metrics import (
     accuracy_off1,
-    amae,
-    ccr,
-    gm,
+    average_mean_absolute_error,
+    geometric_mean,
     gmsec,
-    mae,
-    mmae,
-    ms,
-    mze,
-    rps,
-    spearman,
-    tkendall,
-    wkappa,
+    kendalls_tau,
+    maximum_mean_absolute_error,
+    mean_zero_one_error,
+    minimum_sensitivity,
+    ranked_probability_score,
+    spearmans_rho,
+    weighted_kappa,
+)
+from ._metrics import (
+    amae as amae,
+)
+from ._metrics import (
+    ccr as ccr,
+)
+from ._metrics import (
+    gm as gm,
+)
+from ._metrics import (
+    mae as mae,
+)
+from ._metrics import (
+    mmae as mmae,
+)
+from ._metrics import (
+    ms as ms,
+)
+from ._metrics import (
+    mze as mze,
+)
+from ._metrics import (
+    rps as rps,
+)
+from ._metrics import (
+    spearman as spearman,
+)
+from ._metrics import (
+    tkendall as tkendall,
+)
+from ._metrics import (
+    wkappa as wkappa,
 )
 from ._scorers import get_ordinal_scorer, list_ordinal_scorers
 
 __all__ = [
     "accuracy_off1",
-    "amae",
-    "ccr",
+    "accuracy_score",
+    "average_mean_absolute_error",
+    "geometric_mean",
     "get_ordinal_scorer",
-    "gm",
     "gmsec",
+    "kendalls_tau",
     "list_ordinal_scorers",
-    "mae",
-    "mmae",
-    "ms",
-    "mze",
-    "rps",
-    "spearman",
-    "tkendall",
-    "wkappa",
+    "maximum_mean_absolute_error",
+    "mean_absolute_error",
+    "mean_zero_one_error",
+    "minimum_sensitivity",
+    "ranked_probability_score",
+    "spearmans_rho",
+    "weighted_kappa",
 ]

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -2,52 +2,19 @@
 
 from __future__ import division
 
+import warnings
+
 import numpy as np
 import scipy.stats
-from sklearn.metrics import confusion_matrix, recall_score
+from sklearn.metrics import (
+    accuracy_score,
+    confusion_matrix,
+    mean_absolute_error,
+    recall_score,
+)
 
 
-def ccr(y_true, y_pred):
-    """Calculate the Correctly Classified Ratio.
-
-    Also named Accuracy, it's the percentage of well classified patterns among all
-    patterns from a set.
-
-    Parameters
-    ----------
-    y_true : np.ndarray, shape (n_samples,)
-        Ground truth labels.
-
-    y_pred : np.ndarray, shape (n_samples,)
-        Predicted labels.
-
-    Returns
-    -------
-    ccr : float
-        Correctly classified ratio.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from skordinal.metrics import ccr
-    >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
-    >>> y_pred = np.array([0, 1, 1, 2, 0, 0, 1])
-    >>> ccr(y_true, y_pred)
-    0.5714285714285714
-
-    """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    return np.count_nonzero(y_true == y_pred) / float(len(y_true))
-
-
-def amae(y_true, y_pred):
+def average_mean_absolute_error(y_true, y_pred):
     """Calculate the Average MAE.
 
     Mean of the MAE metric among classes.
@@ -62,16 +29,16 @@ def amae(y_true, y_pred):
 
     Returns
     -------
-    amae : float
+    average_mean_absolute_error : float
         Average mean absolute error.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import amae
+    >>> from skordinal.metrics import average_mean_absolute_error
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
-    >>> amae(y_true, y_pred)
+    >>> average_mean_absolute_error(y_true, y_pred)
     np.float64(0.125)
 
     """
@@ -98,7 +65,7 @@ def amae(y_true, y_pred):
     return np.mean(per_class_maes)
 
 
-def gm(y_true, y_pred):
+def geometric_mean(y_true, y_pred):
     """Calculate the Geometric mean of the sensitivity (accuracy) for each class.
 
     Parameters
@@ -111,16 +78,16 @@ def gm(y_true, y_pred):
 
     Returns
     -------
-    gm : float
+    geometric_mean : float
         Geometric mean of the sensitivities.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import gm
+    >>> from skordinal.metrics import geometric_mean
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
-    >>> gm(y_true, y_pred)
+    >>> geometric_mean(y_true, y_pred)
     np.float64(0.8408964152537145)
 
     """
@@ -181,46 +148,7 @@ def gmsec(y_true, y_pred):
     return np.sqrt(sensitivities[0] * sensitivities[-1])
 
 
-def mae(y_true, y_pred):
-    """Calculate the Mean Absolute Error.
-
-    Average absolute deviation of the predicted class from the actual true class.
-
-    Parameters
-    ----------
-    y_true : np.ndarray, shape (n_samples,)
-        Ground truth labels.
-
-    y_pred : np.ndarray, shape (n_samples,)
-        Predicted labels.
-
-    Returns
-    -------
-    mae : float
-        Mean absolute error.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from skordinal.metrics import mae
-    >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
-    >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
-    >>> mae(y_true, y_pred)
-    np.float64(0.2857142857142857)
-
-    """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    return abs(y_true - y_pred).sum() / len(y_true)
-
-
-def mmae(y_true, y_pred):
+def maximum_mean_absolute_error(y_true, y_pred):
     """Calculate the Maximum Mean Absolute Error.
 
     MAE value of the class with higher distance from the true values to the predicted
@@ -236,16 +164,16 @@ def mmae(y_true, y_pred):
 
     Returns
     -------
-    mmae : float
+    maximum_mean_absolute_error : float
         Maximum mean absolute error.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import mmae
+    >>> from skordinal.metrics import maximum_mean_absolute_error
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
-    >>> mmae(y_true, y_pred)
+    >>> maximum_mean_absolute_error(y_true, y_pred)
     np.float64(0.5)
 
     """
@@ -272,7 +200,7 @@ def mmae(y_true, y_pred):
     return per_class_maes.max()
 
 
-def ms(y_true, y_pred):
+def minimum_sensitivity(y_true, y_pred):
     """Calculate the Minimum Sensitivity.
 
     Lowest percentage of patterns correctly predicted as belonging to each class, with
@@ -288,16 +216,16 @@ def ms(y_true, y_pred):
 
     Returns
     -------
-    ms : float
+    minimum_sensitivity : float
         Minimum sensitivity.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import ms
+    >>> from skordinal.metrics import minimum_sensitivity
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
-    >>> ms(y_true, y_pred)
+    >>> minimum_sensitivity(y_true, y_pred)
     np.float64(0.5)
 
     """
@@ -313,7 +241,7 @@ def ms(y_true, y_pred):
     return np.min(sensitivities)
 
 
-def mze(y_true, y_pred):
+def mean_zero_one_error(y_true, y_pred):
     """Calculate the Mean Zero-one Error.
 
     Better known as error rate, is the complementary measure of CCR.
@@ -328,16 +256,16 @@ def mze(y_true, y_pred):
 
     Returns
     -------
-    mze : float
+    mean_zero_one_error : float
         Mean zero-one error.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import mze
+    >>> from skordinal.metrics import mean_zero_one_error
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
-    >>> mze(y_true, y_pred)
+    >>> mean_zero_one_error(y_true, y_pred)
     np.float64(0.2857142857142857)
 
     """
@@ -353,7 +281,7 @@ def mze(y_true, y_pred):
     return 1 - np.diagonal(confusion).sum() / confusion.sum()
 
 
-def tkendall(y_true, y_pred):
+def kendalls_tau(y_true, y_pred):
     """Calculate Kendall's tau.
 
     A statistic used to measure the association between two measured quantities. It is
@@ -369,16 +297,16 @@ def tkendall(y_true, y_pred):
 
     Returns
     -------
-    tkendall : float
+    kendalls_tau : float
         Kendall's tau.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import tkendall
+    >>> from skordinal.metrics import kendalls_tau
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
-    >>> tkendall(y_true, y_pred)
+    >>> kendalls_tau(y_true, y_pred)
     np.float64(0.8140915784106943)
 
     """
@@ -394,7 +322,7 @@ def tkendall(y_true, y_pred):
     return corr
 
 
-def wkappa(y_true, y_pred):
+def weighted_kappa(y_true, y_pred):
     """Calculate the Weighted Kappa.
 
     A modified version of the Kappa statistic calculated to allow assigning
@@ -410,16 +338,16 @@ def wkappa(y_true, y_pred):
 
     Returns
     -------
-    wkappa : float
+    weighted_kappa : float
         Weighted Kappa.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import wkappa
+    >>> from skordinal.metrics import weighted_kappa
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
-    >>> wkappa(y_true, y_pred)
+    >>> weighted_kappa(y_true, y_pred)
     np.float64(0.7586206896551724)
 
     """
@@ -448,7 +376,7 @@ def wkappa(y_true, y_pred):
     return (po - pe) / (1 - pe)
 
 
-def spearman(y_true, y_pred):
+def spearmans_rho(y_true, y_pred):
     """Calculate the Spearman's rank correlation coefficient.
 
     A non-parametric measure of statistical dependence between two variables.
@@ -463,16 +391,16 @@ def spearman(y_true, y_pred):
 
     Returns
     -------
-    spearman : float
+    spearmans_rho : float
         Spearman rank correlation coefficient.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import spearman
+    >>> from skordinal.metrics import spearmans_rho
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
-    >>> spearman(y_true, y_pred)
+    >>> spearmans_rho(y_true, y_pred)
     np.float64(0.9165444688834581)
 
     """
@@ -500,7 +428,7 @@ def spearman(y_true, y_pred):
         return num / div
 
 
-def rps(y_true, y_proba):
+def ranked_probability_score(y_true, y_proba):
     """Compute the ranked probability score.
 
     As presented in :footcite:t:`janitza2016random`.
@@ -515,20 +443,20 @@ def rps(y_true, y_proba):
 
     Returns
     -------
-    rps : float
+    ranked_probability_score : float
         The ranked probability score.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import rps
+    >>> from skordinal.metrics import ranked_probability_score
     >>> y_true = np.array([0, 0, 3, 2])
     >>> y_pred = np.array(
     ...     [[0.2, 0.4, 0.2, 0.2],
     ...      [0.7, 0.1, 0.1, 0.1],
     ...      [0.5, 0.05, 0.1, 0.35],
     ...      [0.1, 0.05, 0.65, 0.2]])
-    >>> rps(y_true, y_pred)
+    >>> ranked_probability_score(y_true, y_pred)
     np.float64(0.5068750000000001)
 
     """
@@ -597,3 +525,113 @@ def accuracy_off1(y_true, y_pred, labels=None):
     correct = mask * conf_mat
 
     return 1.0 * np.sum(correct) / np.sum(conf_mat)
+
+
+def ccr(y_true, y_pred):
+    """Deprecated alias for :func:`accuracy_score`."""
+    warnings.warn(
+        "ccr is deprecated, use accuracy_score instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return accuracy_score(y_true, y_pred)
+
+
+def amae(y_true, y_pred):
+    """Deprecated alias for :func:`average_mean_absolute_error`."""
+    warnings.warn(
+        "amae is deprecated, use average_mean_absolute_error instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return average_mean_absolute_error(y_true, y_pred)
+
+
+def gm(y_true, y_pred):
+    """Deprecated alias for :func:`geometric_mean`."""
+    warnings.warn(
+        "gm is deprecated, use geometric_mean instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return geometric_mean(y_true, y_pred)
+
+
+def mae(y_true, y_pred):
+    """Deprecated alias for :func:`mean_absolute_error`."""
+    warnings.warn(
+        "mae is deprecated, use mean_absolute_error instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return mean_absolute_error(y_true, y_pred)
+
+
+def mmae(y_true, y_pred):
+    """Deprecated alias for :func:`maximum_mean_absolute_error`."""
+    warnings.warn(
+        "mmae is deprecated, use maximum_mean_absolute_error instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return maximum_mean_absolute_error(y_true, y_pred)
+
+
+def ms(y_true, y_pred):
+    """Deprecated alias for :func:`minimum_sensitivity`."""
+    warnings.warn(
+        "ms is deprecated, use minimum_sensitivity instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return minimum_sensitivity(y_true, y_pred)
+
+
+def mze(y_true, y_pred):
+    """Deprecated alias for :func:`mean_zero_one_error`."""
+    warnings.warn(
+        "mze is deprecated, use mean_zero_one_error instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return mean_zero_one_error(y_true, y_pred)
+
+
+def tkendall(y_true, y_pred):
+    """Deprecated alias for :func:`kendalls_tau`."""
+    warnings.warn(
+        "tkendall is deprecated, use kendalls_tau instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return kendalls_tau(y_true, y_pred)
+
+
+def wkappa(y_true, y_pred):
+    """Deprecated alias for :func:`weighted_kappa`."""
+    warnings.warn(
+        "wkappa is deprecated, use weighted_kappa instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return weighted_kappa(y_true, y_pred)
+
+
+def spearman(y_true, y_pred):
+    """Deprecated alias for :func:`spearmans_rho`."""
+    warnings.warn(
+        "spearman is deprecated, use spearmans_rho instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return spearmans_rho(y_true, y_pred)
+
+
+def rps(y_true, y_proba):
+    """Deprecated alias for :func:`ranked_probability_score`."""
+    warnings.warn(
+        "rps is deprecated, use ranked_probability_score instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return ranked_probability_score(y_true, y_proba)

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -4,46 +4,70 @@ from __future__ import annotations
 
 from typing import Callable
 
-from sklearn.metrics import make_scorer
+from sklearn.metrics import accuracy_score, make_scorer, mean_absolute_error
 
 from ._metrics import (
     accuracy_off1,
-    amae,
-    ccr,
-    gm,
+    average_mean_absolute_error,
+    geometric_mean,
     gmsec,
-    mae,
-    mmae,
-    ms,
-    mze,
-    rps,
-    spearman,
-    tkendall,
-    wkappa,
+    kendalls_tau,
+    maximum_mean_absolute_error,
+    mean_zero_one_error,
+    minimum_sensitivity,
+    ranked_probability_score,
+    spearmans_rho,
+    weighted_kappa,
 )
 
 _SCORERS: dict[str, Callable] = {
-    # Error metrics (greater_is_better=False).
-    "neg_amae": make_scorer(amae, greater_is_better=False),
-    "neg_mae": make_scorer(mae, greater_is_better=False),
-    "neg_mmae": make_scorer(mmae, greater_is_better=False),
-    "neg_mze": make_scorer(mze, greater_is_better=False),
-    "neg_rps": make_scorer(rps, greater_is_better=False),
-    # Scoring metrics (greater_is_better=True).
+    "neg_average_mean_absolute_error": make_scorer(
+        average_mean_absolute_error, greater_is_better=False
+    ),
+    "neg_mean_absolute_error": make_scorer(
+        mean_absolute_error, greater_is_better=False
+    ),
+    "neg_maximum_mean_absolute_error": make_scorer(
+        maximum_mean_absolute_error, greater_is_better=False
+    ),
+    "neg_mean_zero_one_error": make_scorer(
+        mean_zero_one_error, greater_is_better=False
+    ),
+    "neg_ranked_probability_score": make_scorer(
+        ranked_probability_score, greater_is_better=False
+    ),
+    "average_mean_absolute_error": make_scorer(
+        average_mean_absolute_error, greater_is_better=False
+    ),
+    "mean_absolute_error": make_scorer(mean_absolute_error, greater_is_better=False),
+    "maximum_mean_absolute_error": make_scorer(
+        maximum_mean_absolute_error, greater_is_better=False
+    ),
+    "mean_zero_one_error": make_scorer(mean_zero_one_error, greater_is_better=False),
+    "accuracy": make_scorer(accuracy_score),
     "accuracy_off1": make_scorer(accuracy_off1),
-    "ccr": make_scorer(ccr),
-    "gm": make_scorer(gm),
+    "geometric_mean": make_scorer(geometric_mean),
     "gmsec": make_scorer(gmsec),
-    "ms": make_scorer(ms),
-    "spearman": make_scorer(spearman),
-    "tkendall": make_scorer(tkendall),
-    "wkappa": make_scorer(wkappa),
-    # Error metrics without neg_ prefix, for compatibility.
-    "amae": make_scorer(amae, greater_is_better=False),
-    "mae": make_scorer(mae, greater_is_better=False),
-    "mmae": make_scorer(mmae, greater_is_better=False),
-    "mze": make_scorer(mze, greater_is_better=False),
-    "rps": make_scorer(rps, greater_is_better=False),
+    "kendalls_tau": make_scorer(kendalls_tau),
+    "minimum_sensitivity": make_scorer(minimum_sensitivity),
+    "spearmans_rho": make_scorer(spearmans_rho),
+    "weighted_kappa": make_scorer(weighted_kappa),
+    "neg_amae": make_scorer(average_mean_absolute_error, greater_is_better=False),
+    "neg_mae": make_scorer(mean_absolute_error, greater_is_better=False),
+    "neg_mmae": make_scorer(maximum_mean_absolute_error, greater_is_better=False),
+    "neg_mze": make_scorer(mean_zero_one_error, greater_is_better=False),
+    "neg_rps": make_scorer(ranked_probability_score, greater_is_better=False),
+    "amae": make_scorer(average_mean_absolute_error, greater_is_better=False),
+    "ccr": make_scorer(accuracy_score),
+    "gm": make_scorer(geometric_mean),
+    "mae": make_scorer(mean_absolute_error, greater_is_better=False),
+    "mmae": make_scorer(maximum_mean_absolute_error, greater_is_better=False),
+    "ms": make_scorer(minimum_sensitivity),
+    "mze": make_scorer(mean_zero_one_error, greater_is_better=False),
+    "rps": make_scorer(ranked_probability_score, greater_is_better=False),
+    "spearman": make_scorer(spearmans_rho),
+    "tkendall": make_scorer(kendalls_tau),
+    "wkappa": make_scorer(weighted_kappa),
 }
 
 __all__ = ["get_ordinal_scorer", "list_ordinal_scorers"]
@@ -74,7 +98,7 @@ def get_ordinal_scorer(name: str) -> Callable:
     Examples
     --------
     >>> from skordinal.metrics import get_ordinal_scorer
-    >>> scorer = get_ordinal_scorer("neg_mae")
+    >>> scorer = get_ordinal_scorer("neg_mean_absolute_error")
     >>> callable(scorer)
     True
 
@@ -103,7 +127,7 @@ def list_ordinal_scorers() -> list[str]:
     >>> all_scorers = list_ordinal_scorers()
     >>> type(all_scorers)
     <class 'list'>
-    >>> "neg_mae" in all_scorers
+    >>> "neg_mean_absolute_error" in all_scorers
     True
     >>> "ccr" in all_scorers
     True

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -2,22 +2,23 @@
 
 import numpy as np
 import numpy.testing as npt
+import pytest
 from sklearn.metrics import recall_score
 
 from skordinal.metrics import (
     accuracy_off1,
-    amae,
-    ccr,
-    gm,
+    accuracy_score,
+    average_mean_absolute_error,
+    geometric_mean,
     gmsec,
-    mae,
-    mmae,
-    ms,
-    mze,
-    rps,
-    spearman,
-    tkendall,
-    wkappa,
+    kendalls_tau,
+    maximum_mean_absolute_error,
+    mean_absolute_error,
+    mean_zero_one_error,
+    minimum_sensitivity,
+    ranked_probability_score,
+    spearmans_rho,
+    weighted_kappa,
 )
 
 
@@ -36,75 +37,75 @@ def test_accuracy_off1():
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_ccr():
-    """Test the Correctly Classified Ratio (CCR) metric."""
+def test_accuracy_score():
+    """Test the Correctly Classified Ratio (accuracy_score) metric."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
     expected = 0.8000
-    actual = ccr(y_true, y_pred)
+    actual = accuracy_score(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=4)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.5
-    actual = ccr(y_true, y_pred)
+    actual = accuracy_score(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_amae():
-    """Test the Average Mean Absolute Error (AMAE) metric."""
+def test_average_mean_absolute_error():
+    """Test the Average Mean Absolute Error (average_mean_absolute_error) metric."""
     y_true = np.array([0, 0, 1, 1])
     y_pred = np.array([0, 1, 0, 1])
     expected = 0.5
-    actual = amae(y_true, y_pred)
+    actual = average_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     y_true = np.array([0, 0, 1, 1, 2, 2])
     y_pred = np.array([0, 0, 1, 1, 2, 2])
     expected = 0.0
-    actual = amae(y_true, y_pred)
+    actual = average_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     y_true = np.array([0, 0, 2, 1])
     y_pred = np.array([0, 2, 0, 1])
     expected = 1.0
-    actual = amae(y_true, y_pred)
+    actual = average_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     y_true = np.array([0, 0, 2, 1, 3])
     y_pred = np.array([2, 2, 0, 3, 1])
     expected = 2.0
-    actual = amae(y_true, y_pred)
+    actual = average_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.5
-    actual = amae(y_true, y_pred)
+    actual = average_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     y_true = np.array([0, 1, 2, 3, 3])
     y_pred = np.array([0, 1, 2, 3, 4])
     expected = 0.125
-    actual = amae(y_true, y_pred)
+    actual = average_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_gm():
-    """Test the Geometric Mean (GM) metric."""
+def test_geometric_mean():
+    """Test the Geometric Mean (geometric_mean) metric."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
     expected = 0.7991
-    actual = gm(y_true, y_pred)
+    actual = geometric_mean(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=4)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.5
-    actual = gm(y_true, y_pred)
+    actual = geometric_mean(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
@@ -125,102 +126,102 @@ def test_gmsec():
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_mae():
-    """Test the Mean Absolute Error (MAE) metric."""
+def test_mean_absolute_error():
+    """Test the Mean Absolute Error (mean_absolute_error) metric."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
     expected = 0.3000
-    actual = mae(y_true, y_pred)
+    actual = mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=4)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.5
-    actual = mae(y_true, y_pred)
+    actual = mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_mmae():
-    """Test the Maximum Mean Absolute Error (MMAE) metric."""
+def test_maximum_mean_absolute_error():
+    """Test the Maximum Mean Absolute Error (maximum_mean_absolute_error) metric."""
     y_true = np.array([0, 0, 1, 1])
     y_pred = np.array([0, 1, 0, 1])
     expected = 0.5
-    actual = mmae(y_true, y_pred)
+    actual = maximum_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     y_true = np.array([0, 0, 1, 1, 2, 2])
     y_pred = np.array([0, 0, 1, 1, 2, 2])
     expected = 0.0
-    actual = mmae(y_true, y_pred)
+    actual = maximum_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     y_true = np.array([0, 0, 2, 1])
     y_pred = np.array([0, 2, 0, 1])
     expected = 2.0
-    actual = mmae(y_true, y_pred)
+    actual = maximum_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     y_true = np.array([0, 0, 2, 1, 3])
     y_pred = np.array([2, 2, 0, 3, 1])
     expected = 2.0
-    actual = mmae(y_true, y_pred)
+    actual = maximum_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.5
-    actual = mmae(y_true, y_pred)
+    actual = maximum_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     y_true = np.array([0, 1, 2, 3, 3])
     y_pred = np.array([0, 1, 2, 3, 4])
     expected = 0.5
-    actual = mmae(y_true, y_pred)
+    actual = maximum_mean_absolute_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_ms():
-    """Test the Mean Sensitivity (MS) metric."""
+def test_minimum_sensitivity():
+    """Test the Minimum Sensitivity (minimum_sensitivity) metric."""
     y_true = np.array([0, 0, 1, 1])
     y_pred = np.array([0, 1, 0, 1])
     expected = 0.5
-    actual = ms(y_true, y_pred)
+    actual = minimum_sensitivity(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     y_true = np.array([0, 0, 1, 1, 2, 2])
     y_pred = np.array([0, 0, 1, 1, 2, 2])
     expected = 1.0
-    actual = ms(y_true, y_pred)
+    actual = minimum_sensitivity(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.5
-    actual = ms(y_true, y_pred)
+    actual = minimum_sensitivity(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_mze():
-    """Test the Mean Zero-one Error (MZE) metric."""
+def test_mean_zero_one_error():
+    """Test the Mean Zero-one Error (mean_zero_one_error) metric."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
     expected = 0.2000
-    actual = mze(y_true, y_pred)
+    actual = mean_zero_one_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=4)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.5
-    actual = mze(y_true, y_pred)
+    actual = mean_zero_one_error(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_rps():
-    """Test the ranked probability score (RPS) metric."""
+def test_ranked_probability_score():
+    """Test the ranked probability score (ranked_probability_score) metric."""
     y_true = np.array([0, 0, 3, 2])
     y_pred = np.array(
         [
@@ -231,53 +232,133 @@ def test_rps():
         ]
     )
     expected = 0.506875
-    actual = rps(y_true, y_pred)
+    actual = ranked_probability_score(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_tkendall():
-    """Test the Kendall's Tau metric."""
+def test_kendalls_tau():
+    """Test the Kendall's Tau (kendalls_tau) metric."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
     expected = 0.6240
-    actual = tkendall(y_true, y_pred)
+    actual = kendalls_tau(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=4)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.0
-    actual = tkendall(y_true, y_pred)
+    actual = kendalls_tau(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_wkappa():
-    """Test the Weighted Kappa metric."""
+def test_weighted_kappa():
+    """Test the Weighted Kappa (weighted_kappa) metric."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
     expected = 0.6703
-    actual = wkappa(y_true, y_pred)
+    actual = weighted_kappa(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=4)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.0
-    actual = wkappa(y_true, y_pred)
+    actual = weighted_kappa(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
 
 
-def test_spearman():
-    """Test the Spearman's rank correlation coefficient metric."""
+def test_spearmans_rho():
+    """Test the Spearman's rank correlation coefficient (spearmans_rho) metric."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
     expected = 0.6429
-    actual = spearman(y_true, y_pred)
+    actual = spearmans_rho(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=4)
 
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
     expected = 0.0
-    actual = spearman(y_true, y_pred)
+    actual = spearmans_rho(y_true, y_pred)
     npt.assert_almost_equal(expected, actual, decimal=6)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "ccr",
+        "amae",
+        "gm",
+        "mae",
+        "mmae",
+        "ms",
+        "mze",
+        "tkendall",
+        "wkappa",
+        "spearman",
+    ],
+)
+def test_deprecated_alias_warns(name):
+    """Calling a deprecated short-name alias emits DeprecationWarning."""
+    import skordinal.metrics as m
+
+    y_true = np.array([0, 1, 2, 1, 0])
+    y_pred = np.array([0, 1, 1, 2, 0])
+    fn = getattr(m, name)
+    with pytest.warns(DeprecationWarning, match=name):
+        fn(y_true, y_pred)
+
+
+def test_deprecated_rps_warns():
+    """Calling the deprecated rps alias emits DeprecationWarning."""
+    import skordinal.metrics as m
+
+    y_true = np.array([0, 1, 2])
+    y_proba = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]])
+    with pytest.warns(DeprecationWarning, match="rps"):
+        m.rps(y_true, y_proba)
+
+
+def test_deprecated_alias_not_in_all():
+    """Deprecated short names are not present in skordinal.metrics.__all__."""
+    import skordinal.metrics as m
+
+    deprecated = [
+        "ccr",
+        "amae",
+        "gm",
+        "mae",
+        "mmae",
+        "ms",
+        "mze",
+        "tkendall",
+        "wkappa",
+        "spearman",
+        "rps",
+    ]
+    for name in deprecated:
+        assert name not in m.__all__, f"{name!r} should not be in __all__"
+
+
+def test_metric_names_in_all():
+    """All public metric names are present in skordinal.metrics.__all__."""
+    import skordinal.metrics as m
+
+    expected = [
+        "accuracy_score",
+        "average_mean_absolute_error",
+        "geometric_mean",
+        "mean_absolute_error",
+        "maximum_mean_absolute_error",
+        "minimum_sensitivity",
+        "mean_zero_one_error",
+        "kendalls_tau",
+        "weighted_kappa",
+        "spearmans_rho",
+        "ranked_probability_score",
+        "gmsec",
+        "accuracy_off1",
+    ]
+    for name in expected:
+        assert name in m.__all__, f"{name!r} missing from __all__"

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -7,19 +7,20 @@ from sklearn.model_selection import GridSearchCV, StratifiedKFold
 
 from skordinal.metrics import (
     accuracy_off1,
-    amae,
-    ccr,
+    accuracy_score,
+    average_mean_absolute_error,
+    geometric_mean,
     get_ordinal_scorer,
-    gm,
     gmsec,
+    kendalls_tau,
     list_ordinal_scorers,
-    mae,
-    mmae,
-    ms,
-    mze,
-    spearman,
-    tkendall,
-    wkappa,
+    maximum_mean_absolute_error,
+    mean_absolute_error,
+    mean_zero_one_error,
+    minimum_sensitivity,
+    ranked_probability_score,
+    spearmans_rho,
+    weighted_kappa,
 )
 
 
@@ -46,13 +47,13 @@ def test_scorers_not_in_public_all():
     "name, metric_fn",
     [
         ("accuracy_off1", accuracy_off1),
-        ("ccr", ccr),
-        ("gm", gm),
+        ("accuracy", accuracy_score),
+        ("geometric_mean", geometric_mean),
         ("gmsec", gmsec),
-        ("ms", ms),
-        ("spearman", spearman),
-        ("tkendall", tkendall),
-        ("wkappa", wkappa),
+        ("minimum_sensitivity", minimum_sensitivity),
+        ("spearmans_rho", spearmans_rho),
+        ("kendalls_tau", kendalls_tau),
+        ("weighted_kappa", weighted_kappa),
     ],
 )
 def test_utility_scorer_sign(name, metric_fn):
@@ -65,14 +66,15 @@ def test_utility_scorer_sign(name, metric_fn):
 @pytest.mark.parametrize(
     "name, metric_fn",
     [
-        ("neg_amae", amae),
-        ("neg_mae", mae),
-        ("neg_mmae", mmae),
-        ("neg_mze", mze),
-        ("amae", amae),
-        ("mae", mae),
-        ("mmae", mmae),
-        ("mze", mze),
+        ("neg_average_mean_absolute_error", average_mean_absolute_error),
+        ("neg_mean_absolute_error", mean_absolute_error),
+        ("neg_maximum_mean_absolute_error", maximum_mean_absolute_error),
+        ("neg_mean_zero_one_error", mean_zero_one_error),
+        ("neg_ranked_probability_score", ranked_probability_score),
+        ("average_mean_absolute_error", average_mean_absolute_error),
+        ("mean_absolute_error", mean_absolute_error),
+        ("maximum_mean_absolute_error", maximum_mean_absolute_error),
+        ("mean_zero_one_error", mean_zero_one_error),
     ],
 )
 def test_loss_scorer_sign(name, metric_fn):
@@ -82,30 +84,95 @@ def test_loss_scorer_sign(name, metric_fn):
     assert scorer._sign == -1
 
 
-def test_whitespace_stripped():
-    """Leading and trailing whitespace in the name is ignored."""
-    assert get_ordinal_scorer("  neg_mae  ")._sign == -1
+@pytest.mark.parametrize(
+    "name, metric_fn",
+    [
+        ("ccr", accuracy_score),
+        ("gm", geometric_mean),
+        ("ms", minimum_sensitivity),
+        ("spearman", spearmans_rho),
+        ("tkendall", kendalls_tau),
+        ("wkappa", weighted_kappa),
+    ],
+)
+def test_deprecated_utility_scorer_sign(name, metric_fn):
+    """Deprecated short-name utility scorers have sign +1 and wrap the correct function."""
+    scorer = get_ordinal_scorer(name)
+    assert scorer._score_func is metric_fn
+    assert scorer._sign == 1
 
 
 @pytest.mark.parametrize(
     "name, metric_fn",
     [
-        ("ccr", ccr),
+        ("neg_amae", average_mean_absolute_error),
+        ("neg_mae", mean_absolute_error),
+        ("neg_mmae", maximum_mean_absolute_error),
+        ("neg_mze", mean_zero_one_error),
+        ("amae", average_mean_absolute_error),
+        ("mae", mean_absolute_error),
+        ("mmae", maximum_mean_absolute_error),
+        ("mze", mean_zero_one_error),
+    ],
+)
+def test_deprecated_loss_scorer_sign(name, metric_fn):
+    """Deprecated short-name loss scorers have sign -1 and wrap the correct function."""
+    scorer = get_ordinal_scorer(name)
+    assert scorer._score_func is metric_fn
+    assert scorer._sign == -1
+
+
+def test_whitespace_stripped():
+    """Leading and trailing whitespace in the name is ignored."""
+    assert get_ordinal_scorer("  neg_mean_absolute_error  ")._sign == -1
+
+
+@pytest.mark.parametrize(
+    "name, metric_fn",
+    [
+        ("accuracy", accuracy_score),
         ("accuracy_off1", accuracy_off1),
-        ("gm", gm),
+        ("geometric_mean", geometric_mean),
         ("gmsec", gmsec),
-        ("mae", mae),
-        ("mmae", mmae),
-        ("amae", amae),
-        ("ms", ms),
-        ("mze", mze),
-        ("tkendall", tkendall),
-        ("wkappa", wkappa),
-        ("spearman", spearman),
+        ("mean_absolute_error", mean_absolute_error),
+        ("maximum_mean_absolute_error", maximum_mean_absolute_error),
+        ("average_mean_absolute_error", average_mean_absolute_error),
+        ("minimum_sensitivity", minimum_sensitivity),
+        ("mean_zero_one_error", mean_zero_one_error),
+        ("kendalls_tau", kendalls_tau),
+        ("weighted_kappa", weighted_kappa),
+        ("spearmans_rho", spearmans_rho),
     ],
 )
 def test_scorer_output_matches_metric(name, metric_fn):
     """Scorer's score function returns the same value as calling the metric directly."""
+    y_true = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3]
+    y_pred = [1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3]
+    scorer = get_ordinal_scorer(name)
+    npt.assert_almost_equal(
+        scorer._score_func(y_true, y_pred), metric_fn(y_true, y_pred)
+    )
+
+
+@pytest.mark.parametrize(
+    "name, metric_fn",
+    [
+        ("ccr", accuracy_score),
+        ("accuracy_off1", accuracy_off1),
+        ("gm", geometric_mean),
+        ("gmsec", gmsec),
+        ("mae", mean_absolute_error),
+        ("mmae", maximum_mean_absolute_error),
+        ("amae", average_mean_absolute_error),
+        ("ms", minimum_sensitivity),
+        ("mze", mean_zero_one_error),
+        ("tkendall", kendalls_tau),
+        ("wkappa", weighted_kappa),
+        ("spearman", spearmans_rho),
+    ],
+)
+def test_deprecated_scorer_output_matches_metric(name, metric_fn):
+    """Deprecated scorer's score function returns the same value as the metric."""
     y_true = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3]
     y_pred = [1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3]
     scorer = get_ordinal_scorer(name)
@@ -125,7 +192,7 @@ def test_gridcv_with_loss_scorer():
     gs = GridSearchCV(
         LogisticRegression(max_iter=200),
         param_grid={"C": [0.1, 1.0]},
-        scoring=get_ordinal_scorer("neg_mae"),
+        scoring=get_ordinal_scorer("neg_mean_absolute_error"),
         cv=StratifiedKFold(n_splits=2),
     )
     gs.fit(X, y)
@@ -142,3 +209,50 @@ def test_get_ordinal_scorer_value_error():
     """Unknown name raises ValueError mentioning the requested name."""
     with pytest.raises(ValueError, match="roc_auc"):
         get_ordinal_scorer("roc_auc")
+
+
+def test_scorer_names_present():
+    """Every expected scorer name appears in list_ordinal_scorers()."""
+    names = list_ordinal_scorers()
+    expected = [
+        "neg_average_mean_absolute_error",
+        "neg_mean_absolute_error",
+        "neg_maximum_mean_absolute_error",
+        "neg_mean_zero_one_error",
+        "neg_ranked_probability_score",
+        "accuracy",
+        "accuracy_off1",
+        "geometric_mean",
+        "gmsec",
+        "kendalls_tau",
+        "minimum_sensitivity",
+        "spearmans_rho",
+        "weighted_kappa",
+    ]
+    for name in expected:
+        assert name in names, f"{name!r} missing from list_ordinal_scorers()"
+
+
+def test_deprecated_scorer_names_present():
+    """Deprecated short-name scorer keys are still registered."""
+    names = list_ordinal_scorers()
+    deprecated = [
+        "neg_amae",
+        "neg_mae",
+        "neg_mmae",
+        "neg_mze",
+        "neg_rps",
+        "amae",
+        "ccr",
+        "gm",
+        "mae",
+        "mmae",
+        "ms",
+        "mze",
+        "rps",
+        "spearman",
+        "tkendall",
+        "wkappa",
+    ]
+    for name in deprecated:
+        assert name in names, f"{name!r} missing from list_ordinal_scorers()"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Replaces short abbreviations (`ccr`, `amae`, `gm`, `mze`, etc.) with full descriptive names (`accuracy_score`, `average_mean_absolute_error`, `mean_zero_one_error`, etc.). `accuracy_score` and `mean_absolute_error` are re-exported from scikit-learn rather than reimplemented locally.

Old names stay importable but emit `DeprecationWarning` and are removed from `__all__`. The scorer registry adds canonical `neg_*` keys while keeping the old aliases.