### PR TITLE
REF: Add Python type hints across skordinal package

### DIFF
--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -1,10 +1,13 @@
 """Neural Network with Ordered Partitions (NNOP)."""
 
+from __future__ import annotations
+
 import math as math
 from numbers import Integral, Real
 
 import numpy as np
 import scipy
+from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
 from sklearn.utils import check_random_state
 from sklearn.utils._param_validation import Interval
@@ -120,8 +123,13 @@ class NNOP(ClassifierMixin, BaseEstimator):
     }
 
     def __init__(
-        self, epsilon_init=0.5, n_hidden=50, max_iter=500, alpha=0.01, random_state=None
-    ):
+        self,
+        epsilon_init: float = 0.5,
+        n_hidden: int = 50,
+        max_iter: int = 500,
+        alpha: float = 0.01,
+        random_state: int | np.random.RandomState | None = None,
+    ) -> None:
         self.epsilon_init = epsilon_init
         self.n_hidden = n_hidden
         self.max_iter = max_iter
@@ -129,7 +137,7 @@ class NNOP(ClassifierMixin, BaseEstimator):
         self.random_state = random_state
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y):
+    def fit(self, X: ArrayLike, y: ArrayLike) -> NNOP:
         """Fit the model to data matrix X and target(s) y.
 
         Parameters
@@ -216,7 +224,7 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
         return self
 
-    def predict(self, X):
+    def predict(self, X: ArrayLike) -> np.ndarray:
         """Perform classification on samples in X.
 
         Parameters
@@ -259,7 +267,13 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
         return y_pred
 
-    def _unpack_parameters(self, nn_params, n_features, n_hidden, n_classes):
+    def _unpack_parameters(
+        self,
+        nn_params: np.ndarray,
+        n_features: int,
+        n_hidden: int,
+        n_classes: int,
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Get theta1 and theta2 back from nn_params.
 
         Parameters
@@ -299,7 +313,12 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
         return theta1, theta2
 
-    def _rand_initialize_weights(self, L_in, L_out, rng):
+    def _rand_initialize_weights(
+        self,
+        L_in: int,
+        L_out: int,
+        rng: np.random.RandomState,
+    ) -> np.ndarray:
         """Initialize layer weights randomly.
 
         Randomly initialize the weights of a layer with L_in incoming connections and
@@ -327,8 +346,15 @@ class NNOP(ClassifierMixin, BaseEstimator):
         return W
 
     def _nnop_cost_function(
-        self, nn_params, n_features, n_hidden, n_classes, X, Y, alpha
-    ):
+        self,
+        nn_params: np.ndarray,
+        n_features: int,
+        n_hidden: int,
+        n_classes: int,
+        X: np.ndarray,
+        Y: np.ndarray,
+        alpha: float,
+    ) -> tuple[float, np.ndarray]:
         """Implement the cost function and obtain the corresponding derivatives.
 
         Parameters

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -1,10 +1,13 @@
 """Neural Network based on Proportional Odd Model (NNPOM)."""
 
+from __future__ import annotations
+
 import math as math
 from numbers import Integral, Real
 
 import numpy as np
 import scipy
+from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
 from sklearn.utils import check_random_state
 from sklearn.utils._param_validation import Interval
@@ -121,8 +124,13 @@ class NNPOM(ClassifierMixin, BaseEstimator):
     }
 
     def __init__(
-        self, epsilon_init=0.5, n_hidden=50, max_iter=500, alpha=0.01, random_state=None
-    ):
+        self,
+        epsilon_init: float = 0.5,
+        n_hidden: int = 50,
+        max_iter: int = 500,
+        alpha: float = 0.01,
+        random_state: int | np.random.RandomState | None = None,
+    ) -> None:
         self.epsilon_init = epsilon_init
         self.n_hidden = n_hidden
         self.max_iter = max_iter
@@ -130,7 +138,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         self.random_state = random_state
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y):
+    def fit(self, X: ArrayLike, y: ArrayLike) -> NNPOM:
         """Fit the model to data matrix X and target(s) y.
 
         Parameters
@@ -222,7 +230,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         return self
 
-    def predict(self, X):
+    def predict(self, X: ArrayLike) -> np.ndarray:
         """Perform classification on samples in X.
 
         Parameters
@@ -264,7 +272,13 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         return y_pred
 
-    def _unpack_parameters(self, nn_params, n_features, n_hidden, n_classes):
+    def _unpack_parameters(
+        self,
+        nn_params: np.ndarray,
+        n_features: int,
+        n_hidden: int,
+        n_classes: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Get theta1, theta2 and thresholds_param from nn_params.
 
         Parameters
@@ -313,7 +327,12 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         return theta1, theta2, thresholds_param
 
-    def _rand_initialize_weights(self, L_in, L_out, rng):
+    def _rand_initialize_weights(
+        self,
+        L_in: int,
+        L_out: int,
+        rng: np.random.RandomState,
+    ) -> np.ndarray:
         """Initialize layer weights randomly.
 
         Randomly initialize the weights of a layer with L_in incoming connections and
@@ -340,7 +359,11 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         return W
 
-    def _convert_thresholds(self, thresholds_param, n_classes):
+    def _convert_thresholds(
+        self,
+        thresholds_param: np.ndarray,
+        n_classes: int,
+    ) -> np.ndarray:
         """Transform thresholds to perform unconstrained optimization.
 
         thresholds(1) = thresholds_param(1)
@@ -382,8 +405,15 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         return thresholds
 
     def _nnpom_cost_function(
-        self, nn_params, n_features, n_hidden, n_classes, X, Y, alpha
-    ):
+        self,
+        nn_params: np.ndarray,
+        n_features: int,
+        n_hidden: int,
+        n_classes: int,
+        X: np.ndarray,
+        Y: np.ndarray,
+        alpha: float,
+    ) -> tuple[float, np.ndarray]:
         """Implement the cost function and obtain the corresponding derivatives.
 
         Parameters

--- a/skordinal/classifiers/_ordinal_decomposition.py
+++ b/skordinal/classifiers/_ordinal_decomposition.py
@@ -1,6 +1,11 @@
 """OrdinalDecomposition ensemble."""
 
+from __future__ import annotations
+
+from typing import Any
+
 import numpy as np
+from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
 from sklearn.utils._param_validation import StrOptions
 from sklearn.utils.validation import check_is_fitted
@@ -108,18 +113,18 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
 
     def __init__(
         self,
-        dtype="ordered_partitions",
-        decision_method="frank_hall",
-        base_classifier="LogisticRegression",
-        parameters=None,
-    ):
+        dtype: str = "ordered_partitions",
+        decision_method: str = "frank_hall",
+        base_classifier: str = "LogisticRegression",
+        parameters: dict[str, Any] | None = None,
+    ) -> None:
         self.dtype = dtype
         self.decision_method = decision_method
         self.base_classifier = base_classifier
         self.parameters = parameters
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y):
+    def fit(self, X: ArrayLike, y: ArrayLike) -> OrdinalDecomposition:
         """Fit underlying estimators to data matrix X and target(s) y.
 
         Parameters
@@ -180,7 +185,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
 
         return self
 
-    def predict(self, X):
+    def predict(self, X: ArrayLike) -> np.ndarray:
         """Perform classification on samples in X.
 
         Parameters
@@ -248,7 +253,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
 
         return y_pred
 
-    def predict_proba(self, X):
+    def predict_proba(self, X: ArrayLike) -> np.ndarray:
         """Probability estimates.
 
         The returned estimates for all classes are ordered by label of classes.
@@ -330,7 +335,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
 
         return y_proba
 
-    def _coding_matrix(self, dtype, n_classes):
+    def _coding_matrix(self, dtype: str, n_classes: int) -> np.ndarray:
         """Return the coding matrix for a given dataset.
 
         Parameters
@@ -378,7 +383,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
 
         return coding_matrix.astype(int)
 
-    def _get_predictions(self, X):
+    def _get_predictions(self, X: np.ndarray) -> np.ndarray:
         """Return the probability of positive class membership.
 
         For each pattern inside the dataset X, this method returns the probability for
@@ -402,7 +407,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
 
         return predictions
 
-    def _exponential_loss(self, predictions):
+    def _exponential_loss(self, predictions: np.ndarray) -> np.ndarray:
         """Compute the exponential losses for each label.
 
         Computation of the exponential losses for each label of the original ordinal
@@ -426,7 +431,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
         e_losses = np.exp(-M * C).sum(axis=2)
         return e_losses
 
-    def _hinge_loss(self, predictions):
+    def _hinge_loss(self, predictions: np.ndarray) -> np.ndarray:
         """Compute the Hinge losses for each label.
 
         Computation of the Hinge losses for each label of the original ordinal
@@ -450,7 +455,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
         h_losses = np.maximum(0.0, 1.0 - C * M).sum(axis=2)
         return h_losses
 
-    def _logarithmic_loss(self, predictions):
+    def _logarithmic_loss(self, predictions: np.ndarray) -> np.ndarray:
         """Compute the logarithmic losses for each label.
 
         Computation of the logarithmic losses for each label of the original ordinal
@@ -474,7 +479,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
         l_losses = np.log1p(np.exp(-2.0 * C * M)).sum(axis=2)
         return l_losses
 
-    def _frank_hall_method(self, predictions):
+    def _frank_hall_method(self, predictions: np.ndarray) -> np.ndarray:
         """Calculate probability of each pattern belonging to each target.
 
         Returns the probability for each pattern of dataset to belong to each one of

--- a/skordinal/classifiers/_redsvm.py
+++ b/skordinal/classifiers/_redsvm.py
@@ -1,8 +1,11 @@
 """Reduction from ordinal regression to binary SVM (REDSVM)."""
 
+from __future__ import annotations
+
 from numbers import Integral, Real
 
 import numpy as np
+from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
 from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.validation import check_is_fitted
@@ -110,15 +113,15 @@ class REDSVM(ClassifierMixin, BaseEstimator):
 
     def __init__(
         self,
-        C=1,
-        kernel="rbf",
-        degree=3,
-        gamma="auto",
-        coef0=0,
-        shrinking=True,
-        tol=0.001,
-        cache_size=100,
-    ):
+        C: float = 1,
+        kernel: str = "rbf",
+        degree: int = 3,
+        gamma: float | str = "auto",
+        coef0: float = 0,
+        shrinking: bool = True,
+        tol: float = 0.001,
+        cache_size: float = 100,
+    ) -> None:
         self.C = C
         self.kernel = kernel
         self.degree = degree
@@ -129,7 +132,7 @@ class REDSVM(ClassifierMixin, BaseEstimator):
         self.cache_size = cache_size
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y):
+    def fit(self, X: ArrayLike, y: ArrayLike) -> REDSVM:
         """Fit the model with the training data.
 
         Parameters
@@ -191,7 +194,7 @@ class REDSVM(ClassifierMixin, BaseEstimator):
 
         return self
 
-    def predict(self, X):
+    def predict(self, X: ArrayLike) -> np.ndarray:
         """Perform classification on samples in X.
 
         Parameters

--- a/skordinal/classifiers/_svorex.py
+++ b/skordinal/classifiers/_svorex.py
@@ -1,8 +1,11 @@
 """Support Vector for Ordinal Regression (Explicit constraints) (SVOREX)."""
 
+from __future__ import annotations
+
 from numbers import Integral, Real
 
 import numpy as np
+from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
 from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.validation import check_is_fitted
@@ -69,7 +72,14 @@ class SVOREX(ClassifierMixin, BaseEstimator):
         "gamma": [Interval(Real, 0.0, None, closed="neither")],
     }
 
-    def __init__(self, C=1.0, kernel="rbf", degree=2, tol=0.001, gamma=1):
+    def __init__(
+        self,
+        C: float = 1.0,
+        kernel: str = "rbf",
+        degree: int = 2,
+        tol: float = 0.001,
+        gamma: float = 1,
+    ) -> None:
         self.C = C
         self.kernel = kernel
         self.degree = degree
@@ -77,7 +87,7 @@ class SVOREX(ClassifierMixin, BaseEstimator):
         self.gamma = gamma
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y):
+    def fit(self, X: ArrayLike, y: ArrayLike) -> SVOREX:
         """Fit the model with the training data.
 
         Parameters
@@ -116,7 +126,7 @@ class SVOREX(ClassifierMixin, BaseEstimator):
         self.model_ = svorex.fit((y_encoded + 1).tolist(), X.tolist(), options)
         return self
 
-    def predict(self, X):
+    def predict(self, X: ArrayLike) -> np.ndarray:
         """Perform classification on samples in X.
 
         Parameters

--- a/skordinal/datasets/_loaders.py
+++ b/skordinal/datasets/_loaders.py
@@ -1,5 +1,7 @@
 """Utility functions for datasets."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np
@@ -9,7 +11,7 @@ from sklearn.model_selection import train_test_split
 import skordinal.datasets.data
 
 
-def get_data_path():
+def get_data_path() -> Path:
     """Get the absolute path of the skordinal.datasets.data module.
 
     Returns
@@ -27,7 +29,7 @@ def get_data_path():
     return Path(skordinal.datasets.data.__file__).parent
 
 
-def dataset_exists(dataset_name, data_path):
+def dataset_exists(dataset_name, data_path: Path):
     """Check if the dataset directory exists within the data path.
 
     Parameters
@@ -35,7 +37,7 @@ def dataset_exists(dataset_name, data_path):
     dataset_name : str
         Name of the dataset.
 
-    data_path : str or path
+    data_path : Path
         Root directory containing dataset files.
 
     Returns
@@ -55,11 +57,10 @@ def dataset_exists(dataset_name, data_path):
     False
 
     """
-    data_path = Path(data_path)
     return data_path.is_dir() and (data_path / dataset_name).is_dir()
 
 
-def is_undivided(dataset_name, data_path):
+def is_undivided(dataset_name, data_path: Path):
     """Check if there is a dataset file with no train/test split.
 
     Parameters
@@ -67,7 +68,7 @@ def is_undivided(dataset_name, data_path):
     dataset_name : str
         Name for the specific dataset.
 
-    data_path : str or path
+    data_path : Path
         Root directory containing dataset files.
 
     Returns
@@ -85,12 +86,11 @@ def is_undivided(dataset_name, data_path):
     False
 
     """
-    data_path = Path(data_path)
     file_path = data_path / dataset_name / f"{dataset_name}.csv"
     return file_path.exists()
 
 
-def has_unseeded_split(dataset_name, data_path):
+def has_unseeded_split(dataset_name, data_path: Path):
     """Check if the dataset has train/test split files without a seed.
 
     Parameters
@@ -98,7 +98,7 @@ def has_unseeded_split(dataset_name, data_path):
     dataset_name : str
         Name for the specific dataset.
 
-    data_path : str or path
+    data_path : Path
         Root directory containing dataset files.
 
     Returns
@@ -116,14 +116,13 @@ def has_unseeded_split(dataset_name, data_path):
     False
 
     """
-    data_path = Path(data_path)
     return any(
         (data_path / dataset_name / f"{split}_{dataset_name}.csv").exists()
         for split in ["train", "test"]
     )
 
 
-def has_seeded_split(dataset_name, seed, data_path):
+def has_seeded_split(dataset_name, seed, data_path: Path):
     """Check if the dataset has train/test split files with a specific seed.
 
     Parameters
@@ -134,7 +133,7 @@ def has_seeded_split(dataset_name, seed, data_path):
     seed : int
         Numerical seed ensuring reproducible randomization.
 
-    data_path : str or path
+    data_path : Path
         Root directory containing dataset files.
 
     Returns
@@ -154,14 +153,13 @@ def has_seeded_split(dataset_name, seed, data_path):
     False
 
     """
-    data_path = Path(data_path)
     return any(
         (data_path / dataset_name / f"{split}_{dataset_name}_{seed}.csv").exists()
         for split in ["train", "test"]
     )
 
 
-def check_ambiguity(dataset_name, data_path, seed=None):
+def check_ambiguity(dataset_name, data_path: Path, seed=None):
     """Check for ambiguity in dataset format.
 
     Parameters
@@ -169,7 +167,7 @@ def check_ambiguity(dataset_name, data_path, seed=None):
     dataset_name : str
         Name for the specific dataset.
 
-    data_path : str or path
+    data_path : Path
         Root directory containing dataset files.
 
     seed: int, optional
@@ -190,7 +188,6 @@ def check_ambiguity(dataset_name, data_path, seed=None):
     >>> check_ambiguity("nonexistent_dataset", data_path, seed=0)
 
     """
-    data_path = Path(data_path)
     undivided = is_undivided(dataset_name, data_path)
     unseeded = has_unseeded_split(dataset_name, data_path)
     seeded = seed is not None and has_seeded_split(dataset_name, seed, data_path)
@@ -208,7 +205,9 @@ def check_ambiguity(dataset_name, data_path, seed=None):
         )
 
 
-def load_datafile(dataset_name, split="undivided", data_path=None, seed=None):
+def load_datafile(
+    dataset_name, split="undivided", data_path: Path | None = None, seed=None
+):
     """Load a dataset file based on split type and seed.
 
     Parameters
@@ -219,7 +218,7 @@ def load_datafile(dataset_name, split="undivided", data_path=None, seed=None):
     split : str, default='undivided'
         Data division type ('undivided', 'train' or 'test').
 
-    data_path : str or path, optional
+    data_path : Path, optional
         Root directory containing dataset files. If None, defaults to the skordinal
         datasets path.
 
@@ -250,7 +249,7 @@ def load_datafile(dataset_name, split="undivided", data_path=None, seed=None):
     ((38, 54), (38,))
 
     """
-    data_path = Path(data_path or get_data_path()).expanduser()
+    data_path = (data_path or get_data_path()).expanduser()
 
     if not dataset_exists(dataset_name, data_path):
         raise FileNotFoundError(
@@ -269,7 +268,7 @@ def load_datafile(dataset_name, split="undivided", data_path=None, seed=None):
         return None, None
 
 
-def load_dataset(dataset_name, data_path=None, seed=None):
+def load_dataset(dataset_name, data_path: Path | None = None, seed=None):
     """Load a dataset from the specified directory.
 
     The dataset can be stored in one of three formats:
@@ -288,7 +287,7 @@ def load_dataset(dataset_name, data_path=None, seed=None):
     dataset_name : str
         Name of the dataset.
 
-    data_path : str or path, optional
+    data_path : Path, optional
         Root directory containing dataset files. If None, defaults to the skordinal
         datasets path.
 
@@ -322,7 +321,7 @@ def load_dataset(dataset_name, data_path=None, seed=None):
     ((1296, 21), (1296,), (432, 21), (432,))
 
     """
-    data_path = Path(data_path or get_data_path()).expanduser()
+    data_path = (data_path or get_data_path()).expanduser()
 
     if not dataset_exists(dataset_name, data_path):
         raise FileNotFoundError(

--- a/skordinal/datasets/_loaders.py
+++ b/skordinal/datasets/_loaders.py
@@ -29,7 +29,7 @@ def get_data_path() -> Path:
     return Path(skordinal.datasets.data.__file__).parent
 
 
-def dataset_exists(dataset_name, data_path: Path):
+def dataset_exists(dataset_name: str, data_path: Path) -> bool:
     """Check if the dataset directory exists within the data path.
 
     Parameters
@@ -60,7 +60,7 @@ def dataset_exists(dataset_name, data_path: Path):
     return data_path.is_dir() and (data_path / dataset_name).is_dir()
 
 
-def is_undivided(dataset_name, data_path: Path):
+def is_undivided(dataset_name: str, data_path: Path) -> bool:
     """Check if there is a dataset file with no train/test split.
 
     Parameters
@@ -90,7 +90,7 @@ def is_undivided(dataset_name, data_path: Path):
     return file_path.exists()
 
 
-def has_unseeded_split(dataset_name, data_path: Path):
+def has_unseeded_split(dataset_name: str, data_path: Path) -> bool:
     """Check if the dataset has train/test split files without a seed.
 
     Parameters
@@ -122,7 +122,7 @@ def has_unseeded_split(dataset_name, data_path: Path):
     )
 
 
-def has_seeded_split(dataset_name, seed, data_path: Path):
+def has_seeded_split(dataset_name: str, seed: int, data_path: Path) -> bool:
     """Check if the dataset has train/test split files with a specific seed.
 
     Parameters
@@ -159,7 +159,9 @@ def has_seeded_split(dataset_name, seed, data_path: Path):
     )
 
 
-def check_ambiguity(dataset_name, data_path: Path, seed=None):
+def check_ambiguity(
+    dataset_name: str, data_path: Path, seed: int | None = None
+) -> None:
     """Check for ambiguity in dataset format.
 
     Parameters
@@ -206,8 +208,11 @@ def check_ambiguity(dataset_name, data_path: Path, seed=None):
 
 
 def load_datafile(
-    dataset_name, split="undivided", data_path: Path | None = None, seed=None
-):
+    dataset_name: str,
+    split: str = "undivided",
+    data_path: Path | None = None,
+    seed: int | None = None,
+) -> tuple[np.ndarray, np.ndarray] | tuple[None, None]:
     """Load a dataset file based on split type and seed.
 
     Parameters
@@ -268,7 +273,11 @@ def load_datafile(
         return None, None
 
 
-def load_dataset(dataset_name, data_path: Path | None = None, seed=None):
+def load_dataset(
+    dataset_name: str,
+    data_path: Path | None = None,
+    seed: int | None = None,
+) -> tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None, np.ndarray | None]:
     """Load a dataset from the specified directory.
 
     The dataset can be stored in one of three formats:
@@ -348,7 +357,14 @@ def load_dataset(dataset_name, data_path: Path | None = None, seed=None):
     return X_train, y_train, X_test, y_test
 
 
-def shuffle_data(X_train, y_train, X_test, y_test, seed, train_size=0.75):
+def shuffle_data(
+    X_train: np.ndarray | None,
+    y_train: np.ndarray | None,
+    X_test: np.ndarray | None,
+    y_test: np.ndarray | None,
+    seed: int,
+    train_size: float = 0.75,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Shuffle data by combining train and test sets and splitting them again.
 
     Handles cases where either train or test set may be None.
@@ -429,8 +445,9 @@ def shuffle_data(X_train, y_train, X_test, y_test, seed, train_size=0.75):
         )
         y_test = np.empty(0)
 
+    assert y_train is not None and y_test is not None
     X_full = np.vstack((X_train, X_test))
-    y_full = np.concatenate((y_train, y_test))
+    y_full: np.ndarray = np.concatenate((y_train, y_test))
 
     if X_train.size > 0 and X_test.size > 0:
         train_size = len(X_train) / (len(X_train) + len(X_test))

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import warnings
-from typing import Optional
 
 import numpy as np
 import scipy.stats
@@ -105,8 +104,8 @@ def _recall_per_class(
     y_true: NDArray,
     y_pred: NDArray,
     *,
-    labels: Optional[ArrayLike] = None,
-    sample_weight: Optional[ArrayLike] = None,
+    labels: ArrayLike | None = None,
+    sample_weight: ArrayLike | None = None,
 ) -> NDArray[np.float64]:
     """Return per-class recall as a 1-D float64 ndarray.
 
@@ -150,8 +149,8 @@ def _per_class_mae(
     y_true: NDArray,
     y_pred: NDArray,
     *,
-    labels: Optional[ArrayLike] = None,
-    sample_weight: Optional[ArrayLike] = None,
+    labels: ArrayLike | None = None,
+    sample_weight: ArrayLike | None = None,
 ) -> NDArray[np.float64]:
     """Return per-class mean absolute error as a 1-D float64 ndarray.
 
@@ -191,7 +190,7 @@ def average_mean_absolute_error(
     y_true: ArrayLike,
     y_pred: ArrayLike,
     *,
-    sample_weight: Optional[ArrayLike] = None,
+    sample_weight: ArrayLike | None = None,
 ) -> float:
     """Compute the average per-class mean absolute error.
 
@@ -238,7 +237,7 @@ def geometric_mean(
     y_true: ArrayLike,
     y_pred: ArrayLike,
     *,
-    sample_weight: Optional[ArrayLike] = None,
+    sample_weight: ArrayLike | None = None,
 ) -> float:
     """Compute the geometric mean of per-class sensitivities.
 
@@ -292,7 +291,7 @@ def gmsec(
     y_true: ArrayLike,
     y_pred: ArrayLike,
     *,
-    sample_weight: Optional[ArrayLike] = None,
+    sample_weight: ArrayLike | None = None,
 ) -> float:
     """Geometric mean of the sensitivities of the extreme ordinal classes.
 
@@ -340,7 +339,7 @@ def maximum_mean_absolute_error(
     y_true: ArrayLike,
     y_pred: ArrayLike,
     *,
-    sample_weight: Optional[ArrayLike] = None,
+    sample_weight: ArrayLike | None = None,
 ) -> float:
     """Compute the maximum per-class mean absolute error.
 
@@ -386,7 +385,7 @@ def minimum_sensitivity(
     y_true: ArrayLike,
     y_pred: ArrayLike,
     *,
-    sample_weight: Optional[ArrayLike] = None,
+    sample_weight: ArrayLike | None = None,
 ) -> float:
     """Lowest per-class sensitivity.
 
@@ -429,7 +428,7 @@ def mean_zero_one_error(
     y_true: ArrayLike,
     y_pred: ArrayLike,
     *,
-    sample_weight: Optional[ArrayLike] = None,
+    sample_weight: ArrayLike | None = None,
 ) -> float:
     """Fraction of misclassified samples (error rate).
 
@@ -511,7 +510,7 @@ def weighted_kappa(
     y_true: ArrayLike,
     y_pred: ArrayLike,
     *,
-    sample_weight: Optional[ArrayLike] = None,
+    sample_weight: ArrayLike | None = None,
 ) -> float:
     """Weighted Cohen's kappa with linear ordinal weights.
 
@@ -614,7 +613,7 @@ def ranked_probability_score(
     y_true: ArrayLike,
     y_proba: ArrayLike,
     *,
-    sample_weight: Optional[ArrayLike] = None,
+    sample_weight: ArrayLike | None = None,
 ) -> float:
     """Ranked probability score for ordinal class probabilities.
 
@@ -687,8 +686,8 @@ def accuracy_off1(
     y_true: ArrayLike,
     y_pred: ArrayLike,
     *,
-    labels: Optional[ArrayLike] = None,
-    sample_weight: Optional[ArrayLike] = None,
+    labels: ArrayLike | None = None,
+    sample_weight: ArrayLike | None = None,
 ) -> float:
     """1-off accuracy: predictions in adjacent classes count as correct.
 
@@ -744,7 +743,7 @@ def accuracy_off1(
     return float(np.sum(correct) / np.sum(conf_mat))
 
 
-def ccr(y_true, y_pred):
+def ccr(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`accuracy_score`."""
     warnings.warn(
         "ccr is deprecated, use accuracy_score instead",
@@ -754,7 +753,7 @@ def ccr(y_true, y_pred):
     return accuracy_score(y_true, y_pred)
 
 
-def amae(y_true, y_pred):
+def amae(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`average_mean_absolute_error`."""
     warnings.warn(
         "amae is deprecated, use average_mean_absolute_error instead",
@@ -764,7 +763,7 @@ def amae(y_true, y_pred):
     return average_mean_absolute_error(y_true, y_pred)
 
 
-def gm(y_true, y_pred):
+def gm(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`geometric_mean`."""
     warnings.warn(
         "gm is deprecated, use geometric_mean instead",
@@ -774,7 +773,7 @@ def gm(y_true, y_pred):
     return geometric_mean(y_true, y_pred)
 
 
-def mae(y_true, y_pred):
+def mae(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`mean_absolute_error`."""
     warnings.warn(
         "mae is deprecated, use mean_absolute_error instead",
@@ -784,7 +783,7 @@ def mae(y_true, y_pred):
     return mean_absolute_error(y_true, y_pred)
 
 
-def mmae(y_true, y_pred):
+def mmae(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`maximum_mean_absolute_error`."""
     warnings.warn(
         "mmae is deprecated, use maximum_mean_absolute_error instead",
@@ -794,7 +793,7 @@ def mmae(y_true, y_pred):
     return maximum_mean_absolute_error(y_true, y_pred)
 
 
-def ms(y_true, y_pred):
+def ms(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`minimum_sensitivity`."""
     warnings.warn(
         "ms is deprecated, use minimum_sensitivity instead",
@@ -804,7 +803,7 @@ def ms(y_true, y_pred):
     return minimum_sensitivity(y_true, y_pred)
 
 
-def mze(y_true, y_pred):
+def mze(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`mean_zero_one_error`."""
     warnings.warn(
         "mze is deprecated, use mean_zero_one_error instead",
@@ -814,7 +813,7 @@ def mze(y_true, y_pred):
     return mean_zero_one_error(y_true, y_pred)
 
 
-def tkendall(y_true, y_pred):
+def tkendall(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`kendalls_tau`."""
     warnings.warn(
         "tkendall is deprecated, use kendalls_tau instead",
@@ -824,7 +823,7 @@ def tkendall(y_true, y_pred):
     return kendalls_tau(y_true, y_pred)
 
 
-def wkappa(y_true, y_pred):
+def wkappa(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`weighted_kappa`."""
     warnings.warn(
         "wkappa is deprecated, use weighted_kappa instead",
@@ -834,7 +833,7 @@ def wkappa(y_true, y_pred):
     return weighted_kappa(y_true, y_pred)
 
 
-def spearman(y_true, y_pred):
+def spearman(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     """Deprecated alias for :func:`spearmans_rho`."""
     warnings.warn(
         "spearman is deprecated, use spearmans_rho instead",
@@ -844,7 +843,7 @@ def spearman(y_true, y_pred):
     return spearmans_rho(y_true, y_pred)
 
 
-def rps(y_true, y_proba):
+def rps(y_true: ArrayLike, y_proba: ArrayLike) -> float:
     """Deprecated alias for :func:`ranked_probability_score`."""
     warnings.warn(
         "rps is deprecated, use ranked_probability_score instead",

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 from sklearn.metrics import accuracy_score, make_scorer, mean_absolute_error
 

--- a/skordinal/model_selection/_loaders.py
+++ b/skordinal/model_selection/_loaders.py
@@ -1,7 +1,13 @@
 """Model selection and estimator loading utilities."""
 
-from importlib import import_module
+from __future__ import annotations
 
+from collections.abc import Callable
+from importlib import import_module
+from typing import Any
+
+import numpy as np
+from sklearn.base import BaseEstimator
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 
 from skordinal.metrics import get_ordinal_scorer
@@ -27,7 +33,7 @@ _SKLEARN_CLASSIFIERS = {
 _CLASSIFIERS = {**_SKORDINAL_CLASSIFIERS, **_SKLEARN_CLASSIFIERS}
 
 
-def get_classifier_by_name(classifier_name):
+def get_classifier_by_name(classifier_name: str) -> type[BaseEstimator]:
     """Return a classifier not instantiated matching a given input name.
 
     Parameters
@@ -65,13 +71,13 @@ def get_classifier_by_name(classifier_name):
 
 
 def load_classifier(
-    classifier_name,
-    random_state=None,
-    n_jobs=1,
-    cv_n_folds=3,
-    cv_metric="mae",
-    param_grid=None,
-):
+    classifier_name: str,
+    random_state: int | np.random.RandomState | None = None,
+    n_jobs: int = 1,
+    cv_n_folds: int = 3,
+    cv_metric: str | Callable[..., Any] = "mae",
+    param_grid: dict[str, Any] | None = None,
+) -> BaseEstimator | GridSearchCV:
     """Return a fully configured classifier, optionally with cross-validation.
 
     This function loads a classifier, configures its parameters, and optionally

--- a/skordinal/model_selection/_validation.py
+++ b/skordinal/model_selection/_validation.py
@@ -1,13 +1,16 @@
 """Parameter grid preparation and validation utilities for model selection."""
 
+from __future__ import annotations
+
 from ast import literal_eval
 from copy import deepcopy
 from itertools import product
+from typing import Any, cast
 
 import numpy as np
 
 
-def check_for_random_state(estimator):
+def check_for_random_state(estimator: type) -> bool:
     """Check if the estimator accepts a random_state parameter.
 
     Parameters
@@ -39,7 +42,7 @@ def check_for_random_state(estimator):
         return False
 
 
-def is_ensemble(param_grid):
+def is_ensemble(param_grid: dict[str, Any]) -> bool:
     """Check if the given parameters correspond to an ensemble method.
 
     Parameters
@@ -66,7 +69,7 @@ def is_ensemble(param_grid):
     return isinstance(param_grid, dict) and "base_classifier" in param_grid
 
 
-def is_searchcv(param_grid):
+def is_searchcv(param_grid: dict[str, Any]) -> bool:
     """Check if the given parameters require cross-validation search.
 
     Parameters
@@ -105,7 +108,11 @@ def is_searchcv(param_grid):
     return has_search_params
 
 
-def prepare_param_grid(estimator, param_grid, random_state=None):
+def prepare_param_grid(
+    estimator: type,
+    param_grid: dict[str, Any],
+    random_state: int | np.random.RandomState | None = None,
+) -> dict[str, Any]:
     """This function processes parameter grids to ensure compatibility with
     scikit-learn's GridSearchCV and handles special cases like ensemble methods and
     random state injection.
@@ -155,7 +162,7 @@ def prepare_param_grid(estimator, param_grid, random_state=None):
         raise ValueError("param_grid must be a dictionary")
 
     if random_state is None:
-        random_state = np.random.get_state()[1][0]
+        random_state = int(cast(tuple, np.random.get_state())[1][0])
 
     param_grid = deepcopy(param_grid)
     param_grid = _add_random_state(estimator, param_grid, random_state)
@@ -176,7 +183,11 @@ def prepare_param_grid(estimator, param_grid, random_state=None):
     return param_grid
 
 
-def _add_random_state(estimator, param_grid, random_state):
+def _add_random_state(
+    estimator: type,
+    param_grid: dict[str, Any],
+    random_state: int | np.random.RandomState,
+) -> dict[str, Any]:
     """Add random_state to param_grid if the estimator accepts it and it's
     not already present.
 
@@ -203,7 +214,7 @@ def _add_random_state(estimator, param_grid, random_state):
     return param_grid
 
 
-def _normalize_param_grid(param_grid):
+def _normalize_param_grid(param_grid: dict[str, Any]) -> dict[str, list[Any]]:
     """Ensure all values in param_grid are lists (for grid search compatibility).
 
     Parameters
@@ -217,7 +228,7 @@ def _normalize_param_grid(param_grid):
         Dictionary with all values as lists.
 
     """
-    normalized = {}
+    normalized: dict[str, list[Any]] = {}
     for k, v in param_grid.items():
         if isinstance(v, list):
             normalized[k] = v
@@ -226,7 +237,10 @@ def _normalize_param_grid(param_grid):
     return normalized
 
 
-def _prepare_parameters_for_ensemble(param_grid, random_state=None):
+def _prepare_parameters_for_ensemble(
+    param_grid: dict[str, Any],
+    random_state: int | np.random.RandomState | None = None,
+) -> dict[str, Any]:
     """Process the parameters for ensemble methods.
 
     Parameters

--- a/skordinal/preprocessing/_encodings.py
+++ b/skordinal/preprocessing/_encodings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 _VALID_DECOMPOSITIONS = (
     "ordered_partitions",
@@ -13,9 +14,9 @@ _VALID_DECOMPOSITIONS = (
 
 
 def ordinal_to_binary_cumulative(
-    y,
-    classes,
-):
+    y: ArrayLike,
+    classes: ArrayLike,
+) -> np.ndarray:
     """Encode ordinal targets into K-1 binary cumulative problems.
 
     Column ``k`` represents the binary problem
@@ -67,9 +68,9 @@ def ordinal_to_binary_cumulative(
 
 
 def binary_cumulative_to_ordinal(
-    binary_preds,
-    classes,
-):
+    binary_preds: ArrayLike,
+    classes: ArrayLike,
+) -> np.ndarray:
     """Decode K-1 binary predictions back to ordinal class labels.
 
     Accepts either hard ``{0, 1}`` predictions or continuous
@@ -125,9 +126,9 @@ def binary_cumulative_to_ordinal(
 
 
 def build_coding_matrix(
-    n_classes,
-    decomposition,
-):
+    n_classes: int,
+    decomposition: str,
+) -> np.ndarray:
     """Return the coding matrix for an ordinal decomposition strategy.
 
     The resulting matrix has one row per class and one column per

--- a/skordinal/preprocessing/_scalers.py
+++ b/skordinal/preprocessing/_scalers.py
@@ -1,11 +1,18 @@
 """Data scaling functions."""
 
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
 from scipy import sparse
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
 from sklearn.utils.validation import check_array
 
 
-def _validate_and_align(X_train, X_test):
+def _validate_and_align(
+    X_train: ArrayLike,
+    X_test: ArrayLike | None,
+) -> tuple[np.ndarray, np.ndarray | None]:
     """Validate arrays as numeric 2D matrices and ensure matching feature counts.
 
     Parameters
@@ -27,17 +34,29 @@ def _validate_and_align(X_train, X_test):
         If X_test has different number of features than X_train.
 
     """
-    X_train = check_array(X_train, accept_sparse=True, dtype="numeric")
+    X_train_valid: np.ndarray = check_array(
+        X_train, accept_sparse=True, dtype="numeric"
+    )
+    X_test_valid: np.ndarray | None = None
     if X_test is not None:
-        X_test = check_array(X_test, accept_sparse=True, dtype="numeric")
-        if X_test.shape[1] != X_train.shape[1]:
+        X_test_valid = check_array(X_test, accept_sparse=True, dtype="numeric")
+        if X_test_valid.shape[1] != X_train_valid.shape[1]:
             raise ValueError(
-                f"X_test has {X_test.shape[1]} features but X_train has {X_train.shape[1]}."
+                f"X_test has {X_test_valid.shape[1]} features but "
+                f"X_train has {X_train_valid.shape[1]}."
             )
-    return X_train, X_test
+    return X_train_valid, X_test_valid
 
 
-def apply_scaling(X_train, X_test=None, method=None, return_transformer=False):
+def apply_scaling(
+    X_train: ArrayLike,
+    X_test: ArrayLike | None = None,
+    method: str | None = None,
+    return_transformer: bool = False,
+) -> (
+    tuple[np.ndarray, np.ndarray | None]
+    | tuple[np.ndarray, np.ndarray | None, MinMaxScaler | StandardScaler | None]
+):
     """Apply normalization or standardization to the input data.
 
     The preprocessing is fit on the training data and then applied to both
@@ -93,6 +112,7 @@ def apply_scaling(X_train, X_test=None, method=None, return_transformer=False):
 
     """
     if method is None:
+        X_train, X_test = _validate_and_align(X_train, X_test)
         return (X_train, X_test, None) if return_transformer else (X_train, X_test)
 
     if not isinstance(method, str):
@@ -109,7 +129,14 @@ def apply_scaling(X_train, X_test=None, method=None, return_transformer=False):
         )
 
 
-def minmax_scale(X_train, X_test=None, return_transformer=False):
+def minmax_scale(
+    X_train: ArrayLike,
+    X_test: ArrayLike | None = None,
+    return_transformer: bool = False,
+) -> (
+    tuple[np.ndarray, np.ndarray | None]
+    | tuple[np.ndarray, np.ndarray | None, MinMaxScaler]
+):
     """Scale features to a fixed range between 0 and 1.
 
     Fits scaling parameters on training data and applies the same transformation
@@ -163,7 +190,14 @@ def minmax_scale(X_train, X_test=None, return_transformer=False):
         return X_train_scaled, X_test_scaled
 
 
-def standardize(X_train, X_test=None, return_transformer=False):
+def standardize(
+    X_train: ArrayLike,
+    X_test: ArrayLike | None = None,
+    return_transformer: bool = False,
+) -> (
+    tuple[np.ndarray, np.ndarray | None]
+    | tuple[np.ndarray, np.ndarray | None, StandardScaler]
+):
     """Standardize features to have zero mean and unit variance.
 
     Fits scaling parameters on training data and applies the same transformation

--- a/skordinal/results/_results.py
+++ b/skordinal/results/_results.py
@@ -1,12 +1,16 @@
 """Results handling for storing and managing experiment results."""
 
+from __future__ import annotations
+
 import pickle
 from collections import OrderedDict
 from datetime import date, datetime
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
+from sklearn.base import BaseEstimator
 
 
 class Results:
@@ -27,7 +31,7 @@ class Results:
 
     """
 
-    def __init__(self, output_folder: Path):
+    def __init__(self, output_folder: Path) -> None:
         # Getting experiment's folder name
         folder_name = (
             "exp-"
@@ -36,11 +40,17 @@ class Results:
             + datetime.now().strftime("%H-%M-%S")
         )
 
-        self._experiment_folder = output_folder / folder_name
+        self._experiment_folder = Path(output_folder) / folder_name
 
     def add_record(
-        self, partition, best_params, best_model, configuration, metrics, predictions
-    ):
+        self,
+        partition: str,
+        best_params: dict[str, Any],
+        best_model: BaseEstimator,
+        configuration: dict[str, str],
+        metrics: dict[str, dict[str, Any]],
+        predictions: dict[str, np.ndarray | None],
+    ) -> None:
         """Store information obtained from the run of one partition.
 
         Parameters
@@ -105,16 +115,19 @@ class Results:
         pred_filename = (
             configuration["dataset"] + "-" + configuration["config"] + "." + partition
         )
-        np.savetxt(
-            predictions_folder / f"train_{pred_filename}",
-            predictions["train"],
-            fmt="%d",
-        )
+        train_pred = predictions["train"]
+        if train_pred is not None:
+            np.savetxt(
+                predictions_folder / f"train_{pred_filename}",
+                train_pred,
+                fmt="%d",
+            )
 
-        if predictions["test"] is not None:
+        test_pred = predictions["test"]
+        if test_pred is not None:
             np.savetxt(
                 predictions_folder / f"test_{pred_filename}",
-                predictions["test"],
+                test_pred,
                 fmt="%d",
             )
 
@@ -149,7 +162,7 @@ class Results:
         # Saving DataFrame to file
         df.to_csv(df_path)
 
-    def save_summaries(self, metrics_names):
+    def save_summaries(self, metrics_names: list[str]) -> None:
         """Create an experiment summary.
 
         Each dataset-configuration will be represented as a single row of data, which
@@ -190,7 +203,12 @@ class Results:
         train_summary.to_csv(self._experiment_folder / "train_summary.csv")
         test_summary.to_csv(self._experiment_folder / "test_summary.csv")
 
-    def _create_summary(self, df, avg_index, std_index):
+    def _create_summary(
+        self,
+        df: pd.DataFrame,
+        avg_index: list[str],
+        std_index: list[str],
+    ) -> tuple[pd.Series, pd.Series]:
         """Summarize information from a DataFrame into a single row.
 
         Parameters

--- a/skordinal/results/_results.py
+++ b/skordinal/results/_results.py
@@ -16,7 +16,7 @@ class Results:
 
     Parameters
     ----------
-    output_folder : str
+    output_folder : Path
         Base directory for storing experimental results.
 
     Attributes
@@ -27,7 +27,7 @@ class Results:
 
     """
 
-    def __init__(self, output_folder):
+    def __init__(self, output_folder: Path):
         # Getting experiment's folder name
         folder_name = (
             "exp-"
@@ -36,7 +36,7 @@ class Results:
             + datetime.now().strftime("%H-%M-%S")
         )
 
-        self._experiment_folder = Path(output_folder) / folder_name
+        self._experiment_folder = output_folder / folder_name
 
     def add_record(
         self, partition, best_params, best_model, configuration, metrics, predictions

--- a/skordinal/results/tests/test_results.py
+++ b/skordinal/results/tests/test_results.py
@@ -17,7 +17,7 @@ from skordinal.results import Results
 
 @pytest.fixture
 def results():
-    return Results("my_runs/")
+    return Results(Path("my_runs/"))
 
 
 def test_add_record(results):

--- a/skordinal/utilities/_utilities.py
+++ b/skordinal/utilities/_utilities.py
@@ -1,23 +1,27 @@
 """Utility class for running experiments."""
 
+from __future__ import annotations
+
 from collections import OrderedDict
 from copy import deepcopy
 from pathlib import Path
 from time import time
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
 from sklearn import preprocessing
+from sklearn.base import BaseEstimator
 from sklearn.model_selection import GridSearchCV
 
 from skordinal.model_selection import load_classifier
 from skordinal.results import Results
 
 
-def _compute_metric(metric_name, y_true, y_pred):
+def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) -> float:
     from skordinal.metrics import get_ordinal_scorer
 
-    scorer = get_ordinal_scorer(metric_name.strip())
+    scorer = cast(Any, get_ordinal_scorer(metric_name.strip()))
     return scorer._score_func(y_true, y_pred, **scorer._kwargs)
 
 
@@ -54,12 +58,17 @@ class Utilities:
 
     """
 
-    def __init__(self, general_conf, configurations, verbose=True):
+    def __init__(
+        self,
+        general_conf: dict[str, Any],
+        configurations: dict[str, Any],
+        verbose: bool = True,
+    ) -> None:
         self.general_conf = deepcopy(general_conf)
         self.configurations = deepcopy(configurations)
         self.verbose = verbose
 
-    def run_experiment(self):
+    def run_experiment(self) -> None:
         """Run an experiment. Main method of this framework.
 
         Loads all datasets, which can be fragmented in partitions. Builds a model per
@@ -148,8 +157,8 @@ class Utilities:
                     elapsed = np.nan
                     if "test_outputs" in partition:
                         start = time()
-                        test_predicted_y = optimal_estimator.predict(
-                            partition["test_inputs"]
+                        test_predicted_y = np.asarray(
+                            optimal_estimator.predict(partition["test_inputs"])
                         )
                         elapsed = time() - start
 
@@ -168,6 +177,7 @@ class Utilities:
                         # Get test scores
                         test_metrics[metric_name.strip() + "_test"] = np.nan
                         if "test_outputs" in partition:
+                            assert test_predicted_y is not None
                             test_score = _compute_metric(
                                 metric_name, partition["test_outputs"], test_predicted_y
                             )
@@ -203,7 +213,7 @@ class Utilities:
                         {"train": train_predicted_y, "test": test_predicted_y},
                     )
 
-    def _load_dataset(self, dataset_path):
+    def _load_dataset(self, dataset_path: Path) -> list[tuple[str, dict[str, Any]]]:
         """Load all dataset's files, divided into train and test.
 
         Parameters
@@ -227,12 +237,12 @@ class Utilities:
 
         """
 
-        def get_partition_index(filename):
+        def get_partition_index(filename: str) -> str:
             # Extracts the index between the last "_" and ".csv"
             return filename.rsplit("_", 1)[-1].replace(".csv", "")
 
         try:
-            partition_list = {
+            partition_list: dict[str, dict[str, Any]] = {
                 get_partition_index(filename.name): {}
                 for filename in dataset_path.iterdir()
                 if filename.name.startswith("train_")
@@ -261,14 +271,14 @@ class Utilities:
             )
 
         # Saving partitions as a sorted list of (index, partition) tuples
-        partition_list = sorted(
+        sorted_list: list[tuple[str, dict[str, Any]]] = sorted(
             partition_list.items(),
             key=lambda t: int(t[0]) if t[0].lstrip("-").isdigit() else t[0],
         )
 
-        return partition_list
+        return sorted_list
 
-    def _read_file(self, filename):
+    def _read_file(self, filename: Path) -> tuple[np.ndarray, np.ndarray]:
         """Read a CSV containing partitions, or full datasets.
 
         Train and test files must be previously divided for the experiment to run.
@@ -295,7 +305,7 @@ class Utilities:
 
         return inputs, outputs
 
-    def _check_dataset_list(self):
+    def _check_dataset_list(self) -> None:
         """Check if there is some inconsistency in the dataset list.
 
         It also simplifies running all datasets inside one folder.
@@ -323,7 +333,9 @@ class Utilities:
         self.general_conf["basedir"] = str(base_path)
         self.general_conf["datasets"] = dataset_list
 
-    def _normalize_data(self, train_data, test_data):
+    def _normalize_data(
+        self, train_data: np.ndarray, test_data: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Normalize the data.
 
         Test data normalization will be based on train data.
@@ -349,7 +361,9 @@ class Utilities:
 
         return mm_scaler.transform(train_data), mm_scaler.transform(test_data)
 
-    def _standardize_data(self, train_data, test_data):
+    def _standardize_data(
+        self, train_data: np.ndarray, test_data: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Standardize the data.
 
         Test data standardization will be based on train data.
@@ -376,8 +390,12 @@ class Utilities:
         return std_scaler.transform(train_data), std_scaler.transform(test_data)
 
     def _get_optimal_estimator(
-        self, train_inputs, train_outputs, classifier_name, parameters
-    ):
+        self,
+        train_inputs: np.ndarray,
+        train_outputs: np.ndarray,
+        classifier_name: str,
+        parameters: dict[str, Any],
+    ) -> BaseEstimator | GridSearchCV:
         """Perform cross-validation over one dataset and configuration.
 
         Each configuration consists of one classifier and none, one or multiple
@@ -418,7 +436,7 @@ class Utilities:
         """
         estimator = load_classifier(
             classifier_name=classifier_name,
-            random_state=np.random.get_state()[1][0],
+            random_state=int(cast(tuple, np.random.get_state())[1][0]),
             n_jobs=self.general_conf.get("jobs", 1),
             cv_n_folds=self.general_conf.get("hyperparam_cv_nfolds", 3),
             cv_metric=self.general_conf.get("cv_metric", "mae"),
@@ -436,7 +454,7 @@ class Utilities:
 
         return estimator
 
-    def write_report(self):
+    def write_report(self) -> None:
         """Save summarized information about experiment through Results class."""
         if self.verbose:
             print("\nSaving Results...")

--- a/skordinal/utilities/_utilities.py
+++ b/skordinal/utilities/_utilities.py
@@ -81,7 +81,7 @@ class Utilities:
             If the parameters for base_classifier must be list.
 
         """
-        self._results = Results(self.general_conf["output_folder"])
+        self._results = Results(Path(self.general_conf["output_folder"]))
 
         self._check_dataset_list()
 

--- a/skordinal/utils/_sklearn_compat.py
+++ b/skordinal/utils/_sklearn_compat.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any, overload
+
+import numpy as np
+from numpy.typing import ArrayLike
+
 try:
     from sklearn.utils.validation import validate_data as _sk_validate_data
 
@@ -10,7 +15,36 @@ except ImportError:  # scikit-learn < 1.6
     _HAS_VALIDATE_DATA = False
 
 
-def validate_data(estimator, X, y=None, *, reset=True, **check_params):
+@overload
+def validate_data(
+    estimator: Any,
+    X: ArrayLike,
+    y: None = ...,
+    *,
+    reset: bool = ...,
+    **check_params: Any,
+) -> np.ndarray: ...
+
+
+@overload
+def validate_data(
+    estimator: Any,
+    X: ArrayLike,
+    y: ArrayLike,
+    *,
+    reset: bool = ...,
+    **check_params: Any,
+) -> tuple[np.ndarray, np.ndarray]: ...
+
+
+def validate_data(
+    estimator: Any,
+    X: ArrayLike,
+    y: ArrayLike | None = None,
+    *,
+    reset: bool = True,
+    **check_params: Any,
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
     """Validate ``X`` (and optionally ``y``) for a scikit-learn estimator.
 
     Thin wrapper around the API split introduced in scikit-learn 1.6.

--- a/skordinal/utils/validation.py
+++ b/skordinal/utils/validation.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 def check_ordinal_targets(
-    y,
+    y: ArrayLike,
 ) -> tuple[NDArray, NDArray[np.intp]]:
     """Validate an ordinal target vector and return its integer encoding.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds full type annotations to every function across `skordinal/` using PEP 604 syntax (`from __future__ import annotations` for Python 3.9 compatibility). Estimator methods follow scikit-learn conventions: `ArrayLike` inputs, `np.ndarray` outputs, forward-referenced `self` returns.

Also migrates file-path parameters in `datasets`, `results`, and `Utilities` from implicit `str | os.PathLike` to `pathlib.Path`. API break: callers that passed bare strings must now wrap them with `Path(...)`.