### PR TITLE
CI: Expand test matrix with macOS and NumPy 2.x

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          # Extra job: verify compatibility with NumPy 2.x.
+          - os: ubuntu-latest
+            python-version: "3.12"
+            numpy-constraint: ">=2.0,<3"
     steps:
       - uses: actions/checkout@v6
 
@@ -35,6 +40,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+          if [ -n "${{ matrix.numpy-constraint }}" ]; then
+            pip install "numpy${{ matrix.numpy-constraint }}"
+          fi
 
       - name: Run tests
         run: pytest -m "not network" --cov=skordinal --cov-report=xml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,10 +16,11 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
@@ -27,6 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: "pip"
 
       - name: Install dependencies


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `macos-latest` as a second runner in the test matrix. Platform differences in filesystem behavior and C extension compilation (`libsvmrank`, `svorex`) are now caught on both operating systems.

Also adds a dedicated job that pins `numpy>=2.0,<3` to verify the library works under NumPy 2.x, which introduced breaking API changes.