### PR TITLE
ENH: Add sample_weight and type hints to ordinal metrics

### DIFF
--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -643,7 +643,7 @@ def accuracy_off1(
         y_true, y_pred, labels=labels, sample_weight=sample_weight
     )
     n = conf_mat.shape[0]
-    mask = np.eye(n, n) + np.eye(n, n, k=1), +np.eye(n, n, k=-1)
+    mask = np.eye(n, n) + np.eye(n, n, k=1) + np.eye(n, n, k=-1)
     correct = mask * conf_mat
 
     return float(np.sum(correct) / np.sum(conf_mat))

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -12,9 +12,164 @@ from sklearn.metrics import (
     mean_absolute_error,
     recall_score,
 )
+from sklearn.utils import check_array, check_consistent_length
 
 
-def average_mean_absolute_error(y_true, y_pred):
+def _check_metric_inputs(y_true, y_pred):
+    """Coerce metric inputs to 1-D arrays and validate length consistency.
+
+    Two-dimensional inputs are interpreted as one-hot encoded labels and
+    collapsed via ``argmax`` along the last axis. Centralises the input
+    coercion that every public ordinal metric needs.
+
+    Parameters
+    ----------
+    y_true : array-like of shape (n_samples,) or (n_samples, n_classes)
+        Ground truth labels.
+
+    y_pred : array-like of shape (n_samples,) or (n_samples, n_classes)
+        Predicted labels or class scores.
+
+    Returns
+    -------
+    y_true : ndarray of shape (n_samples,)
+    y_pred : ndarray of shape (n_samples,)
+
+    Raises
+    ------
+    ValueError
+        If ``y_true`` and ``y_pred`` have different lengths.
+    """
+    y_true_arr = np.asarray(y_true)
+    y_pred_arr = np.asarray(y_pred)
+    if y_true_arr.ndim > 1:
+        y_true_arr = y_true_arr.argmax(axis=-1)
+    if y_pred_arr.ndim > 1:
+        y_pred_arr = y_pred_arr.argmax(axis=-1)
+    check_consistent_length(y_true_arr, y_pred_arr)
+    return y_true_arr, y_pred_arr
+
+
+def _check_proba_inputs(y_true, y_proba, *, sum_atol=1e-6):
+    """Validate inputs for probabilistic ordinal metrics.
+
+    ``y_true`` may be 1-D class labels or a 2-D one-hot matrix.
+    ``y_proba`` must be a 2-D matrix coercible to ``float64`` whose rows
+    sum to approximately one.
+
+    Parameters
+    ----------
+    y_true : array-like of shape (n_samples,) or (n_samples, n_classes)
+        Ground truth labels.
+
+    y_proba : array-like of shape (n_samples, n_classes)
+        Predicted class probability matrix.
+
+    sum_atol : float, default=1e-6
+        Absolute tolerance for the row-sum check.
+
+    Returns
+    -------
+    y_true : ndarray of shape (n_samples,)
+    y_proba : ndarray of shape (n_samples, n_classes), dtype float64
+
+    Raises
+    ------
+    ValueError
+        If ``y_true`` and ``y_proba`` have inconsistent length, or if any
+        row of ``y_proba`` does not sum to 1 within ``sum_atol``.
+    """
+    y_true_arr = np.asarray(y_true)
+    if y_true_arr.ndim > 1:
+        y_true_arr = y_true_arr.argmax(axis=-1)
+    y_proba_arr = check_array(
+        y_proba, ensure_2d=True, dtype="float64", input_name="y_proba"
+    )
+    check_consistent_length(y_true_arr, y_proba_arr)
+    row_sums = y_proba_arr.sum(axis=1)
+    if not np.allclose(row_sums, 1.0, atol=sum_atol):
+        raise ValueError(
+            f"y_proba rows must sum to 1 (atol={sum_atol}); got row-sum "
+            f"range [{row_sums.min():.6g}, {row_sums.max():.6g}]"
+        )
+    return y_true_arr, y_proba_arr
+
+
+def _recall_per_class(y_true, y_pred, *, labels=None, sample_weight=None):
+    """Return per-class recall as a 1-D float64 ndarray.
+
+    Thin wrapper around :func:`sklearn.metrics.recall_score` with
+    ``average=None`` and ``zero_division=0``. Centralises the call so
+    public sensitivity-based metrics share one implementation.
+
+    Parameters
+    ----------
+    y_true : ndarray of shape (n_samples,)
+        Ground truth labels.
+
+    y_pred : ndarray of shape (n_samples,)
+        Predicted labels.
+
+    labels : array-like of shape (n_classes,), default=None
+        Labels in the order to score. If ``None``, all unique labels are
+        used.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    Returns
+    -------
+    sensitivities : ndarray of shape (n_classes,), dtype float64
+    """
+    return np.asarray(
+        recall_score(
+            y_true,
+            y_pred,
+            labels=labels,
+            average=None,
+            sample_weight=sample_weight,
+            zero_division=0,
+        ),
+        dtype=np.float64,
+    )
+
+
+def _per_class_mae(y_true, y_pred, *, labels=None, sample_weight=None):
+    """Return per-class mean absolute error as a 1-D float64 ndarray.
+
+    Drops rows of the confusion matrix with no support (zero true
+    samples for that class) so divisions remain finite. Shared by
+    :func:`average_mean_absolute_error` and
+    :func:`maximum_mean_absolute_error`.
+
+    Parameters
+    ----------
+    y_true : ndarray of shape (n_samples,)
+        Ground truth labels.
+
+    y_pred : ndarray of shape (n_samples,)
+        Predicted labels.
+
+    labels : array-like of shape (n_classes,), default=None
+        Labels to index the confusion matrix.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    Returns
+    -------
+    per_class_mae : ndarray of shape (n_classes_with_support,), dtype float64
+    """
+    cm = confusion_matrix(y_true, y_pred, labels=labels, sample_weight=sample_weight)
+    n_class = cm.shape[0]
+    costs = np.abs(np.arange(n_class)[:, None] - np.arange(n_class)[None, :])
+    errors = costs * cm
+    support = cm.sum(axis=1).astype(np.float64)
+    non_zero = support > 0
+    return errors[non_zero].sum(axis=1) / support[non_zero]
+
+
+def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     """Calculate the Average MAE.
 
     Mean of the MAE metric among classes.
@@ -42,30 +197,11 @@ def average_mean_absolute_error(y_true, y_pred):
     np.float64(0.125)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    cm = confusion_matrix(y_true, y_pred)
-    n_class = cm.shape[0]
-    costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
-    costs = np.abs(costs - np.transpose(costs))
-    errors = costs * cm
-
-    # Remove rows with all zeros in the confusion matrix
-    non_zero_cm_rows = ~np.all(cm == 0, axis=1)
-    errors = errors[non_zero_cm_rows]
-    cm = cm[non_zero_cm_rows]
-
-    per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
-    return np.mean(per_class_maes)
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    return _per_class_mae(y_true, y_pred, sample_weight=sample_weight).mean()
 
 
-def geometric_mean(y_true, y_pred):
+def geometric_mean(y_true, y_pred, *, sample_weight=None):
     """Calculate the Geometric mean of the sensitivity (accuracy) for each class.
 
     Parameters
@@ -91,23 +227,16 @@ def geometric_mean(y_true, y_pred):
     np.float64(0.8408964152537145)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    cm = confusion_matrix(y_true, y_pred)
-    sum_by_class = np.sum(cm, axis=1)
-    sensitivities = np.diag(cm) / sum_by_class.astype("double")
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
+    sum_by_class = cm.sum(axis=1)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        sensitivities = np.diag(cm) / sum_by_class.astype("double")
     sensitivities[sum_by_class == 0] = 1
-    gm = pow(np.prod(sensitivities), 1.0 / cm.shape[0])
-    return gm
+    return pow(np.prod(sensitivities), 1.0 / cm.shape[0])
 
 
-def gmsec(y_true, y_pred):
+def gmsec(y_true, y_pred, *, sample_weight=None):
     """Compute the Geometric Mean of the Sensitivity of the Extreme Classes (GMSEC).
 
     Proposed in (:footcite:t:`vargas2024improving`) to assess the classification
@@ -136,19 +265,12 @@ def gmsec(y_true, y_pred):
     np.float64(0.7071067811865476)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    sensitivities = recall_score(y_true, y_pred, average=None)
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
     return np.sqrt(sensitivities[0] * sensitivities[-1])
 
 
-def maximum_mean_absolute_error(y_true, y_pred):
+def maximum_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     """Calculate the Maximum Mean Absolute Error.
 
     MAE value of the class with higher distance from the true values to the predicted
@@ -177,30 +299,11 @@ def maximum_mean_absolute_error(y_true, y_pred):
     np.float64(0.5)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    cm = confusion_matrix(y_true, y_pred)
-    n_class = cm.shape[0]
-    costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
-    costs = np.abs(costs - np.transpose(costs))
-    errors = costs * cm
-
-    # Remove rows with all zeros in the confusion matrix
-    non_zero_cm_rows = ~np.all(cm == 0, axis=1)
-    errors = errors[non_zero_cm_rows]
-    cm = cm[non_zero_cm_rows]
-
-    per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
-    return per_class_maes.max()
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    return _per_class_mae(y_true, y_pred, sample_weight=sample_weight).max()
 
 
-def minimum_sensitivity(y_true, y_pred):
+def minimum_sensitivity(y_true, y_pred, *, sample_weight=None):
     """Calculate the Minimum Sensitivity.
 
     Lowest percentage of patterns correctly predicted as belonging to each class, with
@@ -229,19 +332,12 @@ def minimum_sensitivity(y_true, y_pred):
     np.float64(0.5)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    sensitivities = recall_score(y_true, y_pred, average=None)
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
     return np.min(sensitivities)
 
 
-def mean_zero_one_error(y_true, y_pred):
+def mean_zero_one_error(y_true, y_pred, *, sample_weight=None):
     """Calculate the Mean Zero-one Error.
 
     Better known as error rate, is the complementary measure of CCR.
@@ -269,16 +365,9 @@ def mean_zero_one_error(y_true, y_pred):
     np.float64(0.2857142857142857)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    confusion = confusion_matrix(y_true, y_pred)
-    return 1 - np.diagonal(confusion).sum() / confusion.sum()
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
+    return 1 - np.diagonal(cm).sum() / cm.sum()
 
 
 def kendalls_tau(y_true, y_pred):
@@ -310,19 +399,12 @@ def kendalls_tau(y_true, y_pred):
     np.float64(0.8140915784106943)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    corr, pvalue = scipy.stats.kendalltau(y_true, y_pred)
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    corr, _ = scipy.stats.kendalltau(y_true, y_pred)
     return corr
 
 
-def weighted_kappa(y_true, y_pred):
+def weighted_kappa(y_true, y_pred, *, sample_weight=None):
     """Calculate the Weighted Kappa.
 
     A modified version of the Kappa statistic calculated to allow assigning
@@ -351,25 +433,17 @@ def weighted_kappa(y_true, y_pred):
     np.float64(0.7586206896551724)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    cm = confusion_matrix(y_true, y_pred)
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     n_class = cm.shape[0]
-    costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
-    costs = np.abs(costs - np.transpose(costs))
+    costs = np.abs(np.arange(n_class)[:, None] - np.arange(n_class)[None, :])
     f = 1 - costs
 
     n = cm.sum()
     x = cm / n
 
-    r = x.sum(axis=1)  # Row sum
-    s = x.sum(axis=0)  # Col sum
+    r = x.sum(axis=1)
+    s = x.sum(axis=0)
     Ex = r.reshape(-1, 1) * s
     po = (x * f).sum()
     pe = (Ex * f).sum()
@@ -404,31 +478,18 @@ def spearmans_rho(y_true, y_pred):
     np.float64(0.9165444688834581)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
-
-    n = len(y_true)
-    num = (
-        (y_true - np.repeat(np.mean(y_true), n))
-        * (y_pred - np.repeat(np.mean(y_pred), n))
-    ).sum()
-    div = np.sqrt(
-        (pow(y_true - np.repeat(np.mean(y_true), n), 2)).sum()
-        * (pow(y_pred - np.repeat(np.mean(y_pred), n), 2)).sum()
-    )
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    y_true_centered = y_true - np.mean(y_true)
+    y_pred_centered = y_pred - np.mean(y_pred)
+    num = (y_true_centered * y_pred_centered).sum()
+    div = np.sqrt((y_true_centered**2).sum() * (y_pred_centered**2).sum())
 
     if num == 0:
         return 0
-    else:
-        return num / div
+    return num / div
 
 
-def ranked_probability_score(y_true, y_proba):
+def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     """Compute the ranked probability score.
 
     As presented in :footcite:t:`janitza2016random`.
@@ -460,25 +521,26 @@ def ranked_probability_score(y_true, y_proba):
     np.float64(0.5068750000000001)
 
     """
-    y_true = np.array(y_true)
-    y_proba = np.array(y_proba)
+    y_true, y_proba = _check_proba_inputs(y_true, y_proba)
+    y_true = y_true.astype(np.intp)
+    n_samples, n_classes = y_proba.shape
 
-    y_oh = np.zeros(y_proba.shape)
-    y_oh[np.arange(len(y_true)), y_true] = 1
+    in_range = (y_true >= 0) & (y_true < n_classes)
+    y_oh = np.zeros_like(y_proba)
+    rows = np.arange(n_samples)[in_range]
+    y_oh[rows, y_true[in_range]] = 1.0
 
-    y_oh = y_oh.cumsum(axis=1)
-    y_proba = y_proba.cumsum(axis=1)
+    y_oh_cum = y_oh.cumsum(axis=1)
+    y_proba_cum = y_proba.cumsum(axis=1)
 
-    rps = 0
-    for i in range(len(y_true)):
-        if y_true[i] in np.arange(y_proba.shape[1]):
-            rps += np.power(y_proba[i] - y_oh[i], 2).sum()
-        else:
-            rps += 1
-    return rps / len(y_true)
+    per_sample = np.power(y_proba_cum - y_oh_cum, 2).sum(axis=1)
+    per_sample[~in_range] = 1.0
+
+    weights = None if sample_weight is None else np.asarray(sample_weight, dtype=float)
+    return np.average(per_sample, weights=weights)
 
 
-def accuracy_off1(y_true, y_pred, labels=None):
+def accuracy_off1(y_true, y_pred, *, labels=None, sample_weight=None):
     """Computes the accuracy of the predictions.
 
     Allows errors if they occur in an adjacent class.
@@ -509,17 +571,13 @@ def accuracy_off1(y_true, y_pred, labels=None):
     np.float64(0.8571428571428571)
 
     """
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-
-    if len(y_true.shape) > 1:
-        y_true = np.argmax(y_true, axis=1)
-    if len(y_pred.shape) > 1:
-        y_pred = np.argmax(y_pred, axis=1)
+    y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     if labels is None:
         labels = np.unique(y_true)
 
-    conf_mat = confusion_matrix(y_true, y_pred, labels=labels)
+    conf_mat = confusion_matrix(
+        y_true, y_pred, labels=labels, sample_weight=sample_weight
+    )
     n = conf_mat.shape[0]
     mask = np.eye(n, n) + np.eye(n, n, k=1), +np.eye(n, n, k=-1)
     correct = mask * conf_mat

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -1,11 +1,13 @@
 """Metrics for ordinal classification."""
 
-from __future__ import division
+from __future__ import annotations
 
 import warnings
+from typing import Optional
 
 import numpy as np
 import scipy.stats
+from numpy.typing import ArrayLike, NDArray
 from sklearn.metrics import (
     accuracy_score,
     confusion_matrix,
@@ -15,7 +17,9 @@ from sklearn.metrics import (
 from sklearn.utils import check_array, check_consistent_length
 
 
-def _check_metric_inputs(y_true, y_pred):
+def _check_metric_inputs(
+    y_true: ArrayLike, y_pred: ArrayLike
+) -> tuple[NDArray, NDArray]:
     """Coerce metric inputs to 1-D arrays and validate length consistency.
 
     Two-dimensional inputs are interpreted as one-hot encoded labels and
@@ -50,7 +54,9 @@ def _check_metric_inputs(y_true, y_pred):
     return y_true_arr, y_pred_arr
 
 
-def _check_proba_inputs(y_true, y_proba, *, sum_atol=1e-6):
+def _check_proba_inputs(
+    y_true: ArrayLike, y_proba: ArrayLike, *, sum_atol: float = 1e-6
+) -> tuple[NDArray, NDArray[np.float64]]:
     """Validate inputs for probabilistic ordinal metrics.
 
     ``y_true`` may be 1-D class labels or a 2-D one-hot matrix.
@@ -95,7 +101,13 @@ def _check_proba_inputs(y_true, y_proba, *, sum_atol=1e-6):
     return y_true_arr, y_proba_arr
 
 
-def _recall_per_class(y_true, y_pred, *, labels=None, sample_weight=None):
+def _recall_per_class(
+    y_true: NDArray,
+    y_pred: NDArray,
+    *,
+    labels: Optional[ArrayLike] = None,
+    sample_weight: Optional[ArrayLike] = None,
+) -> NDArray[np.float64]:
     """Return per-class recall as a 1-D float64 ndarray.
 
     Thin wrapper around :func:`sklearn.metrics.recall_score` with
@@ -134,7 +146,13 @@ def _recall_per_class(y_true, y_pred, *, labels=None, sample_weight=None):
     )
 
 
-def _per_class_mae(y_true, y_pred, *, labels=None, sample_weight=None):
+def _per_class_mae(
+    y_true: NDArray,
+    y_pred: NDArray,
+    *,
+    labels: Optional[ArrayLike] = None,
+    sample_weight: Optional[ArrayLike] = None,
+) -> NDArray[np.float64]:
     """Return per-class mean absolute error as a 1-D float64 ndarray.
 
     Drops rows of the confusion matrix with no support (zero true
@@ -169,7 +187,12 @@ def _per_class_mae(y_true, y_pred, *, labels=None, sample_weight=None):
     return errors[non_zero].sum(axis=1) / support[non_zero]
 
 
-def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
+def average_mean_absolute_error(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    *,
+    sample_weight: Optional[ArrayLike] = None,
+) -> float:
     """Calculate the Average MAE.
 
     Mean of the MAE metric among classes.
@@ -194,14 +217,19 @@ def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> average_mean_absolute_error(y_true, y_pred)
-    np.float64(0.125)
+    0.125
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
-    return _per_class_mae(y_true, y_pred, sample_weight=sample_weight).mean()
+    return float(_per_class_mae(y_true, y_pred, sample_weight=sample_weight).mean())
 
 
-def geometric_mean(y_true, y_pred, *, sample_weight=None):
+def geometric_mean(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    *,
+    sample_weight: Optional[ArrayLike] = None,
+) -> float:
     """Calculate the Geometric mean of the sensitivity (accuracy) for each class.
 
     Parameters
@@ -224,7 +252,7 @@ def geometric_mean(y_true, y_pred, *, sample_weight=None):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> geometric_mean(y_true, y_pred)
-    np.float64(0.8408964152537145)
+    0.8408964152537145
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
@@ -233,10 +261,15 @@ def geometric_mean(y_true, y_pred, *, sample_weight=None):
     with np.errstate(divide="ignore", invalid="ignore"):
         sensitivities = np.diag(cm) / sum_by_class.astype("double")
     sensitivities[sum_by_class == 0] = 1
-    return pow(np.prod(sensitivities), 1.0 / cm.shape[0])
+    return float(pow(np.prod(sensitivities), 1.0 / cm.shape[0]))
 
 
-def gmsec(y_true, y_pred, *, sample_weight=None):
+def gmsec(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    *,
+    sample_weight: Optional[ArrayLike] = None,
+) -> float:
     """Compute the Geometric Mean of the Sensitivity of the Extreme Classes (GMSEC).
 
     Proposed in (:footcite:t:`vargas2024improving`) to assess the classification
@@ -262,15 +295,20 @@ def gmsec(y_true, y_pred, *, sample_weight=None):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> gmsec(y_true, y_pred)
-    np.float64(0.7071067811865476)
+    0.7071067811865476
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
-    return np.sqrt(sensitivities[0] * sensitivities[-1])
+    return float(np.sqrt(sensitivities[0] * sensitivities[-1]))
 
 
-def maximum_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
+def maximum_mean_absolute_error(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    *,
+    sample_weight: Optional[ArrayLike] = None,
+) -> float:
     """Calculate the Maximum Mean Absolute Error.
 
     MAE value of the class with higher distance from the true values to the predicted
@@ -296,14 +334,19 @@ def maximum_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> maximum_mean_absolute_error(y_true, y_pred)
-    np.float64(0.5)
+    0.5
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
-    return _per_class_mae(y_true, y_pred, sample_weight=sample_weight).max()
+    return float(_per_class_mae(y_true, y_pred, sample_weight=sample_weight).max())
 
 
-def minimum_sensitivity(y_true, y_pred, *, sample_weight=None):
+def minimum_sensitivity(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    *,
+    sample_weight: Optional[ArrayLike] = None,
+) -> float:
     """Calculate the Minimum Sensitivity.
 
     Lowest percentage of patterns correctly predicted as belonging to each class, with
@@ -329,15 +372,20 @@ def minimum_sensitivity(y_true, y_pred, *, sample_weight=None):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> minimum_sensitivity(y_true, y_pred)
-    np.float64(0.5)
+    0.5
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
-    return np.min(sensitivities)
+    return float(np.min(sensitivities))
 
 
-def mean_zero_one_error(y_true, y_pred, *, sample_weight=None):
+def mean_zero_one_error(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    *,
+    sample_weight: Optional[ArrayLike] = None,
+) -> float:
     """Calculate the Mean Zero-one Error.
 
     Better known as error rate, is the complementary measure of CCR.
@@ -362,15 +410,15 @@ def mean_zero_one_error(y_true, y_pred, *, sample_weight=None):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> mean_zero_one_error(y_true, y_pred)
-    np.float64(0.2857142857142857)
+    0.2857142857142857
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
-    return 1 - np.diagonal(cm).sum() / cm.sum()
+    return float(1 - np.diagonal(cm).sum() / cm.sum())
 
 
-def kendalls_tau(y_true, y_pred):
+def kendalls_tau(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Calculate Kendall's tau.
 
     A statistic used to measure the association between two measured quantities. It is
@@ -396,15 +444,20 @@ def kendalls_tau(y_true, y_pred):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> kendalls_tau(y_true, y_pred)
-    np.float64(0.8140915784106943)
+    0.8140915784106943
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     corr, _ = scipy.stats.kendalltau(y_true, y_pred)
-    return corr
+    return float(corr)
 
 
-def weighted_kappa(y_true, y_pred, *, sample_weight=None):
+def weighted_kappa(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    *,
+    sample_weight: Optional[ArrayLike] = None,
+) -> float:
     """Calculate the Weighted Kappa.
 
     A modified version of the Kappa statistic calculated to allow assigning
@@ -430,7 +483,7 @@ def weighted_kappa(y_true, y_pred, *, sample_weight=None):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> weighted_kappa(y_true, y_pred)
-    np.float64(0.7586206896551724)
+    0.7586206896551724
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
@@ -447,10 +500,10 @@ def weighted_kappa(y_true, y_pred, *, sample_weight=None):
     Ex = r.reshape(-1, 1) * s
     po = (x * f).sum()
     pe = (Ex * f).sum()
-    return (po - pe) / (1 - pe)
+    return float((po - pe) / (1 - pe))
 
 
-def spearmans_rho(y_true, y_pred):
+def spearmans_rho(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Calculate the Spearman's rank correlation coefficient.
 
     A non-parametric measure of statistical dependence between two variables.
@@ -475,7 +528,7 @@ def spearmans_rho(y_true, y_pred):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> spearmans_rho(y_true, y_pred)
-    np.float64(0.9165444688834581)
+    0.9165444688834581
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
@@ -485,11 +538,16 @@ def spearmans_rho(y_true, y_pred):
     div = np.sqrt((y_true_centered**2).sum() * (y_pred_centered**2).sum())
 
     if num == 0:
-        return 0
-    return num / div
+        return 0.0
+    return float(num / div)
 
 
-def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
+def ranked_probability_score(
+    y_true: ArrayLike,
+    y_proba: ArrayLike,
+    *,
+    sample_weight: Optional[ArrayLike] = None,
+) -> float:
     """Compute the ranked probability score.
 
     As presented in :footcite:t:`janitza2016random`.
@@ -518,7 +576,7 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     ...      [0.5, 0.05, 0.1, 0.35],
     ...      [0.1, 0.05, 0.65, 0.2]])
     >>> ranked_probability_score(y_true, y_pred)
-    np.float64(0.5068750000000001)
+    0.5068750000000001
 
     """
     y_true, y_proba = _check_proba_inputs(y_true, y_proba)
@@ -537,10 +595,16 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     per_sample[~in_range] = 1.0
 
     weights = None if sample_weight is None else np.asarray(sample_weight, dtype=float)
-    return np.average(per_sample, weights=weights)
+    return float(np.average(per_sample, weights=weights))
 
 
-def accuracy_off1(y_true, y_pred, *, labels=None, sample_weight=None):
+def accuracy_off1(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    *,
+    labels: Optional[ArrayLike] = None,
+    sample_weight: Optional[ArrayLike] = None,
+) -> float:
     """Computes the accuracy of the predictions.
 
     Allows errors if they occur in an adjacent class.
@@ -568,7 +632,7 @@ def accuracy_off1(y_true, y_pred, *, labels=None, sample_weight=None):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 0, 0, 1])
     >>> accuracy_off1(y_true, y_pred)
-    np.float64(0.8571428571428571)
+    0.8571428571428571
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
@@ -582,7 +646,7 @@ def accuracy_off1(y_true, y_pred, *, labels=None, sample_weight=None):
     mask = np.eye(n, n) + np.eye(n, n, k=1), +np.eye(n, n, k=-1)
     correct = mask * conf_mat
 
-    return 1.0 * np.sum(correct) / np.sum(conf_mat)
+    return float(np.sum(correct) / np.sum(conf_mat))
 
 
 def ccr(y_true, y_pred):

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -193,22 +193,32 @@ def average_mean_absolute_error(
     *,
     sample_weight: Optional[ArrayLike] = None,
 ) -> float:
-    """Calculate the Average MAE.
+    """Compute the average per-class mean absolute error.
 
-    Mean of the MAE metric among classes.
+    For each class with at least one ground-truth sample, the mean
+    absolute error is computed using the class label as the numerical
+    score. The per-class errors are then averaged with equal weight,
+    which makes the metric robust to class imbalance.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray, shape (n_samples,)
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights forwarded to the confusion matrix.
 
     Returns
     -------
-    average_mean_absolute_error : float
-        Average mean absolute error.
+    score : float
+        Average per-class mean absolute error.
+
+    Notes
+    -----
+    Classes with no ground-truth samples are excluded from the average.
 
     Examples
     --------
@@ -230,20 +240,34 @@ def geometric_mean(
     *,
     sample_weight: Optional[ArrayLike] = None,
 ) -> float:
-    """Calculate the Geometric mean of the sensitivity (accuracy) for each class.
+    """Compute the geometric mean of per-class sensitivities.
+
+    Sensitivity (recall) is computed for every class from the confusion
+    matrix and the result is the geometric mean across classes. The
+    metric penalises poor performance on minority classes more strongly
+    than a simple average.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray, shape (n_samples,)
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights forwarded to the confusion matrix.
 
     Returns
     -------
-    geometric_mean : float
-        Geometric mean of the sensitivities.
+    score : float
+        Geometric mean of the per-class sensitivities.
+
+    Notes
+    -----
+    Classes with no ground-truth samples are treated as sensitivity 1,
+    leaving them out of the geometric mean. This avoids collapsing the
+    score to zero when a class has no support.
 
     Examples
     --------
@@ -270,23 +294,32 @@ def gmsec(
     *,
     sample_weight: Optional[ArrayLike] = None,
 ) -> float:
-    """Compute the Geometric Mean of the Sensitivity of the Extreme Classes (GMSEC).
+    """Geometric mean of the sensitivities of the extreme ordinal classes.
 
-    Proposed in (:footcite:t:`vargas2024improving`) to assess the classification
-    performance for the first and the last classes.
+    Proposed in :footcite:t:`vargas2024improving` to assess the
+    classification performance on the first and the last classes of an
+    ordinal scale. Returns the geometric mean of the recall of the
+    lowest and the highest classes that appear in ``y_true``.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray, shape (n_samples,)
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights forwarded to ``recall_score``.
 
     Returns
     -------
-    gmsec : float
+    score : float
         Geometric mean of the sensitivities of the extreme classes.
+
+    References
+    ----------
+    .. footbibliography::
 
     Examples
     --------
@@ -309,23 +342,31 @@ def maximum_mean_absolute_error(
     *,
     sample_weight: Optional[ArrayLike] = None,
 ) -> float:
-    """Calculate the Maximum Mean Absolute Error.
+    """Compute the maximum per-class mean absolute error.
 
-    MAE value of the class with higher distance from the true values to the predicted
-    ones.
+    Returns the largest per-class MAE across classes with at least one
+    ground-truth sample. Useful for monitoring the worst-performing
+    class under imbalance.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray, shape (n_samples,)
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights forwarded to the confusion matrix.
 
     Returns
     -------
-    maximum_mean_absolute_error : float
-        Maximum mean absolute error.
+    score : float
+        Maximum per-class mean absolute error.
+
+    Notes
+    -----
+    Classes with no ground-truth samples are excluded from the maximum.
 
     Examples
     --------
@@ -347,23 +388,27 @@ def minimum_sensitivity(
     *,
     sample_weight: Optional[ArrayLike] = None,
 ) -> float:
-    """Calculate the Minimum Sensitivity.
+    """Lowest per-class sensitivity.
 
-    Lowest percentage of patterns correctly predicted as belonging to each class, with
-    respect to the total number of examples in the corresponding class.
+    Returns the minimum recall across all classes present in
+    ``y_true``. The metric flags the class on which the classifier
+    performs worst regardless of class prevalence.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray, shape (n_samples,)
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights forwarded to ``recall_score``.
 
     Returns
     -------
-    minimum_sensitivity : float
-        Minimum sensitivity.
+    score : float
+        Minimum per-class sensitivity.
 
     Examples
     --------
@@ -386,21 +431,25 @@ def mean_zero_one_error(
     *,
     sample_weight: Optional[ArrayLike] = None,
 ) -> float:
-    """Calculate the Mean Zero-one Error.
+    """Fraction of misclassified samples (error rate).
 
-    Better known as error rate, is the complementary measure of CCR.
+    Equivalent to ``1 - accuracy``; the complementary measure of the
+    Correct Classification Rate.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray, shape (n_samples,)
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights forwarded to the confusion matrix.
 
     Returns
     -------
-    mean_zero_one_error : float
+    score : float
         Mean zero-one error.
 
     Examples
@@ -419,23 +468,29 @@ def mean_zero_one_error(
 
 
 def kendalls_tau(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Calculate Kendall's tau.
+    """Kendall's tau rank correlation coefficient.
 
-    A statistic used to measure the association between two measured quantities. It is
-    a measure of rank correlation.
+    Measures the ordinal association between ``y_true`` and ``y_pred``
+    using the number of concordant minus discordant pairs. Computed via
+    :func:`scipy.stats.kendalltau`.
 
     Parameters
     ----------
-    y_true : np.ndarray
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
 
     Returns
     -------
-    kendalls_tau : float
-        Kendall's tau.
+    score : float
+        Kendall's tau in the range [-1, 1].
+
+    Notes
+    -----
+    Does not accept ``sample_weight`` because the underlying scipy
+    backend does not support it.
 
     Examples
     --------
@@ -458,23 +513,28 @@ def weighted_kappa(
     *,
     sample_weight: Optional[ArrayLike] = None,
 ) -> float:
-    """Calculate the Weighted Kappa.
+    """Weighted Cohen's kappa with linear ordinal weights.
 
-    A modified version of the Kappa statistic calculated to allow assigning
-    different weights to different levels of aggregation between two variables.
+    A version of the kappa statistic that assigns different weights to
+    different levels of disagreement, so off-by-one errors penalise the
+    score less than far-off ones. The current implementation uses
+    linear weights ``w_{ij} = |i - j|``.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray, shape (n_samples,)
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights forwarded to the confusion matrix.
 
     Returns
     -------
-    weighted_kappa : float
-        Weighted Kappa.
+    score : float
+        Weighted kappa in the range [-1, 1].
 
     Examples
     --------
@@ -504,22 +564,30 @@ def weighted_kappa(
 
 
 def spearmans_rho(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Calculate the Spearman's rank correlation coefficient.
+    """Spearman's rank correlation coefficient between two ordinal vectors.
 
-    A non-parametric measure of statistical dependence between two variables.
+    A non-parametric measure of monotonic association computed from
+    label values directly (treated as numerical scores). Returns ``0.0`` when one
+    of the inputs is constant.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray, shape (n_samples,)
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
 
     Returns
     -------
-    spearmans_rho : float
-        Spearman rank correlation coefficient.
+    score : float
+        Spearman's rho in the range [-1, 1].
+
+    Notes
+    -----
+    Does not accept ``sample_weight``: weighted Spearman is not
+    implemented in scipy and the rank correlation has no canonical
+    weighted definition.
 
     Examples
     --------
@@ -548,22 +616,39 @@ def ranked_probability_score(
     *,
     sample_weight: Optional[ArrayLike] = None,
 ) -> float:
-    """Compute the ranked probability score.
+    """Ranked probability score for ordinal class probabilities.
 
-    As presented in :footcite:t:`janitza2016random`.
+    Quadratic distance between the cumulative ground-truth indicator
+    function and the cumulative predicted distribution, averaged over
+    samples. The lower the value, the better. Defined for ordinal
+    targets in :footcite:t:`janitza2016random`.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
-        Ground truth labels.
+    y_true : array-like of shape (n_samples,)
+        Ground truth labels encoded as 0-based integer indices.
 
-    y_proba : np.ndarray, shape (n_samples, n_classes)
-        Predicted probability distribution across different classes.
+    y_proba : array-like of shape (n_samples, n_classes)
+        Predicted class probability distribution. Each row must sum to
+        approximately ``1`` (``atol=1e-6``); otherwise ``ValueError`` is
+        raised.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights forwarded to :func:`numpy.average`.
 
     Returns
     -------
-    ranked_probability_score : float
-        The ranked probability score.
+    score : float
+        Ranked probability score; lower is better.
+
+    Notes
+    -----
+    Samples whose ``y_true`` falls outside ``[0, n_classes)`` are
+    counted with a per-sample contribution of ``1.0``.
+
+    References
+    ----------
+    .. footbibliography::
 
     Examples
     --------
@@ -605,25 +690,35 @@ def accuracy_off1(
     labels: Optional[ArrayLike] = None,
     sample_weight: Optional[ArrayLike] = None,
 ) -> float:
-    """Computes the accuracy of the predictions.
+    """1-off accuracy: predictions in adjacent classes count as correct.
 
-    Allows errors if they occur in an adjacent class.
+    A prediction is counted as correct when it lies within one class
+    of the ground truth, on either side of the ordinal scale.
 
     Parameters
     ----------
-    y_true : np.ndarray, shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         Ground truth labels.
 
-    y_pred : np.ndarray, shape (n_samples,)
+    y_pred : array-like of shape (n_samples,)
         Predicted labels.
 
-    labels : np.ndarray, shape (n_classes,) or None, default=None
-        Labels of the classes. If None, the labels are inferred from the data.
+    labels : array-like of shape (n_classes,), default=None
+        Labels of the classes used to index the confusion matrix. If
+        ``None``, the labels are inferred from ``y_true``.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights forwarded to the confusion matrix.
 
     Returns
     -------
-    acc : float
-        1-off accuracy.
+    score : float
+        1-off accuracy in the range [0, 1].
+
+    Notes
+    -----
+    Both adjacent diagonals are counted: a prediction one class above
+    or one class below the truth contributes to the score.
 
     Examples
     --------

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -1,9 +1,10 @@
 """Tests for the metrics module."""
 
+import inspect
+
 import numpy as np
 import numpy.testing as npt
 import pytest
-from sklearn.metrics import recall_score
 
 from skordinal.metrics import (
     accuracy_off1,
@@ -20,208 +21,216 @@ from skordinal.metrics import (
     spearmans_rho,
     weighted_kappa,
 )
+from skordinal.metrics._metrics import _check_metric_inputs, _check_proba_inputs
+
+_WEIGHTED_METRICS = [
+    accuracy_off1,
+    average_mean_absolute_error,
+    geometric_mean,
+    gmsec,
+    maximum_mean_absolute_error,
+    mean_zero_one_error,
+    minimum_sensitivity,
+    weighted_kappa,
+    ranked_probability_score,
+]
+
+_WEIGHTED_METRIC_IDS = [fn.__name__ for fn in _WEIGHTED_METRICS]
+
+_Y_PROBA_6 = np.array(
+    [
+        [0.7, 0.2, 0.1],
+        [0.1, 0.6, 0.3],
+        [0.2, 0.3, 0.5],
+        [0.3, 0.5, 0.2],
+        [0.6, 0.3, 0.1],
+        [0.1, 0.2, 0.7],
+    ]
+)
 
 
-def test_accuracy_off1():
-    """Test the Accuracy that allows errors in adjacent classes."""
-    y_true = np.array([0, 1, 2, 3, 4, 5])
-    y_pred = np.array([1, 2, 3, 4, 5, 0])
-    expected = 0.8333333333333334
-    actual = accuracy_off1(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+def test_check_metric_inputs_1d_passthrough():
+    """1-D arrays are returned unchanged by _check_metric_inputs."""
+    y_t = np.array([0, 1, 2, 1])
+    y_p = np.array([0, 2, 2, 1])
+    out_t, out_p = _check_metric_inputs(y_t, y_p)
+    assert np.array_equal(out_t, y_t)
+    assert np.array_equal(out_p, y_p)
 
-    y_true = np.array([0, 1, 2, 3, 4])
-    y_pred = np.array([0, 2, 1, 4, 3])
-    expected = 1.0
-    actual = accuracy_off1(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+
+def test_check_metric_inputs_one_hot_argmax():
+    """2-D one-hot inputs are collapsed to 1-D label vectors via argmax."""
+    y_t_oh = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    y_p_oh = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
+    out_t, out_p = _check_metric_inputs(y_t_oh, y_p_oh)
+    assert np.array_equal(out_t, np.array([0, 1, 2]))
+    assert np.array_equal(out_p, np.array([1, 0, 2]))
+
+
+def test_check_metric_inputs_length_mismatch_raises():
+    """Mismatched lengths raise ValueError."""
+    with pytest.raises(ValueError):
+        _check_metric_inputs([0, 1, 2], [0, 1])
+
+
+def test_check_proba_inputs_requires_2d_proba():
+    """1-D y_proba raises; valid 2-D passes; one-hot y_true is collapsed."""
+    with pytest.raises(ValueError):
+        _check_proba_inputs(np.array([0, 1]), np.array([0.6, 0.4]))
+
+    y_t = np.array([0, 1, 2])
+    y_p = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]])
+    out_t, out_p = _check_proba_inputs(y_t, y_p)
+    assert np.array_equal(out_t, y_t)
+    npt.assert_allclose(out_p, y_p)
+
+    out_t_oh, _ = _check_proba_inputs(np.eye(3), y_p)
+    assert np.array_equal(out_t_oh, y_t)
+
+
+def test_check_proba_inputs_rejects_unnormalised_rows():
+    """Rows not summing to 1 raise ValueError mentioning row-sum."""
+    y_t = np.array([0, 1, 2])
+    y_p_bad = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]]) * 2
+    with pytest.raises(ValueError, match="row"):
+        _check_proba_inputs(y_t, y_p_bad)
+
+
+def test_check_proba_inputs_accepts_within_atol():
+    """Rows summing to 1 within atol are accepted without error."""
+    y_t = np.array([0, 1, 2])
+    y_p = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]])
+    y_p[0, 0] += 5e-7
+    _check_proba_inputs(y_t, y_p)
 
 
 def test_accuracy_score():
-    """Test the Correctly Classified Ratio (accuracy_score) metric."""
+    """accuracy_score correctly classifies a known label sequence."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
-    expected = 0.8000
-    actual = accuracy_score(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=4)
-
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.5
-    actual = accuracy_score(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+    npt.assert_almost_equal(accuracy_score(y_true, y_pred), 0.8000, decimal=4)
 
 
-def test_average_mean_absolute_error():
-    """Test the Average Mean Absolute Error (average_mean_absolute_error) metric."""
-    y_true = np.array([0, 0, 1, 1])
-    y_pred = np.array([0, 1, 0, 1])
-    expected = 0.5
-    actual = average_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected",
+    [
+        ([0, 1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 0], 5 / 6),
+        ([0, 1, 2, 3, 4], [0, 2, 1, 4, 3], 1.0),
+    ],
+)
+def test_accuracy_off1(y_true, y_pred, expected):
+    """accuracy_off1 counts predictions within one ordinal class of truth."""
+    npt.assert_almost_equal(accuracy_off1(y_true, y_pred), expected, decimal=6)
 
-    y_true = np.array([0, 0, 1, 1, 2, 2])
-    y_pred = np.array([0, 0, 1, 1, 2, 2])
-    expected = 0.0
-    actual = average_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
 
-    y_true = np.array([0, 0, 2, 1])
-    y_pred = np.array([0, 2, 0, 1])
-    expected = 1.0
-    actual = average_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+def test_accuracy_off1_lower_diagonal():
+    """Predictions one class below truth all count as correct (off1 = 1.0)."""
+    y_true = np.array([1, 2, 3])
+    y_pred = np.array([0, 1, 2])
+    npt.assert_allclose(accuracy_off1(y_true, y_pred), 1.0)
 
-    y_true = np.array([0, 0, 2, 1, 3])
-    y_pred = np.array([2, 2, 0, 3, 1])
-    expected = 2.0
-    actual = average_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
 
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.5
-    actual = average_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected",
+    [
+        ([0, 0, 1, 1], [0, 1, 0, 1], 0.5),
+        ([0, 0, 1, 1, 2, 2], [0, 0, 1, 1, 2, 2], 0.0),
+        ([0, 0, 2, 1], [0, 2, 0, 1], 1.0),
+        ([0, 0, 2, 1, 3], [2, 2, 0, 3, 1], 2.0),
+    ],
+)
+def test_average_mean_absolute_error(y_true, y_pred, expected):
+    """average_mean_absolute_error equals the mean of per-class MAEs."""
+    npt.assert_almost_equal(
+        average_mean_absolute_error(y_true, y_pred), expected, decimal=6
+    )
 
-    y_true = np.array([0, 1, 2, 3, 3])
-    y_pred = np.array([0, 1, 2, 3, 4])
-    expected = 0.125
-    actual = average_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+
+def test_average_mean_absolute_error_pred_only_class_excluded():
+    """Classes that appear only in predictions are excluded from AMAE."""
+    npt.assert_almost_equal(
+        average_mean_absolute_error([0, 1, 2, 3, 3], [0, 1, 2, 3, 4]), 0.125, decimal=6
+    )
 
 
 def test_geometric_mean():
-    """Test the Geometric Mean (geometric_mean) metric."""
+    """geometric_mean returns the geometric mean of per-class sensitivities."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
-    expected = 0.7991
-    actual = geometric_mean(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=4)
-
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.5
-    actual = geometric_mean(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+    npt.assert_almost_equal(geometric_mean(y_true, y_pred), 0.7991, decimal=4)
 
 
-def test_gmsec():
-    """Test the Geometric Mean of Sensitivity and Specificity (GMSEC) metric."""
-    y_true = np.array([0, 0, 1, 1])
-    y_pred = np.array([0, 1, 0, 1])
-    sensitivities = recall_score(y_true, y_pred, average=None)
-    expected = np.sqrt(sensitivities[0] * sensitivities[-1])
-    actual = gmsec(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
-
+def test_geometric_mean_empty_class_treated_as_one():
+    """A class with zero total weight is treated as sensitivity 1, not 0."""
     y_true = np.array([0, 0, 1, 1, 2, 2])
     y_pred = np.array([0, 0, 1, 1, 2, 2])
-    sensitivities = recall_score(y_true, y_pred, average=None)
-    expected = np.sqrt(sensitivities[0] * sensitivities[-1])
-    actual = gmsec(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+    w = np.array([0.0, 0.0, 1.0, 1.0, 1.0, 1.0])
+    npt.assert_almost_equal(geometric_mean(y_true, y_pred, sample_weight=w), 1.0)
+
+
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected",
+    [
+        ([0, 0, 1, 1], [0, 1, 0, 1], 0.5),
+        ([0, 0, 1, 1, 2, 2], [0, 0, 1, 1, 2, 2], 1.0),
+    ],
+)
+def test_gmsec(y_true, y_pred, expected):
+    """gmsec equals the geometric mean of the two extreme class sensitivities."""
+    npt.assert_almost_equal(gmsec(y_true, y_pred), expected, decimal=6)
 
 
 def test_mean_absolute_error():
-    """Test the Mean Absolute Error (mean_absolute_error) metric."""
+    """mean_absolute_error computes the correct global MAE for a known sequence."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
-    expected = 0.3000
-    actual = mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=4)
-
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.5
-    actual = mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+    npt.assert_almost_equal(mean_absolute_error(y_true, y_pred), 0.3000, decimal=4)
 
 
-def test_maximum_mean_absolute_error():
-    """Test the Maximum Mean Absolute Error (maximum_mean_absolute_error) metric."""
-    y_true = np.array([0, 0, 1, 1])
-    y_pred = np.array([0, 1, 0, 1])
-    expected = 0.5
-    actual = maximum_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
-
-    y_true = np.array([0, 0, 1, 1, 2, 2])
-    y_pred = np.array([0, 0, 1, 1, 2, 2])
-    expected = 0.0
-    actual = maximum_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
-
-    y_true = np.array([0, 0, 2, 1])
-    y_pred = np.array([0, 2, 0, 1])
-    expected = 2.0
-    actual = maximum_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
-
-    y_true = np.array([0, 0, 2, 1, 3])
-    y_pred = np.array([2, 2, 0, 3, 1])
-    expected = 2.0
-    actual = maximum_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
-
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.5
-    actual = maximum_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
-
-    y_true = np.array([0, 1, 2, 3, 3])
-    y_pred = np.array([0, 1, 2, 3, 4])
-    expected = 0.5
-    actual = maximum_mean_absolute_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected",
+    [
+        ([0, 0, 1, 1], [0, 1, 0, 1], 0.5),
+        ([0, 0, 1, 1, 2, 2], [0, 0, 1, 1, 2, 2], 0.0),
+        ([0, 0, 2, 1], [0, 2, 0, 1], 2.0),
+        ([0, 0, 2, 1, 3], [2, 2, 0, 3, 1], 2.0),
+    ],
+)
+def test_maximum_mean_absolute_error(y_true, y_pred, expected):
+    """maximum_mean_absolute_error equals the worst per-class MAE."""
+    npt.assert_almost_equal(
+        maximum_mean_absolute_error(y_true, y_pred), expected, decimal=6
+    )
 
 
-def test_minimum_sensitivity():
-    """Test the Minimum Sensitivity (minimum_sensitivity) metric."""
-    y_true = np.array([0, 0, 1, 1])
-    y_pred = np.array([0, 1, 0, 1])
-    expected = 0.5
-    actual = minimum_sensitivity(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+def test_maximum_mean_absolute_error_pred_only_class_excluded():
+    """Classes that appear only in predictions are excluded from MMAE."""
+    npt.assert_almost_equal(
+        maximum_mean_absolute_error([0, 1, 2, 3, 3], [0, 1, 2, 3, 4]), 0.5, decimal=6
+    )
 
-    y_true = np.array([0, 0, 1, 1, 2, 2])
-    y_pred = np.array([0, 0, 1, 1, 2, 2])
-    expected = 1.0
-    actual = minimum_sensitivity(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
 
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.5
-    actual = minimum_sensitivity(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected",
+    [
+        ([0, 0, 1, 1], [0, 1, 0, 1], 0.5),
+        ([0, 0, 1, 1, 2, 2], [0, 0, 1, 1, 2, 2], 1.0),
+    ],
+)
+def test_minimum_sensitivity(y_true, y_pred, expected):
+    """minimum_sensitivity returns the lowest per-class recall."""
+    npt.assert_almost_equal(minimum_sensitivity(y_true, y_pred), expected, decimal=6)
 
 
 def test_mean_zero_one_error():
-    """Test the Mean Zero-one Error (mean_zero_one_error) metric."""
+    """mean_zero_one_error returns the fraction of misclassified samples."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
-    expected = 0.2000
-    actual = mean_zero_one_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=4)
-
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.5
-    actual = mean_zero_one_error(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+    npt.assert_almost_equal(mean_zero_one_error(y_true, y_pred), 0.2000, decimal=4)
 
 
 def test_ranked_probability_score():
-    """Test the ranked probability score (ranked_probability_score) metric."""
+    """ranked_probability_score returns the correct RPS for a known prediction."""
     y_true = np.array([0, 0, 3, 2])
     y_pred = np.array(
         [
@@ -231,57 +240,44 @@ def test_ranked_probability_score():
             [0.1, 0.05, 0.65, 0.2],
         ]
     )
-    expected = 0.506875
-    actual = ranked_probability_score(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+    npt.assert_almost_equal(
+        ranked_probability_score(y_true, y_pred), 0.506875, decimal=6
+    )
+
+
+def test_ranked_probability_score_out_of_range():
+    """y_true values outside [0, n_classes) contribute 1.0 per-sample RPS."""
+    y_true = np.array([0, 5, 1])
+    y_proba = np.array([[1.0, 0.0, 0.0], [0.0, 0.5, 0.5], [0.0, 1.0, 0.0]])
+    npt.assert_almost_equal(
+        ranked_probability_score(y_true, y_proba), 1.0 / 3, decimal=6
+    )
 
 
 def test_kendalls_tau():
-    """Test the Kendall's Tau (kendalls_tau) metric."""
+    """kendalls_tau returns the correct rank correlation for a known sequence."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
-    expected = 0.6240
-    actual = kendalls_tau(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=4)
-
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.0
-    actual = kendalls_tau(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+    npt.assert_almost_equal(kendalls_tau(y_true, y_pred), 0.6240, decimal=4)
 
 
 def test_weighted_kappa():
-    """Test the Weighted Kappa (weighted_kappa) metric."""
+    """weighted_kappa returns the correct kappa for a known sequence."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
-    expected = 0.6703
-    actual = weighted_kappa(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=4)
-
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.0
-    actual = weighted_kappa(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+    npt.assert_almost_equal(weighted_kappa(y_true, y_pred), 0.6703, decimal=4)
 
 
 def test_spearmans_rho():
-    """Test the Spearman's rank correlation coefficient (spearmans_rho) metric."""
+    """spearmans_rho returns the correct rank correlation for a known sequence."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
     y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
-    expected = 0.6429
-    actual = spearmans_rho(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=4)
+    npt.assert_almost_equal(spearmans_rho(y_true, y_pred), 0.6429, decimal=4)
 
-    # Test using one-hot and probabilities
-    y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
-    y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
-    expected = 0.0
-    actual = spearmans_rho(y_true, y_pred)
-    npt.assert_almost_equal(expected, actual, decimal=6)
+
+def test_spearmans_rho_constant_input():
+    """spearmans_rho returns 0.0 when y_true is constant (zero numerator)."""
+    npt.assert_equal(spearmans_rho(np.array([1, 1, 1, 1]), np.array([0, 1, 2, 3])), 0.0)
 
 
 @pytest.mark.parametrize(
@@ -362,3 +358,79 @@ def test_metric_names_in_all():
     ]
     for name in expected:
         assert name in m.__all__, f"{name!r} missing from __all__"
+
+
+@pytest.mark.parametrize("fn", _WEIGHTED_METRICS, ids=_WEIGHTED_METRIC_IDS)
+def test_sample_weight_is_keyword_only(fn):
+    """sample_weight is a keyword-only parameter in every weighted metric."""
+    sig = inspect.signature(fn)
+    assert sig.parameters["sample_weight"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_accuracy_off1_labels_is_keyword_only():
+    """labels is a keyword-only parameter of accuracy_off1."""
+    sig = inspect.signature(accuracy_off1)
+    assert sig.parameters["labels"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_correlation_metrics_reject_sample_weight():
+    """kendalls_tau and spearmans_rho raise TypeError when sample_weight is passed."""
+    y_t = np.array([0, 1, 2, 1, 0])
+    y_p = np.array([0, 1, 2, 0, 1])
+    w = np.ones(5)
+    for fn in (kendalls_tau, spearmans_rho):
+        with pytest.raises(TypeError):
+            fn(y_t, y_p, sample_weight=w)
+
+
+@pytest.mark.parametrize("fn", _WEIGHTED_METRICS, ids=_WEIGHTED_METRIC_IDS)
+def test_metric_unit_sample_weight_matches_unweighted(fn):
+    """All-ones sample_weight produces the same result as no weight."""
+    y_t = np.array([0, 1, 2, 1, 0, 2])
+    y_p = np.array([0, 1, 1, 2, 0, 2])
+    n = len(y_t)
+    w = np.ones(n)
+
+    if fn is ranked_probability_score:
+        unweighted = fn(y_t, _Y_PROBA_6)
+        weighted = fn(y_t, _Y_PROBA_6, sample_weight=w)
+    else:
+        unweighted = fn(y_t, y_p)
+        weighted = fn(y_t, y_p, sample_weight=w)
+
+    npt.assert_allclose(weighted, unweighted)
+
+
+def test_metric_zero_weight_excludes_sample():
+    """Setting a sample's weight to 0 removes its contribution to accuracy_off1."""
+    y_t = np.array([0, 1, 2, 1, 0, 3])
+    y_p = np.array([3, 1, 2, 1, 0, 3])
+    n = len(y_t)
+
+    unit_w = np.ones(n)
+    zero_w = np.ones(n)
+    zero_w[0] = 0.0
+
+    score_unit = accuracy_off1(y_t, y_p, sample_weight=unit_w)
+    score_zero = accuracy_off1(y_t, y_p, sample_weight=zero_w)
+    assert score_zero > score_unit
+
+
+@pytest.mark.parametrize(
+    "fn",
+    _WEIGHTED_METRICS + [kendalls_tau, spearmans_rho],
+    ids=_WEIGHTED_METRIC_IDS + ["kendalls_tau", "spearmans_rho"],
+)
+def test_metric_returns_python_float(fn):
+    """Every public metric returns a Python float, not a numpy scalar."""
+    y_t = np.array([0, 1, 2, 1, 0, 2])
+    y_p = np.array([0, 1, 1, 2, 0, 2])
+
+    if fn is ranked_probability_score:
+        result = fn(y_t, _Y_PROBA_6)
+    else:
+        result = fn(y_t, y_p)
+
+    assert type(result) is float, (
+        f"{fn.__name__} returned {type(result).__name__}, expected float"
+    )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `sample_weight` to the ordinal metrics that support it. The correlation metrics (`kendalls_tau`, `spearmans_rho`) reject it explicitly — scipy has no weighted rank-correlation. Public functions are now type-annotated and return Python `float` instead of numpy scalars.

Also fixes `accuracy_off1`: the lower diagonal of the mask was a tuple by accident, so predictions one class below the truth weren't being counted.
