### PR TITLE
MNT: Remove deprecated metric aliases and scorer keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ skordinal includes sample datasets with pre-partitioned train/test splits using 
         "datasets": ["balance-scale", "contact-lenses", "tae"],
         "hyperparam_cv_nfolds": 3,
         "output_folder": "results/",
-        "metrics": ["ccr", "mae", "amae"],
-        "cv_metric": "mae"
+        "metrics": ["accuracy_score", "neg_mean_absolute_error", "neg_average_mean_absolute_error"],
+        "cv_metric": "neg_mean_absolute_error"
     },
     "configurations": {
         "SVM": {

--- a/skordinal/metrics/__init__.py
+++ b/skordinal/metrics/__init__.py
@@ -3,7 +3,7 @@
 from sklearn.metrics import accuracy_score, mean_absolute_error
 
 from ._metrics import (
-    accuracy_off1,
+    accuracy_off1_score,
     average_mean_absolute_error,
     geometric_mean,
     gmsec,
@@ -18,7 +18,7 @@ from ._metrics import (
 from ._scorers import get_ordinal_scorer, list_ordinal_scorers
 
 __all__ = [
-    "accuracy_off1",
+    "accuracy_off1_score",
     "accuracy_score",
     "average_mean_absolute_error",
     "geometric_mean",

--- a/skordinal/metrics/__init__.py
+++ b/skordinal/metrics/__init__.py
@@ -15,39 +15,6 @@ from ._metrics import (
     spearmans_rho,
     weighted_kappa,
 )
-from ._metrics import (
-    amae as amae,
-)
-from ._metrics import (
-    ccr as ccr,
-)
-from ._metrics import (
-    gm as gm,
-)
-from ._metrics import (
-    mae as mae,
-)
-from ._metrics import (
-    mmae as mmae,
-)
-from ._metrics import (
-    ms as ms,
-)
-from ._metrics import (
-    mze as mze,
-)
-from ._metrics import (
-    rps as rps,
-)
-from ._metrics import (
-    spearman as spearman,
-)
-from ._metrics import (
-    tkendall as tkendall,
-)
-from ._metrics import (
-    wkappa as wkappa,
-)
 from ._scorers import get_ordinal_scorer, list_ordinal_scorers
 
 __all__ = [

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -2,17 +2,10 @@
 
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 import scipy.stats
 from numpy.typing import ArrayLike, NDArray
-from sklearn.metrics import (
-    accuracy_score,
-    confusion_matrix,
-    mean_absolute_error,
-    recall_score,
-)
+from sklearn.metrics import confusion_matrix, recall_score
 from sklearn.utils import check_array, check_consistent_length
 
 
@@ -741,113 +734,3 @@ def accuracy_off1(
     correct = mask * conf_mat
 
     return float(np.sum(correct) / np.sum(conf_mat))
-
-
-def ccr(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`accuracy_score`."""
-    warnings.warn(
-        "ccr is deprecated, use accuracy_score instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return accuracy_score(y_true, y_pred)
-
-
-def amae(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`average_mean_absolute_error`."""
-    warnings.warn(
-        "amae is deprecated, use average_mean_absolute_error instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return average_mean_absolute_error(y_true, y_pred)
-
-
-def gm(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`geometric_mean`."""
-    warnings.warn(
-        "gm is deprecated, use geometric_mean instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return geometric_mean(y_true, y_pred)
-
-
-def mae(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`mean_absolute_error`."""
-    warnings.warn(
-        "mae is deprecated, use mean_absolute_error instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return mean_absolute_error(y_true, y_pred)
-
-
-def mmae(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`maximum_mean_absolute_error`."""
-    warnings.warn(
-        "mmae is deprecated, use maximum_mean_absolute_error instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return maximum_mean_absolute_error(y_true, y_pred)
-
-
-def ms(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`minimum_sensitivity`."""
-    warnings.warn(
-        "ms is deprecated, use minimum_sensitivity instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return minimum_sensitivity(y_true, y_pred)
-
-
-def mze(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`mean_zero_one_error`."""
-    warnings.warn(
-        "mze is deprecated, use mean_zero_one_error instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return mean_zero_one_error(y_true, y_pred)
-
-
-def tkendall(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`kendalls_tau`."""
-    warnings.warn(
-        "tkendall is deprecated, use kendalls_tau instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return kendalls_tau(y_true, y_pred)
-
-
-def wkappa(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`weighted_kappa`."""
-    warnings.warn(
-        "wkappa is deprecated, use weighted_kappa instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return weighted_kappa(y_true, y_pred)
-
-
-def spearman(y_true: ArrayLike, y_pred: ArrayLike) -> float:
-    """Deprecated alias for :func:`spearmans_rho`."""
-    warnings.warn(
-        "spearman is deprecated, use spearmans_rho instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return spearmans_rho(y_true, y_pred)
-
-
-def rps(y_true: ArrayLike, y_proba: ArrayLike) -> float:
-    """Deprecated alias for :func:`ranked_probability_score`."""
-    warnings.warn(
-        "rps is deprecated, use ranked_probability_score instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return ranked_probability_score(y_true, y_proba)

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -675,7 +675,7 @@ def ranked_probability_score(
     return float(np.average(per_sample, weights=weights))
 
 
-def accuracy_off1(
+def accuracy_off1_score(
     y_true: ArrayLike,
     y_pred: ArrayLike,
     *,
@@ -715,10 +715,10 @@ def accuracy_off1(
     Examples
     --------
     >>> import numpy as np
-    >>> from skordinal.metrics import accuracy_off1
+    >>> from skordinal.metrics import accuracy_off1_score
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 0, 0, 1])
-    >>> accuracy_off1(y_true, y_pred)
+    >>> accuracy_off1_score(y_true, y_pred)
     0.8571428571428571
 
     """

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -44,7 +44,7 @@ _SCORERS: dict[str, Callable] = {
         maximum_mean_absolute_error, greater_is_better=False
     ),
     "mean_zero_one_error": make_scorer(mean_zero_one_error, greater_is_better=False),
-    "accuracy": make_scorer(accuracy_score),
+    "accuracy_score": make_scorer(accuracy_score),
     "accuracy_off1": make_scorer(accuracy_off1),
     "geometric_mean": make_scorer(geometric_mean),
     "gmsec": make_scorer(gmsec),
@@ -52,22 +52,6 @@ _SCORERS: dict[str, Callable] = {
     "minimum_sensitivity": make_scorer(minimum_sensitivity),
     "spearmans_rho": make_scorer(spearmans_rho),
     "weighted_kappa": make_scorer(weighted_kappa),
-    "neg_amae": make_scorer(average_mean_absolute_error, greater_is_better=False),
-    "neg_mae": make_scorer(mean_absolute_error, greater_is_better=False),
-    "neg_mmae": make_scorer(maximum_mean_absolute_error, greater_is_better=False),
-    "neg_mze": make_scorer(mean_zero_one_error, greater_is_better=False),
-    "neg_rps": make_scorer(ranked_probability_score, greater_is_better=False),
-    "amae": make_scorer(average_mean_absolute_error, greater_is_better=False),
-    "ccr": make_scorer(accuracy_score),
-    "gm": make_scorer(geometric_mean),
-    "mae": make_scorer(mean_absolute_error, greater_is_better=False),
-    "mmae": make_scorer(maximum_mean_absolute_error, greater_is_better=False),
-    "ms": make_scorer(minimum_sensitivity),
-    "mze": make_scorer(mean_zero_one_error, greater_is_better=False),
-    "rps": make_scorer(ranked_probability_score, greater_is_better=False),
-    "spearman": make_scorer(spearmans_rho),
-    "tkendall": make_scorer(kendalls_tau),
-    "wkappa": make_scorer(weighted_kappa),
 }
 
 __all__ = ["get_ordinal_scorer", "list_ordinal_scorers"]
@@ -129,7 +113,7 @@ def list_ordinal_scorers() -> list[str]:
     <class 'list'>
     >>> "neg_mean_absolute_error" in all_scorers
     True
-    >>> "ccr" in all_scorers
+    >>> "accuracy_score" in all_scorers
     True
 
     """

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from sklearn.metrics import accuracy_score, make_scorer, mean_absolute_error
 
 from ._metrics import (
-    accuracy_off1,
+    accuracy_off1_score,
     average_mean_absolute_error,
     geometric_mean,
     gmsec,
@@ -45,7 +45,7 @@ _SCORERS: dict[str, Callable] = {
     ),
     "mean_zero_one_error": make_scorer(mean_zero_one_error, greater_is_better=False),
     "accuracy_score": make_scorer(accuracy_score),
-    "accuracy_off1": make_scorer(accuracy_off1),
+    "accuracy_off1_score": make_scorer(accuracy_off1_score),
     "geometric_mean": make_scorer(geometric_mean),
     "gmsec": make_scorer(gmsec),
     "kendalls_tau": make_scorer(kendalls_tau),

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -280,63 +280,6 @@ def test_spearmans_rho_constant_input():
     npt.assert_equal(spearmans_rho(np.array([1, 1, 1, 1]), np.array([0, 1, 2, 3])), 0.0)
 
 
-@pytest.mark.parametrize(
-    "name",
-    [
-        "ccr",
-        "amae",
-        "gm",
-        "mae",
-        "mmae",
-        "ms",
-        "mze",
-        "tkendall",
-        "wkappa",
-        "spearman",
-    ],
-)
-def test_deprecated_alias_warns(name):
-    """Calling a deprecated short-name alias emits DeprecationWarning."""
-    import skordinal.metrics as m
-
-    y_true = np.array([0, 1, 2, 1, 0])
-    y_pred = np.array([0, 1, 1, 2, 0])
-    fn = getattr(m, name)
-    with pytest.warns(DeprecationWarning, match=name):
-        fn(y_true, y_pred)
-
-
-def test_deprecated_rps_warns():
-    """Calling the deprecated rps alias emits DeprecationWarning."""
-    import skordinal.metrics as m
-
-    y_true = np.array([0, 1, 2])
-    y_proba = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]])
-    with pytest.warns(DeprecationWarning, match="rps"):
-        m.rps(y_true, y_proba)
-
-
-def test_deprecated_alias_not_in_all():
-    """Deprecated short names are not present in skordinal.metrics.__all__."""
-    import skordinal.metrics as m
-
-    deprecated = [
-        "ccr",
-        "amae",
-        "gm",
-        "mae",
-        "mmae",
-        "ms",
-        "mze",
-        "tkendall",
-        "wkappa",
-        "spearman",
-        "rps",
-    ]
-    for name in deprecated:
-        assert name not in m.__all__, f"{name!r} should not be in __all__"
-
-
 def test_metric_names_in_all():
     """All public metric names are present in skordinal.metrics.__all__."""
     import skordinal.metrics as m

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pytest
 
 from skordinal.metrics import (
-    accuracy_off1,
+    accuracy_off1_score,
     accuracy_score,
     average_mean_absolute_error,
     geometric_mean,
@@ -24,7 +24,7 @@ from skordinal.metrics import (
 from skordinal.metrics._metrics import _check_metric_inputs, _check_proba_inputs
 
 _WEIGHTED_METRICS = [
-    accuracy_off1,
+    accuracy_off1_score,
     average_mean_absolute_error,
     geometric_mean,
     gmsec,
@@ -118,16 +118,16 @@ def test_accuracy_score():
         ([0, 1, 2, 3, 4], [0, 2, 1, 4, 3], 1.0),
     ],
 )
-def test_accuracy_off1(y_true, y_pred, expected):
-    """accuracy_off1 counts predictions within one ordinal class of truth."""
-    npt.assert_almost_equal(accuracy_off1(y_true, y_pred), expected, decimal=6)
+def test_accuracy_off1_score(y_true, y_pred, expected):
+    """accuracy_off1_score counts predictions within one ordinal class of truth."""
+    npt.assert_almost_equal(accuracy_off1_score(y_true, y_pred), expected, decimal=6)
 
 
-def test_accuracy_off1_lower_diagonal():
+def test_accuracy_off1_score_lower_diagonal():
     """Predictions one class below truth all count as correct (off1 = 1.0)."""
     y_true = np.array([1, 2, 3])
     y_pred = np.array([0, 1, 2])
-    npt.assert_allclose(accuracy_off1(y_true, y_pred), 1.0)
+    npt.assert_allclose(accuracy_off1_score(y_true, y_pred), 1.0)
 
 
 @pytest.mark.parametrize(
@@ -297,7 +297,7 @@ def test_metric_names_in_all():
         "spearmans_rho",
         "ranked_probability_score",
         "gmsec",
-        "accuracy_off1",
+        "accuracy_off1_score",
     ]
     for name in expected:
         assert name in m.__all__, f"{name!r} missing from __all__"
@@ -310,9 +310,9 @@ def test_sample_weight_is_keyword_only(fn):
     assert sig.parameters["sample_weight"].kind == inspect.Parameter.KEYWORD_ONLY
 
 
-def test_accuracy_off1_labels_is_keyword_only():
-    """labels is a keyword-only parameter of accuracy_off1."""
-    sig = inspect.signature(accuracy_off1)
+def test_accuracy_off1_score_labels_is_keyword_only():
+    """labels is a keyword-only parameter of accuracy_off1_score."""
+    sig = inspect.signature(accuracy_off1_score)
     assert sig.parameters["labels"].kind == inspect.Parameter.KEYWORD_ONLY
 
 
@@ -345,7 +345,7 @@ def test_metric_unit_sample_weight_matches_unweighted(fn):
 
 
 def test_metric_zero_weight_excludes_sample():
-    """Setting a sample's weight to 0 removes its contribution to accuracy_off1."""
+    """Setting a sample's weight to 0 removes its contribution to accuracy_off1_score."""
     y_t = np.array([0, 1, 2, 1, 0, 3])
     y_p = np.array([3, 1, 2, 1, 0, 3])
     n = len(y_t)
@@ -354,8 +354,8 @@ def test_metric_zero_weight_excludes_sample():
     zero_w = np.ones(n)
     zero_w[0] = 0.0
 
-    score_unit = accuracy_off1(y_t, y_p, sample_weight=unit_w)
-    score_zero = accuracy_off1(y_t, y_p, sample_weight=zero_w)
+    score_unit = accuracy_off1_score(y_t, y_p, sample_weight=unit_w)
+    score_zero = accuracy_off1_score(y_t, y_p, sample_weight=zero_w)
     assert score_zero > score_unit
 
 

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -6,7 +6,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 
 from skordinal.metrics import (
-    accuracy_off1,
+    accuracy_off1_score,
     accuracy_score,
     average_mean_absolute_error,
     geometric_mean,
@@ -46,7 +46,7 @@ def test_scorers_not_in_public_all():
 @pytest.mark.parametrize(
     "name, metric_fn",
     [
-        ("accuracy_off1", accuracy_off1),
+        ("accuracy_off1_score", accuracy_off1_score),
         ("accuracy_score", accuracy_score),
         ("geometric_mean", geometric_mean),
         ("gmsec", gmsec),
@@ -93,7 +93,7 @@ def test_whitespace_stripped():
     "name, metric_fn",
     [
         ("accuracy_score", accuracy_score),
-        ("accuracy_off1", accuracy_off1),
+        ("accuracy_off1_score", accuracy_off1_score),
         ("geometric_mean", geometric_mean),
         ("gmsec", gmsec),
         ("mean_absolute_error", mean_absolute_error),
@@ -156,7 +156,7 @@ def test_scorer_names_present():
         "neg_mean_zero_one_error",
         "neg_ranked_probability_score",
         "accuracy_score",
-        "accuracy_off1",
+        "accuracy_off1_score",
         "geometric_mean",
         "gmsec",
         "kendalls_tau",

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -47,7 +47,7 @@ def test_scorers_not_in_public_all():
     "name, metric_fn",
     [
         ("accuracy_off1", accuracy_off1),
-        ("accuracy", accuracy_score),
+        ("accuracy_score", accuracy_score),
         ("geometric_mean", geometric_mean),
         ("gmsec", gmsec),
         ("minimum_sensitivity", minimum_sensitivity),
@@ -84,44 +84,6 @@ def test_loss_scorer_sign(name, metric_fn):
     assert scorer._sign == -1
 
 
-@pytest.mark.parametrize(
-    "name, metric_fn",
-    [
-        ("ccr", accuracy_score),
-        ("gm", geometric_mean),
-        ("ms", minimum_sensitivity),
-        ("spearman", spearmans_rho),
-        ("tkendall", kendalls_tau),
-        ("wkappa", weighted_kappa),
-    ],
-)
-def test_deprecated_utility_scorer_sign(name, metric_fn):
-    """Deprecated short-name utility scorers have sign +1 and wrap the correct function."""
-    scorer = get_ordinal_scorer(name)
-    assert scorer._score_func is metric_fn
-    assert scorer._sign == 1
-
-
-@pytest.mark.parametrize(
-    "name, metric_fn",
-    [
-        ("neg_amae", average_mean_absolute_error),
-        ("neg_mae", mean_absolute_error),
-        ("neg_mmae", maximum_mean_absolute_error),
-        ("neg_mze", mean_zero_one_error),
-        ("amae", average_mean_absolute_error),
-        ("mae", mean_absolute_error),
-        ("mmae", maximum_mean_absolute_error),
-        ("mze", mean_zero_one_error),
-    ],
-)
-def test_deprecated_loss_scorer_sign(name, metric_fn):
-    """Deprecated short-name loss scorers have sign -1 and wrap the correct function."""
-    scorer = get_ordinal_scorer(name)
-    assert scorer._score_func is metric_fn
-    assert scorer._sign == -1
-
-
 def test_whitespace_stripped():
     """Leading and trailing whitespace in the name is ignored."""
     assert get_ordinal_scorer("  neg_mean_absolute_error  ")._sign == -1
@@ -130,7 +92,7 @@ def test_whitespace_stripped():
 @pytest.mark.parametrize(
     "name, metric_fn",
     [
-        ("accuracy", accuracy_score),
+        ("accuracy_score", accuracy_score),
         ("accuracy_off1", accuracy_off1),
         ("geometric_mean", geometric_mean),
         ("gmsec", gmsec),
@@ -146,33 +108,6 @@ def test_whitespace_stripped():
 )
 def test_scorer_output_matches_metric(name, metric_fn):
     """Scorer's score function returns the same value as calling the metric directly."""
-    y_true = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3]
-    y_pred = [1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3]
-    scorer = get_ordinal_scorer(name)
-    npt.assert_almost_equal(
-        scorer._score_func(y_true, y_pred), metric_fn(y_true, y_pred)
-    )
-
-
-@pytest.mark.parametrize(
-    "name, metric_fn",
-    [
-        ("ccr", accuracy_score),
-        ("accuracy_off1", accuracy_off1),
-        ("gm", geometric_mean),
-        ("gmsec", gmsec),
-        ("mae", mean_absolute_error),
-        ("mmae", maximum_mean_absolute_error),
-        ("amae", average_mean_absolute_error),
-        ("ms", minimum_sensitivity),
-        ("mze", mean_zero_one_error),
-        ("tkendall", kendalls_tau),
-        ("wkappa", weighted_kappa),
-        ("spearman", spearmans_rho),
-    ],
-)
-def test_deprecated_scorer_output_matches_metric(name, metric_fn):
-    """Deprecated scorer's score function returns the same value as the metric."""
     y_true = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3]
     y_pred = [1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3]
     scorer = get_ordinal_scorer(name)
@@ -220,7 +155,7 @@ def test_scorer_names_present():
         "neg_maximum_mean_absolute_error",
         "neg_mean_zero_one_error",
         "neg_ranked_probability_score",
-        "accuracy",
+        "accuracy_score",
         "accuracy_off1",
         "geometric_mean",
         "gmsec",
@@ -230,29 +165,4 @@ def test_scorer_names_present():
         "weighted_kappa",
     ]
     for name in expected:
-        assert name in names, f"{name!r} missing from list_ordinal_scorers()"
-
-
-def test_deprecated_scorer_names_present():
-    """Deprecated short-name scorer keys are still registered."""
-    names = list_ordinal_scorers()
-    deprecated = [
-        "neg_amae",
-        "neg_mae",
-        "neg_mmae",
-        "neg_mze",
-        "neg_rps",
-        "amae",
-        "ccr",
-        "gm",
-        "mae",
-        "mmae",
-        "ms",
-        "mze",
-        "rps",
-        "spearman",
-        "tkendall",
-        "wkappa",
-    ]
-    for name in deprecated:
         assert name in names, f"{name!r} missing from list_ordinal_scorers()"

--- a/skordinal/model_selection/tests/test_loaders.py
+++ b/skordinal/model_selection/tests/test_loaders.py
@@ -72,7 +72,7 @@ def test_load_classifier_with_searchcv():
         param_grid=param_grid,
         random_state=TEST_RANDOM_STATE,
         cv_n_folds=5,
-        cv_metric="mae",
+        cv_metric="neg_mean_absolute_error",
         n_jobs=1,
     )
 
@@ -104,7 +104,7 @@ def test_load_classifier_with_ensemble_method():
         param_grid=param_grid,
         n_jobs=10,
         cv_n_folds=3,
-        cv_metric=get_ordinal_scorer("neg_mae"),
+        cv_metric=get_ordinal_scorer("neg_mean_absolute_error"),
         random_state=TEST_RANDOM_STATE,
     )
     assert isinstance(classifier, GridSearchCV)

--- a/skordinal/utilities/tests/test_utilities.py
+++ b/skordinal/utilities/tests/test_utilities.py
@@ -53,7 +53,7 @@ def experiment_conf(tmp_path, partition_dataset):
         "jobs": 1,
         "output_folder": str(tmp_path / "runs"),
         "metrics": [
-            "accuracy",
+            "accuracy_score",
             "mean_absolute_error",
             "average_mean_absolute_error",
             "mean_zero_one_error",


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Removes 11 deprecated metric alias functions (`ccr`, `amae`, `gm`, `mae`, `mmae`, `ms`, `mze`, `tkendall`, `wkappa`, `spearman`, `rps`) and 16 deprecated scorer registry entries. Renames the scorer key `"accuracy"` to `"accuracy_score"` to match sklearn's function name. 