### PR TITLE
ENH: Add ExperimentResult dataclass for partition run outputs

### DIFF
--- a/skordinal/experiments/__init__.py
+++ b/skordinal/experiments/__init__.py
@@ -1,6 +1,6 @@
 """Experiments orchestration module."""
 
-from ._results import Results
+from ._results import ExperimentResult, Results
 from ._utilities import Utilities
 
-__all__ = ["Results", "Utilities"]
+__all__ = ["ExperimentResult", "Results", "Utilities"]

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -96,44 +96,21 @@ class Results:
 
         self._experiment_folder = Path(output_folder) / folder_name
 
-    def add_record(
+    def save(
         self,
-        partition: str,
-        best_params: dict[str, Any],
-        best_model: BaseEstimator,
-        configuration: dict[str, str],
-        metrics: dict[str, dict[str, Any]],
-        predictions: dict[str, np.ndarray | None],
+        result: ExperimentResult,
+        *,
+        save_model: bool = True,
     ) -> None:
         """Store information obtained from the run of one partition.
 
         Parameters
         ----------
-        partition : str
-            Partition's index.
+        result : ExperimentResult
+            All data produced by a single classifier run on one partition.
 
-        best_params : dict
-            Best hyper-parameter's values found for this configuration and dataset
-            during cross-validation. If an ensemble method has been used, there'll
-            exist a parameter called 'parameters' that will store a dict with the best
-            hyper-parameters found for the base classifier. Keys are the name of each
-            parameter.
-
-        best_model : estimator
-            Best model created during cross-validation.
-
-        configuration : dict
-            Dictionary containing the name used for this pair of dataset and
-            configuration. Keys are 'dataset' and 'config'.
-
-        metrics : dict of dictionaries
-            Dictionary containing the metrics for train and test for this particular
-            configuration. It contains computational times for both of them as well.
-            Keys are 'train' and 'test'.
-
-        predictions : dict of lists
-            Dictionary that stores train and test class predictions. Keys are 'train'
-            and 'test'.
+        save_model : bool, default=True
+            Whether to pickle the fitted model to disk.
 
         Raises
         ------
@@ -142,7 +119,7 @@ class Results:
 
         """
         dataset_folder = self._experiment_folder / (
-            configuration["dataset"] + "-" + configuration["config"]
+            result.dataset_name + "-" + result.classifier_name
         )
         models_folder = dataset_folder / "models"
         predictions_folder = dataset_folder / "predictions"
@@ -150,44 +127,62 @@ class Results:
         # Creating folder for this dataset-configuration if necessary
         if not dataset_folder.exists():
             try:
-                models_folder.mkdir(parents=True)
-                predictions_folder.mkdir(parents=True)
+                if save_model:
+                    models_folder.mkdir(parents=True)
+                else:
+                    predictions_folder.mkdir(parents=True)
+                predictions_folder.mkdir(exist_ok=True)
 
             except OSError:
                 raise OSError(
-                    f"Could not create folder {dataset_folder} (or subfolders) to store results."
+                    f"Could not create folder {dataset_folder} (or subfolders) "
+                    "to store results."
                 )
 
         # Saving partition model
-        model_filename = (
-            configuration["dataset"] + "-" + configuration["config"] + "." + partition
-        )
-        with open(models_folder / model_filename, "wb") as output:
-            pickle.dump(best_model, output)
+        if save_model:
+            models_folder.mkdir(exist_ok=True)
+            model_filename = (
+                result.dataset_name
+                + "-"
+                + result.classifier_name
+                + "."
+                + result.resample_id
+            )
+            with open(models_folder / model_filename, "wb") as output:
+                pickle.dump(result.best_model, output)
 
         # Saving model predictions
         pred_filename = (
-            configuration["dataset"] + "-" + configuration["config"] + "." + partition
+            result.dataset_name
+            + "-"
+            + result.classifier_name
+            + "."
+            + result.resample_id
         )
-        train_pred = predictions["train"]
-        if train_pred is not None:
+        if result.train_predicted_y is not None:
             np.savetxt(
                 predictions_folder / f"train_{pred_filename}",
-                train_pred,
+                result.train_predicted_y,
                 fmt="%d",
             )
 
-        test_pred = predictions["test"]
-        if test_pred is not None:
+        if result.test_predicted_y is not None:
             np.savetxt(
                 predictions_folder / f"test_{pred_filename}",
-                test_pred,
+                result.test_predicted_y,
                 fmt="%d",
+            )
+
+        if result.y_proba is not None:
+            np.savetxt(
+                predictions_folder / f"proba_{pred_filename}",
+                result.y_proba,
             )
 
         dataframe_row = OrderedDict()
         # Adding best parameters as first elements in row
-        for p_name, p_value in best_params.items():
+        for p_name, p_value in result.best_params.items():
             # If some ensemble method has been used, then one of its parameters will be
             # a dictionary containing the best parameters found for the base classifier.
             if isinstance(p_value, dict):
@@ -198,17 +193,15 @@ class Results:
 
         # Concatenating train and test metrics
         for (tm_name, tm_value), (ts_name, ts_value) in zip(
-            metrics["train"].items(), metrics["test"].items()
+            result.train_metrics.items(), result.test_metrics.items()
         ):
             dataframe_row[tm_name] = tm_value
             dataframe_row[ts_name] = ts_value
 
         # Adding row to existing DataFrame or creating new one
-        df_path = (
-            dataset_folder / f"{configuration['dataset']}-{configuration['config']}.csv"
-        )
+        df_path = dataset_folder / f"{result.dataset_name}-{result.classifier_name}.csv"
 
-        df = pd.DataFrame([dataframe_row], index=[partition])
+        df = pd.DataFrame([dataframe_row], index=[result.resample_id])
         if df_path.is_file():
             previous_df = pd.read_csv(df_path, index_col=[0])
             df = pd.concat([previous_df, df], axis=0)

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pickle
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,59 @@ from typing import Any
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    """Result of running a single classifier on one dataset partition.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Name of the dataset.
+
+    classifier_name : str
+        Name of the classifier configuration.
+
+    resample_id : str
+        Partition identifier.
+
+    train_predicted_y : ndarray
+        Class predictions on the training partition.
+
+    test_predicted_y : ndarray or None
+        Class predictions on the test partition. ``None`` if no test partition
+        was available.
+
+    y_proba : ndarray or None
+        Class probability estimates on the test partition, shape
+        ``(n_samples, n_classes)``. ``None`` if the estimator does not support
+        ``predict_proba``.
+
+    train_metrics : dict
+        Metric values computed on the training partition, including timing.
+
+    test_metrics : dict
+        Metric values computed on the test partition, including timing.
+
+    best_params : dict
+        Best hyper-parameter values found during cross-validation.
+
+    best_model : estimator
+        Fitted estimator selected during cross-validation or direct fit.
+
+    """
+
+    dataset_name: str
+    classifier_name: str
+    resample_id: str
+    train_predicted_y: np.ndarray
+    test_predicted_y: np.ndarray | None
+    y_proba: np.ndarray | None
+    train_metrics: dict[str, Any]
+    test_metrics: dict[str, Any]
+    best_params: dict[str, Any]
+    best_model: BaseEstimator
 
 
 class Results:

--- a/skordinal/experiments/_utilities.py
+++ b/skordinal/experiments/_utilities.py
@@ -16,7 +16,7 @@ from sklearn.model_selection import GridSearchCV
 
 from skordinal.model_selection import load_classifier
 
-from ._results import Results
+from ._results import ExperimentResult, Results
 
 
 def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) -> float:
@@ -204,14 +204,28 @@ class Utilities:
                         train_metrics["time_train"] = optimal_estimator.refit_time_
                         test_metrics["time_test"] = elapsed
 
+                    y_proba = None
+                    if "test_outputs" in partition and hasattr(
+                        optimal_estimator.best_estimator_, "predict_proba"
+                    ):
+                        y_proba = optimal_estimator.best_estimator_.predict_proba(
+                            partition["test_inputs"]
+                        )
+
                     # Saving the results for this partition
-                    self._results.add_record(
-                        part_idx,
-                        optimal_estimator.best_params_,
-                        optimal_estimator.best_estimator_,
-                        {"dataset": dataset_name, "config": conf_name},
-                        {"train": train_metrics, "test": test_metrics},
-                        {"train": train_predicted_y, "test": test_predicted_y},
+                    self._results.save(
+                        ExperimentResult(
+                            dataset_name=dataset_name,
+                            classifier_name=conf_name,
+                            resample_id=part_idx,
+                            train_predicted_y=train_predicted_y,
+                            test_predicted_y=test_predicted_y,
+                            y_proba=y_proba,
+                            train_metrics=train_metrics,
+                            test_metrics=test_metrics,
+                            best_params=optimal_estimator.best_params_,
+                            best_model=optimal_estimator.best_estimator_,
+                        )
                     )
 
     def _load_dataset(self, dataset_path: Path) -> list[tuple[str, dict[str, Any]]]:

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -12,7 +12,34 @@ import pandas.testing as pdt
 import pytest
 from sklearn.svm import SVC
 
-from skordinal.experiments import Results
+from skordinal.experiments import ExperimentResult, Results
+
+
+def _make_result(
+    partition: str,
+    dataset: str,
+    configuration: str,
+    best_params: dict,
+    train_metrics: dict,
+    test_metrics: dict,
+    train_predicted_y: np.ndarray,
+    test_predicted_y: np.ndarray,
+    estimator=None,
+) -> ExperimentResult:
+    if estimator is None:
+        estimator = SVC()
+    return ExperimentResult(
+        dataset_name=dataset,
+        classifier_name=configuration,
+        resample_id=partition,
+        train_predicted_y=train_predicted_y,
+        test_predicted_y=test_predicted_y,
+        y_proba=None,
+        train_metrics=train_metrics,
+        test_metrics=test_metrics,
+        best_params=best_params,
+        best_model=estimator,
+    )
 
 
 @pytest.fixture
@@ -20,85 +47,64 @@ def results():
     return Results(Path("my_runs/"))
 
 
-def test_add_record(results):
-    """Checking behavior of add_record method.
+def test_save(results):
+    """Checking behavior of save method.
 
     Two partitions for the same dataset and configuration will be added and
     retreived later on to check if they are similar.
 
     """
-    # Saving fist partition results to DataFrame
-    partition = "0"
-    dataset = "toy"
-    configuration = "conf_1"
-
     estimator = SVC()
-    best_params = OrderedDict([("C", 0.1), ("gamma", 1)])
 
-    train_metrics = OrderedDict(
-        [("ccr_train", 0.7222222222), ("mae_train", 0.2777777777)]
+    # Saving first partition results to DataFrame
+    result_0 = _make_result(
+        partition="0",
+        dataset="toy",
+        configuration="conf_1",
+        best_params=OrderedDict([("C", 0.1), ("gamma", 1)]),
+        train_metrics=OrderedDict(
+            [("ccr_train", 0.7222222222), ("mae_train", 0.2777777777)]
+        ),
+        test_metrics=OrderedDict(
+            [("ccr_test", 0.6666666666), ("mae_test", 0.3333333333)]
+        ),
+        train_predicted_y=np.array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3]),
+        test_predicted_y=np.array([1, 1, 2, 2, 2, 3, 3]),
+        estimator=estimator,
     )
-    test_metrics = OrderedDict([("ccr_test", 0.6666666666), ("mae_test", 0.3333333333)])
-
-    train_predicted_y = np.array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3])
-    test_predicted_y = np.array([1, 1, 2, 2, 2, 3, 3])
-
-    results.add_record(
-        partition,
-        best_params,
-        estimator,
-        {"dataset": dataset, "config": configuration},
-        {"train": train_metrics, "test": test_metrics},
-        {"train": train_predicted_y, "test": test_predicted_y},
-    )
+    results.save(result_0)
 
     # Saving second partition to DataFrame
-    partition = "1"
-    dataset = "toy"
-    configuration = "conf_1"
-
-    best_params = OrderedDict([("C", 1), ("gamma", 1)])
-
-    train_metrics = OrderedDict(
-        [("ccr_train", 0.9333333333), ("mae_train", 0.2777777777)]
+    result_1 = _make_result(
+        partition="1",
+        dataset="toy",
+        configuration="conf_1",
+        best_params=OrderedDict([("C", 1), ("gamma", 1)]),
+        train_metrics=OrderedDict(
+            [("ccr_train", 0.9333333333), ("mae_train", 0.2777777777)]
+        ),
+        test_metrics=OrderedDict([("ccr_test", 1.0), ("mae_test", 0.3333333333)]),
+        train_predicted_y=np.array([1, 1, 1, 1, 1, 2, 2, 3, 3, 2, 3, 3, 3, 3]),
+        test_predicted_y=np.array([1, 1, 2, 1, 2, 3, 3]),
+        estimator=estimator,
     )
-    test_metrics = OrderedDict([("ccr_test", 1.0), ("mae_test", 0.3333333333)])
-
-    train_predicted_y = np.array([1, 1, 1, 1, 1, 2, 2, 3, 3, 2, 3, 3, 3, 3])
-    test_predicted_y = np.array([1, 1, 2, 1, 2, 3, 3])
-
-    results.add_record(
-        partition,
-        best_params,
-        estimator,
-        {"dataset": dataset, "config": configuration},
-        {"train": train_metrics, "test": test_metrics},
-        {"train": train_predicted_y, "test": test_predicted_y},
-    )
+    results.save(result_1)
 
     # Saving first partition for a different configuration
-    partition = "0"
-    dataset = "toy"
-    configuration = "conf_2"
-
-    best_params = OrderedDict([("C", 1), ("gamma", 0.1)])
-
-    train_metrics = OrderedDict(
-        [("ccr_train", 0.8333333333), ("mae_train", 0.2777777777)]
+    result_conf2 = _make_result(
+        partition="0",
+        dataset="toy",
+        configuration="conf_2",
+        best_params=OrderedDict([("C", 1), ("gamma", 0.1)]),
+        train_metrics=OrderedDict(
+            [("ccr_train", 0.8333333333), ("mae_train", 0.2777777777)]
+        ),
+        test_metrics=OrderedDict([("ccr_test", 1.0), ("mae_test", 0.3333333333)]),
+        train_predicted_y=np.array([1, 1, 1, 1, 1, 2, 2, 3, 3, 2, 3, 3, 3, 3]),
+        test_predicted_y=np.array([1, 1, 2, 1, 2, 3, 3]),
+        estimator=estimator,
     )
-    test_metrics = OrderedDict([("ccr_test", 1.0), ("mae_test", 0.3333333333)])
-
-    train_predicted_y = np.array([1, 1, 1, 1, 1, 2, 2, 3, 3, 2, 3, 3, 3, 3])
-    test_predicted_y = np.array([1, 1, 2, 1, 2, 3, 3])
-
-    results.add_record(
-        partition,
-        best_params,
-        estimator,
-        {"dataset": dataset, "config": configuration},
-        {"train": train_metrics, "test": test_metrics},
-        {"train": train_predicted_y, "test": test_predicted_y},
-    )
+    results.save(result_conf2)
 
     # Checking if everything has been saved correctly
     experiment_folder = Path(results._experiment_folder)
@@ -190,40 +196,81 @@ def test_add_record(results):
     rmtree("my_runs/")
 
 
+def test_save_model_false(results):
+    """save_model=False must not create a models/ folder."""
+    result = _make_result(
+        partition="0",
+        dataset="toy",
+        configuration="conf_1",
+        best_params=OrderedDict([("C", 1)]),
+        train_metrics=OrderedDict([("ccr_train", 0.9)]),
+        test_metrics=OrderedDict([("ccr_test", 0.8)]),
+        train_predicted_y=np.array([1, 2, 3]),
+        test_predicted_y=np.array([1, 2]),
+    )
+    results.save(result, save_model=False)
+
+    folder = Path(results._experiment_folder) / "toy-conf_1"
+    assert not (folder / "models").exists()
+    assert (folder / "predictions").exists()
+
+    # Deleting temporary directories
+    rmtree("my_runs/")
+
+
+def test_save_proba(results):
+    """y_proba is persisted when provided."""
+    y_proba = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3]])
+    result = ExperimentResult(
+        dataset_name="toy",
+        classifier_name="conf_1",
+        resample_id="0",
+        train_predicted_y=np.array([1, 2]),
+        test_predicted_y=np.array([1, 2]),
+        y_proba=y_proba,
+        train_metrics=OrderedDict([("ccr_train", 0.9)]),
+        test_metrics=OrderedDict([("ccr_test", 0.8)]),
+        best_params={"C": 1},
+        best_model=SVC(),
+    )
+    results.save(result, save_model=False)
+
+    proba_path = (
+        Path(results._experiment_folder)
+        / "toy-conf_1"
+        / "predictions"
+        / "proba_toy-conf_1.0"
+    )
+    assert proba_path.exists()
+    loaded = np.loadtxt(proba_path)
+    npt.assert_allclose(loaded, y_proba)
+
+    # Deleting temporary directories
+    rmtree("my_runs/")
+
+
 def test_create_summary(results):
     """Tests create_summary method."""
-    dataset = "toy"
-    configuration = "conf_1"
-
-    best_params = OrderedDict([("C", 0.1), ("gamma", 1)])
     estimator = SVC()
 
-    train_metrics = OrderedDict(
-        [("ccr_train", 0.7222222222), ("mae_train", 0.2777777777)]
-    )
-    test_metrics = OrderedDict([("ccr_test", 0.6666666666), ("mae_test", 0.3333333333)])
-
-    train_predicted_y = np.array([1, 1, 1, 1, 1, 2, 2, 3, 3, 2, 3, 3, 3, 3])
-    test_predicted_y = np.array([1, 1, 2, 1, 2, 3, 3])
-
     # Adding two identical rows as two partitions
-    results.add_record(
-        "0",
-        best_params,
-        estimator,
-        {"dataset": dataset, "config": configuration},
-        {"train": train_metrics, "test": test_metrics},
-        {"train": train_predicted_y, "test": test_predicted_y},
-    )
-
-    results.add_record(
-        "1",
-        best_params,
-        estimator,
-        {"dataset": dataset, "config": configuration},
-        {"train": train_metrics, "test": test_metrics},
-        {"train": train_predicted_y, "test": test_predicted_y},
-    )
+    for partition in ("0", "1"):
+        result = _make_result(
+            partition=partition,
+            dataset="toy",
+            configuration="conf_1",
+            best_params=OrderedDict([("C", 0.1), ("gamma", 1)]),
+            train_metrics=OrderedDict(
+                [("ccr_train", 0.7222222222), ("mae_train", 0.2777777777)]
+            ),
+            test_metrics=OrderedDict(
+                [("ccr_test", 0.6666666666), ("mae_test", 0.3333333333)]
+            ),
+            train_predicted_y=np.array([1, 1, 1, 1, 1, 2, 2, 3, 3, 2, 3, 3, 3, 3]),
+            test_predicted_y=np.array([1, 1, 2, 1, 2, 3, 3]),
+            estimator=estimator,
+        )
+        results.save(result)
 
     mean_index = ["ccr_mean", "mae_mean"]
     std_index = ["ccr_std", "mae_std"]
@@ -246,7 +293,6 @@ def test_create_summary(results):
         ),
         index=["ccr_mean", "ccr_std", "mae_mean", "mae_std"],
     )
-
     desired_test_row = pd.Series(
         data=OrderedDict(
             [


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`Results.add_record()` took six positional arguments with nothing tying them together. This replaces it with `ExperimentResult`, a typed dataclass that holds all outputs from a single partition run, and `Results.save(result)` as the new entry point.

`ExperimentResult` is public and exported from `skordinal.experiments`. `save_model=False` skips pickling. `y_proba` is saved automatically when the estimator supports `predict_proba`.