### PR TITLE
REF: Replace general_conf dict with keyword params in Utilities

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,7 +18,18 @@ def main(general_conf, configurations):
             + "For more information about using this framework, please refer to the README."
         )
 
-    interface = Utilities(general_conf, configurations)
+    interface = Utilities(
+        configurations,
+        data_path=general_conf["basedir"],
+        datasets=general_conf["datasets"],
+        eval_metrics=general_conf["metrics"],
+        results_path=general_conf["output_folder"],
+        tuning_metric=general_conf.get("cv_metric", "neg_mean_absolute_error"),
+        cv=general_conf.get("hyperparam_cv_nfolds", 3),
+        n_jobs=general_conf.get("jobs", 1),
+        input_preprocessing=general_conf.get("input_preprocessing"),
+        random_state=general_conf.get("random_state"),
+    )
     interface.run_experiment()
     interface.write_report()
 

--- a/skordinal/experiments/_utilities.py
+++ b/skordinal/experiments/_utilities.py
@@ -29,69 +29,155 @@ def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) ->
 class Utilities:
     """Run experiments over N datasets with M different configurations.
 
-    Configurations are composed of a classifier method and different parameters, where
-    it may be multiple values for every one of them.
+    Configurations are composed of a classifier method and different parameters,
+    where it may be multiple values for every one of them.
 
-    Running the main function of this class will perform cross-validation for each
-    partition per dataset-configuration pairs, obtaining the most optimal model, after
-    what will be used to infer the labels for the test sets.
+    Running the main function of this class will perform cross-validation for
+    each partition per dataset-configuration pair, obtaining the most optimal
+    model, which is then used to infer labels for the test sets.
 
     Parameters
     ----------
-    general_conf : dict
-        Dictionary containing values needed to run the experiment. It gives this class
-        information about where are located the different datasets, which one are going
-        to be tested, the metrics to use, etc.
-
     configurations : dict
-        Dictionary in which are stated the different classifiers to build methods upon
-        the selected datasets, as well as the different values for the hyper-parameters
-        used to optimize the model during cross-validation phase.
+        Mapping of configuration labels to their settings. Each entry must have
+        the form ``{label: {"classifier": str, "parameters": dict}}``, where
+        ``"classifier"`` is the registered name of the classification algorithm
+        and ``"parameters"`` is a dictionary of hyper-parameter grids (lists of
+        values to search over) or fixed values.
 
-    verbose : bool
-        Variable used for testing purposes. Silences all prints.
+    data_path : str or Path
+        Base directory that contains one sub-folder per dataset.
+
+    datasets : list of str
+        Names of the dataset sub-folders to run. Pass ``["all"]`` to expand
+        automatically to every directory found under ``data_path``.
+
+    eval_metrics : list of str
+        Metric names to compute for every partition (e.g.
+        ``["mean_absolute_error", "average_mean_absolute_error"]``).
+        Names must be recognised by ``skordinal.metrics.get_ordinal_scorer``.
+
+    results_path : str or Path
+        Directory where result files are written.
+
+    tuning_metric : str, default="neg_mean_absolute_error"
+        Metric used as the cross-validation scoring criterion when selecting the
+        best hyper-parameter combination. Must be recognised by
+        ``skordinal.metrics.get_ordinal_scorer``; validation is deferred to
+        runtime.
+
+    cv : int, default=3
+        Number of folds used in hyper-parameter cross-validation.
+
+    n_jobs : int, default=1
+        Number of parallel jobs forwarded to ``GridSearchCV``.
+
+    input_preprocessing : {"std", "norm"} or None, default=None
+        Optional feature preprocessing applied to every partition before
+        fitting: ``"norm"`` applies min-max normalisation and ``"std"`` applies
+        z-score standardisation. Both scalers are fitted on the training split
+        only, then applied to both train and test splits. ``None`` means no
+        preprocessing.
+
+    random_state : int or None, default=None
+        Seed used for two sources of randomness: the base estimator and the
+        cross-validation splitter (``StratifiedKFold``) used during
+        hyper-parameter search. When ``None``, both use their own default
+        random behaviour.
+
+    verbose : bool, default=True
+        If ``True``, progress messages are printed to stdout.
 
     Attributes
     ----------
     _results : Results
-        Class used to manage and store all information obtained during the run of an
-        experiment.
+        Manages and stores all information obtained during the experiment run.
+
+    Examples
+    --------
+    >>> from skordinal.experiments import Utilities  # doctest: +SKIP
+    >>> u = Utilities(  # doctest: +SKIP
+    ...     configurations={"SVM": {"classifier": "svc", "parameters": {"C": [1]}}},
+    ...     data_path="/data/ordinal",
+    ...     datasets=["balance-scale"],
+    ...     eval_metrics=["mean_absolute_error"],
+    ...     results_path="/tmp/results",
+    ... )
+    >>> u.run_experiment()  # doctest: +SKIP
 
     """
 
     def __init__(
         self,
-        general_conf: dict[str, Any],
         configurations: dict[str, Any],
+        *,
+        data_path: str | Path,
+        datasets: list[str],
+        eval_metrics: list[str],
+        results_path: str | Path,
+        tuning_metric: str = "neg_mean_absolute_error",
+        cv: int = 3,
+        n_jobs: int = 1,
+        input_preprocessing: str | None = None,
+        random_state: int | None = None,
         verbose: bool = True,
     ) -> None:
-        self.general_conf = deepcopy(general_conf)
+        if not configurations:
+            raise ValueError(
+                "'configurations' must be a non-empty dict; got an empty mapping."
+            )
+        if not datasets:
+            raise ValueError(
+                "'datasets' must be a non-empty list; got an empty sequence."
+            )
+        if not eval_metrics:
+            raise ValueError(
+                "'eval_metrics' must be a non-empty list; got an empty sequence."
+            )
+
+        _allowed_preproc = {"std", "norm"}
+        if input_preprocessing is not None:
+            _normalized = str(input_preprocessing).strip().lower()
+            if _normalized not in _allowed_preproc:
+                raise ValueError(
+                    f"'input_preprocessing' must be one of {None, 'std', 'norm'}; "
+                    f"got '{input_preprocessing}'."
+                )
+            input_preprocessing = _normalized
+
         self.configurations = deepcopy(configurations)
+        self.data_path: str | Path = data_path
+        self.datasets: list[str] = list(datasets)
+        self.eval_metrics: list[str] = list(eval_metrics)
+        self.results_path: str | Path = results_path
+        self.tuning_metric = tuning_metric
+        self.cv = cv
+        self.n_jobs = n_jobs
+        self.input_preprocessing = input_preprocessing
+        self.random_state = random_state
         self.verbose = verbose
 
     def run_experiment(self) -> None:
         """Run an experiment. Main method of this framework.
 
-        Loads all datasets, which can be fragmented in partitions. Builds a model per
-        partition, using cross-validation to find the optimal values among the
+        Loads all datasets, which can be fragmented in partitions. Builds a model
+        per partition, using cross-validation to find the optimal values among the
         hyper-parameters to compare from.
 
-        Uses the built model to get train and test metrics, storing all the information
-        into a Results object.
+        Uses the built model to get train and test metrics, storing all the
+        information into a Results object.
 
         Raises
         ------
         ValueError
-            If the dataset list is inconsistent.
+            If the dataset list is inconsistent, or a dataset path does not
+            exist.
 
-        AttributeError
-            If the input preprocessing is unknown.
-
-        TypeError
-            If the parameters for base_classifier must be list.
+        RuntimeError
+            If a partition is found without its train file.
 
         """
-        self._results = Results(Path(self.general_conf["output_folder"]))
+        self._results = Results(Path(self.results_path))
 
         self._check_dataset_list()
 
@@ -101,9 +187,9 @@ class Utilities:
             print("###############################")
 
         # Iterating over Datasets
-        for x in self.general_conf["datasets"]:
+        for x in self.datasets:
             dataset_name = x.strip()
-            dataset_path = Path(self.general_conf["basedir"]) / dataset_name
+            dataset_path = Path(self.data_path) / dataset_name
 
             dataset = self._load_dataset(dataset_path)
 
@@ -121,25 +207,18 @@ class Utilities:
                     if self.verbose:
                         print("  Running Partition", part_idx)
 
-                    # Normalization or Standardization of the partition if requested
-                    _preproc = (
-                        self.general_conf.get("input_preprocessing", "").strip().lower()
-                    )
-                    if _preproc == "norm":
+                    # Normalisation or standardisation of the partition if requested
+                    if self.input_preprocessing == "norm":
                         partition["train_inputs"], partition["test_inputs"] = (
                             self._normalize_data(
                                 partition["train_inputs"], partition["test_inputs"]
                             )
                         )
-                    elif _preproc == "std":
+                    elif self.input_preprocessing == "std":
                         partition["train_inputs"], partition["test_inputs"] = (
                             self._standardize_data(
                                 partition["train_inputs"], partition["test_inputs"]
                             )
-                        )
-                    elif _preproc != "":
-                        raise AttributeError(
-                            "Input preprocessing named '%s' unknown" % _preproc
                         )
 
                     optimal_estimator = self._get_optimal_estimator(
@@ -166,7 +245,7 @@ class Utilities:
                     # Obtaining train and test metrics values.
                     train_metrics = OrderedDict()
                     test_metrics = OrderedDict()
-                    for metric_name in self.general_conf["metrics"]:
+                    for metric_name in self.eval_metrics:
                         # Get train scores
                         train_score = _compute_metric(
                             metric_name,
@@ -241,8 +320,9 @@ class Utilities:
         Returns
         -------
         partition_list : list of tuples
-            List of partitions found inside a dataset folder. Each partition is stored
-            into a dictionary, disjoining train and test inputs and outputs.
+            List of partitions found inside a dataset folder. Each partition is
+            stored into a dictionary, disjoining train and test inputs and
+            outputs.
 
         Raises
         ------
@@ -333,12 +413,13 @@ class Utilities:
             If the dataset list is inconsistent or contains non-string values.
 
         """
-        base_path = Path(self.general_conf["basedir"])
-        dataset_list = self.general_conf["datasets"]
+        base_path = Path(self.data_path)
 
         # Check if home path is shortened
         if str(base_path).startswith("~"):
             base_path = Path.home() / str(base_path)[1:]
+
+        dataset_list = self.datasets
 
         # Check if 'all' is the only value, and if it is, expand it
         if len(dataset_list) == 1 and dataset_list[0] == "all":
@@ -347,8 +428,8 @@ class Utilities:
         elif not all(isinstance(item, str) for item in dataset_list):
             raise ValueError("Dataset list can only contain strings")
 
-        self.general_conf["basedir"] = str(base_path)
-        self.general_conf["datasets"] = dataset_list
+        self.data_path = str(base_path)
+        self.datasets = dataset_list
 
     def _normalize_data(
         self, train_data: np.ndarray, test_data: np.ndarray
@@ -416,12 +497,12 @@ class Utilities:
         """Perform cross-validation over one dataset and configuration.
 
         Each configuration consists of one classifier and none, one or multiple
-        hyper-parameters, that, in turn, can contain one or multiple values used to
-        optimize the resulting model.
+        hyper-parameters, that, in turn, can contain one or multiple values used
+        to optimize the resulting model.
 
-        At the end of cross-validation phase, the model with the specific combination of
-        values from the hyper-parameters that achieved the best metrics from all the
-        combinations will remain.
+        At the end of cross-validation phase, the model with the specific
+        combination of values from the hyper-parameters that achieved the best
+        metrics from all the combinations will remain.
 
         Parameters
         ----------
@@ -435,28 +516,28 @@ class Utilities:
             Name of the classification algorithm being employed.
 
         parameters : dict
-            Dictionary containing parameters to optimize as keys, and the list of
-            values that we want to compare as values.
+            Dictionary containing parameters to optimize as keys, and the list
+            of values that we want to compare as values.
 
         Returns
         -------
-        optimal: GridSearchCV object or classifier object
+        optimal : GridSearchCV object or classifier object
             An already fitted model of the given classifier, with the best found
-            parameters after cross-validation. If cross-validation is not needed, it will
-            return the classifier model already trained.
+            parameters after cross-validation. If cross-validation is not needed,
+            it will return the classifier model already trained.
 
         Raises
         ------
-        AttributeError
-            If the metric name is not found or cv_metric is not a string.
+        ValueError
+            If the classifier name is unknown or a hyper-parameter is invalid.
 
         """
         estimator = load_classifier(
             classifier_name=classifier_name,
-            random_state=int(cast(tuple, np.random.get_state())[1][0]),
-            n_jobs=self.general_conf.get("jobs", 1),
-            cv_n_folds=self.general_conf.get("hyperparam_cv_nfolds", 3),
-            cv_metric=self.general_conf.get("cv_metric", "mae"),
+            random_state=self.random_state,
+            n_jobs=self.n_jobs,
+            cv_n_folds=self.cv,
+            cv_metric=self.tuning_metric,
             param_grid=parameters,
         )
 

--- a/skordinal/experiments/tests/test_utilities.py
+++ b/skordinal/experiments/tests/test_utilities.py
@@ -10,12 +10,23 @@ import pytest
 from skordinal.experiments import Utilities
 from skordinal.utils._testing import make_balance_scale_split
 
+_MINIMAL_CONF = {"cfg": {"classifier": "SVC", "parameters": {}}}
 
-@pytest.fixture
-def util():
-    general_conf = {}
-    configurations = {}
-    return Utilities(general_conf, configurations)
+
+def _minimal_util(results_path: Path) -> Utilities:
+    """Return a Utilities instance with stub args sufficient to pass validation.
+
+    Used by tests that only exercise helper methods (_load_dataset,
+    _read_file, _normalize_data, _standardize_data) and therefore do not
+    need real dataset paths or metric names beyond the minimum to construct.
+    """
+    return Utilities(
+        _MINIMAL_CONF,
+        data_path=".",
+        datasets=["x"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=str(results_path),
+    )
 
 
 def create_csv(path, filename):
@@ -31,6 +42,31 @@ def _write_partition_csv(directory, filename, n_per_class=10):
     labels = np.repeat([0, 1, 2], n_per_class).reshape(-1, 1)
     data = np.hstack([features, labels])
     np.savetxt(directory / filename, data, delimiter=",", fmt="%d")
+
+
+def _from_general_conf(general_conf: dict, configurations: dict, **kwargs) -> Utilities:
+    """Construct Utilities from an old-style ``general_conf`` dict.
+
+    Keeps test call-sites readable without duplicating the key mapping.
+    """
+    return Utilities(
+        configurations,
+        data_path=general_conf["basedir"],
+        datasets=general_conf["datasets"],
+        eval_metrics=general_conf["metrics"],
+        results_path=general_conf["output_folder"],
+        tuning_metric=general_conf.get("cv_metric", "neg_mean_absolute_error"),
+        cv=general_conf.get("hyperparam_cv_nfolds", 3),
+        n_jobs=general_conf.get("jobs", 1),
+        input_preprocessing=general_conf.get("input_preprocessing"),
+        **kwargs,
+    )
+
+
+@pytest.fixture
+def util(tmp_path):
+    """Minimal valid Utilities instance for testing internal helper methods."""
+    return _minimal_util(tmp_path)
 
 
 @pytest.fixture
@@ -73,10 +109,8 @@ def svm_conf():
 
 
 def test_run_experiment(tmp_path, experiment_conf, svm_conf):
-    """End-to-end test: run_experiment and write_report complete without error
-    and produce the expected output structure and metrics files.
-    """
-    util = Utilities(experiment_conf, svm_conf, verbose=False)
+    """run_experiment and write_report produce the expected on-disk layout."""
+    util = _from_general_conf(experiment_conf, svm_conf, verbose=False)
     util.run_experiment()
     util.write_report()
 
@@ -86,38 +120,26 @@ def test_run_experiment(tmp_path, experiment_conf, svm_conf):
     svm_dir = runs_dir / "SVM" / "balance"
     assert svm_dir.exists()
 
-    metrics_csv = svm_dir / "report.csv"
-    df = pd.read_csv(metrics_csv, index_col=0)
-    npt.assert_equal(df.shape[0], 2)
-    npt.assert_equal(df.shape[1], 12)
-    npt.assert_equal(all(df[c].dtype == np.float64 for c in df.columns), True)
+    df = pd.read_csv(svm_dir / "report.csv", index_col=0)
+    assert df.shape == (2, 12)
+    assert all(df[c].dtype == np.float64 for c in df.columns)
 
-    models = list((svm_dir / "models").iterdir())
-    npt.assert_equal(len(models), 2)
-
-    predictions = list((svm_dir / "predictions").iterdir())
-    npt.assert_equal(len(predictions), 4)
+    assert len(list((svm_dir / "models").iterdir())) == 2
+    assert len(list((svm_dir / "predictions").iterdir())) == 4
 
     train_summary = pd.read_csv(runs_dir / "train_summary.csv")
-    npt.assert_equal(train_summary.shape, (1, 15))
-    npt.assert_equal(
-        all(train_summary[c].dtype == np.float64 for c in train_summary.columns[2:-1]),
-        True,
+    assert train_summary.shape == (1, 15)
+    assert all(
+        train_summary[c].dtype == np.float64 for c in train_summary.columns[2:-1]
     )
 
     test_summary = pd.read_csv(runs_dir / "test_summary.csv")
-    npt.assert_equal(test_summary.shape, (1, 15))
-    npt.assert_equal(
-        all(test_summary[c].dtype == np.float64 for c in test_summary.columns[2:-1]),
-        True,
-    )
+    assert test_summary.shape == (1, 15)
+    assert all(test_summary[c].dtype == np.float64 for c in test_summary.columns[2:-1])
 
 
 def test_load_complete_dataset(tmp_path, util):
-    """Loading dataset composed of 5 partitions, each one of them composed of
-    a train and test file.
-
-    """
+    """Load a dataset of 5 partitions, each with a train and a test file."""
     dataset_path = tmp_path / "complete"
     dataset_path.mkdir()
 
@@ -127,16 +149,13 @@ def test_load_complete_dataset(tmp_path, util):
 
     partition_list = util._load_dataset(dataset_path)
 
-    # Check all partitions have been loaded
-    npt.assert_equal(len(partition_list), (len(list(dataset_path.iterdir())) / 2))
-    # Check if every partition has train and test inputs and outputs (4 diferent dictionaries)
-    npt.assert_equal(
-        all([len(partition[1]) == 4 for partition in partition_list]), True
-    )
+    # Every partition holds train and test inputs and outputs (4 entries).
+    assert len(partition_list) == len(list(dataset_path.iterdir())) / 2
+    assert all(len(partition[1]) == 4 for partition in partition_list)
 
 
 def test_load_partitionless_dataset(tmp_path, util):
-    """Loading dataset composed of only two csv files (train and test files)"""
+    """Load a dataset of a single train and test file."""
     dataset_path = tmp_path / "partitionless"
     dataset_path.mkdir()
 
@@ -145,14 +164,12 @@ def test_load_partitionless_dataset(tmp_path, util):
 
     partition_list = util._load_dataset(dataset_path)
 
-    npt.assert_equal(len(partition_list), 1)
-    npt.assert_equal(
-        all([len(partition[1]) == 4 for partition in partition_list]), True
-    )
+    assert len(partition_list) == 1
+    assert all(len(partition[1]) == 4 for partition in partition_list)
 
 
 def test_load_nontestfile_dataset(tmp_path, util):
-    """Loading dataset composed of five train files."""
+    """Load a dataset of five train files with no test files."""
     dataset_path = tmp_path / "nontestfile"
     dataset_path.mkdir()
 
@@ -161,17 +178,12 @@ def test_load_nontestfile_dataset(tmp_path, util):
 
     partition_list = util._load_dataset(dataset_path)
 
-    npt.assert_equal(len(partition_list), len(list(dataset_path.iterdir())))
-    npt.assert_equal(
-        all([len(partition[1]) == 2 for partition in partition_list]), True
-    )
+    assert len(partition_list) == len(list(dataset_path.iterdir()))
+    assert all(len(partition[1]) == 2 for partition in partition_list)
 
 
 def test_load_nontrainfile_dataset(tmp_path, util):
-    """Loading dataset with 2 partitions, one of them lacking its train file.
-    This should raise an exception.
-
-    """
+    """A partition lacking its train file raises RuntimeError."""
     dataset_path = tmp_path / "nontrainfile"
     dataset_path.mkdir()
 
@@ -182,25 +194,134 @@ def test_load_nontrainfile_dataset(tmp_path, util):
         util._load_dataset(dataset_path)
 
 
-def test_normalize_data(tmp_path, util):
-    # Test preparation
+def test_normalize_data(util):
+    """Min-max normalisation maps training features into [0, 1]."""
     X_train, X_test, _, _ = make_balance_scale_split()
 
-    # Test execution
     norm_X_train, _ = util._normalize_data(X_train, X_test)
 
-    # Test verification
-    result = (norm_X_train >= 0).all() and (norm_X_train <= 1).all()
-    npt.assert_equal(result, True)
+    assert (norm_X_train >= 0).all()
+    assert (norm_X_train <= 1).all()
 
 
 def test_standardize_data(util):
-    # Test preparation
+    """Standardisation gives training features zero mean and unit variance."""
     X_train, X_test, _, _ = make_balance_scale_split()
 
-    # Test execution
     std_X_train, _ = util._standardize_data(X_train, X_test)
 
-    # Test verification
     npt.assert_almost_equal(np.mean(std_X_train), 0)
     npt.assert_almost_equal(np.std(std_X_train), 1)
+
+
+def test_empty_configurations_raises(tmp_path):
+    """An empty configurations dict raises ValueError."""
+    with pytest.raises(ValueError, match="'configurations' must be a non-empty dict"):
+        Utilities(
+            {},
+            data_path=".",
+            datasets=["x"],
+            eval_metrics=["mean_absolute_error"],
+            results_path=str(tmp_path),
+        )
+
+
+def test_none_configurations_raises(tmp_path):
+    """None configurations is rejected by the non-empty check (ValueError)."""
+    with pytest.raises(ValueError, match="'configurations' must be a non-empty dict"):
+        Utilities(
+            None,  # type: ignore[arg-type]
+            data_path=".",
+            datasets=["x"],
+            eval_metrics=["mean_absolute_error"],
+            results_path=str(tmp_path),
+        )
+
+
+def test_empty_datasets_raises(tmp_path):
+    """An empty datasets list raises ValueError."""
+    with pytest.raises(ValueError, match="'datasets' must be a non-empty list"):
+        Utilities(
+            _MINIMAL_CONF,
+            data_path=".",
+            datasets=[],
+            eval_metrics=["mean_absolute_error"],
+            results_path=str(tmp_path),
+        )
+
+
+def test_empty_eval_metrics_raises(tmp_path):
+    """An empty eval_metrics list raises ValueError."""
+    with pytest.raises(ValueError, match="'eval_metrics' must be a non-empty list"):
+        Utilities(
+            _MINIMAL_CONF,
+            data_path=".",
+            datasets=["x"],
+            eval_metrics=[],
+            results_path=str(tmp_path),
+        )
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, None),
+        ("std", "std"),
+        ("norm", "norm"),
+        (" STD ", "std"),
+        ("NORM", "norm"),
+    ],
+)
+def test_input_preprocessing_accepted_and_normalized(tmp_path, raw, expected):
+    """Valid input_preprocessing values are accepted and lower-stripped."""
+    util = Utilities(
+        _MINIMAL_CONF,
+        data_path=".",
+        datasets=["x"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=str(tmp_path),
+        input_preprocessing=raw,
+    )
+    assert util.input_preprocessing == expected
+
+
+@pytest.mark.parametrize("bad_value", ["minmax", ""])
+def test_input_preprocessing_invalid_raises(tmp_path, bad_value):
+    """Unrecognised input_preprocessing values raise ValueError."""
+    with pytest.raises(ValueError, match="'input_preprocessing' must be one of"):
+        Utilities(
+            _MINIMAL_CONF,
+            data_path=".",
+            datasets=["x"],
+            eval_metrics=["mean_absolute_error"],
+            results_path=str(tmp_path),
+            input_preprocessing=bad_value,
+        )
+
+
+@pytest.mark.parametrize("kwargs, expected", [({}, None), ({"random_state": 42}, 42)])
+def test_random_state_stored(tmp_path, kwargs, expected):
+    """random_state defaults to None and is stored as given on the instance."""
+    util = Utilities(
+        _MINIMAL_CONF,
+        data_path=".",
+        datasets=["x"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=str(tmp_path),
+        **kwargs,
+    )
+    assert util.random_state == expected
+
+
+def test_configurations_is_deep_copied(tmp_path):
+    """Mutating the original configurations dict does not affect the stored copy."""
+    original = {"cfg": {"classifier": "SVC", "parameters": {"C": [1]}}}
+    util = Utilities(
+        original,
+        data_path=".",
+        datasets=["x"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=str(tmp_path),
+    )
+    original["cfg"]["parameters"]["C"].append(10)
+    assert util.configurations["cfg"]["parameters"]["C"] == [1]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Replaces the `general_conf` dictionary with explicit keyword arguments (`data_path`, `datasets`, `eval_metrics`, `results_path` and the rest). Also fixes the cross-validation seed, which was read from NumPy's global RNG state. It now comes from an explicit `random_state`, so a run can be reproduced.

The JSON config format stays the same. The CLI unpacks it into the new arguments, so existing recipes keep working.