### PR TITLE
REF: Reshape Utilities around a single-experiment runner

### DIFF
--- a/skordinal/experiments/_utilities.py
+++ b/skordinal/experiments/_utilities.py
@@ -25,6 +25,93 @@ def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) ->
     return scorer._score_func(y_true, y_pred, **scorer._kwargs)
 
 
+def _read_file(filename: Path) -> tuple[np.ndarray, np.ndarray]:
+    """Read a CSV partition file into ``(inputs, outputs)`` arrays."""
+    # Detect the separator automatically.
+    f = pd.read_csv(filename, header=None, engine="python")
+
+    inputs = f.values[:, 0:(-1)]
+    outputs = f.values[:, (-1)]
+
+    return inputs, outputs
+
+
+def _check_dataset_list(
+    data_path: str | Path, datasets: list[str]
+) -> tuple[str | Path, list[str]]:
+    """Resolve a dataset list, expanding ``["all"]`` and validating entries.
+
+    Expands a home-shorthand ``data_path`` and raises ``ValueError`` if the
+    list contains non-string entries.
+    """
+    base_path = Path(data_path)
+
+    # Check if home path is shortened
+    if str(base_path).startswith("~"):
+        base_path = Path.home() / str(base_path)[1:]
+
+    dataset_list = datasets
+
+    # Check if 'all' is the only value, and if it is, expand it
+    if len(dataset_list) == 1 and dataset_list[0] == "all":
+        dataset_list = [item.name for item in base_path.iterdir() if item.is_dir()]
+
+    elif not all(isinstance(item, str) for item in dataset_list):
+        raise ValueError("Dataset list can only contain strings")
+
+    return str(base_path), dataset_list
+
+
+def _load_dataset(dataset_path: Path) -> list[tuple[str, dict[str, Any]]]:
+    """Load a dataset folder into a sorted list of ``(index, partition)`` tuples.
+
+    Each partition dict disjoins train/test inputs and outputs. Raises
+    ``ValueError`` if the folder is missing and ``RuntimeError`` if a partition
+    has no train file.
+    """
+
+    def get_partition_index(filename: str) -> str:
+        # Extract the index between the last "_" and ".csv".
+        return filename.rsplit("_", 1)[-1].replace(".csv", "")
+
+    try:
+        partition_list: dict[str, dict[str, Any]] = {
+            get_partition_index(filename.name): {}
+            for filename in dataset_path.iterdir()
+            if filename.name.startswith("train_")
+        }
+
+        # Load train and test arrays for each partition.
+        for filename in dataset_path.iterdir():
+            if filename.name.startswith("train_"):
+                idx = get_partition_index(filename.name)
+                train_inputs, train_outputs = _read_file(filename)
+                partition_list[idx]["train_inputs"] = train_inputs
+                partition_list[idx]["train_outputs"] = train_outputs
+
+            elif filename.name.startswith("test_"):
+                idx = get_partition_index(filename.name)
+                test_inputs, test_outputs = _read_file(filename)
+                partition_list[idx]["test_inputs"] = test_inputs
+                partition_list[idx]["test_outputs"] = test_outputs
+
+    except OSError:
+        raise ValueError(f"No such file or directory: '{dataset_path}'")
+
+    except KeyError:
+        raise RuntimeError(
+            f"Found partition without train files: partition {filename.name}"
+        )
+
+    # Sort partitions into a list of (index, partition) tuples.
+    sorted_list: list[tuple[str, dict[str, Any]]] = sorted(
+        partition_list.items(),
+        key=lambda t: int(t[0]) if t[0].lstrip("-").isdigit() else t[0],
+    )
+
+    return sorted_list
+
+
 class Utilities:
     """Run experiments over N datasets with M different configurations.
 
@@ -178,7 +265,9 @@ class Utilities:
         """
         self._results = Results(Path(self.results_path))
 
-        self._check_dataset_list()
+        self.data_path, self.datasets = _check_dataset_list(
+            self.data_path, self.datasets
+        )
 
         if self.verbose:
             print("\n###############################")
@@ -190,7 +279,7 @@ class Utilities:
             dataset_name = x.strip()
             dataset_path = Path(self.data_path) / dataset_name
 
-            dataset = self._load_dataset(dataset_path)
+            dataset = _load_dataset(dataset_path)
 
             if self.verbose:
                 print("\nRunning", dataset_name, "dataset")
@@ -378,128 +467,6 @@ class Utilities:
             train_true_y=y_train,
             test_true_y=y_test,
         )
-
-    def _load_dataset(self, dataset_path: Path) -> list[tuple[str, dict[str, Any]]]:
-        """Load all dataset's files, divided into train and test.
-
-        Parameters
-        ----------
-        dataset_path : Path
-            Path to dataset folder.
-
-        Returns
-        -------
-        partition_list : list of tuples
-            List of partitions found inside a dataset folder. Each partition is
-            stored into a dictionary, disjoining train and test inputs and
-            outputs.
-
-        Raises
-        ------
-        ValueError
-            If the dataset path does not exist.
-
-        RuntimeError
-            If a partition is found without train files.
-
-        """
-
-        def get_partition_index(filename: str) -> str:
-            # Extracts the index between the last "_" and ".csv"
-            return filename.rsplit("_", 1)[-1].replace(".csv", "")
-
-        try:
-            partition_list: dict[str, dict[str, Any]] = {
-                get_partition_index(filename.name): {}
-                for filename in dataset_path.iterdir()
-                if filename.name.startswith("train_")
-            }
-
-            # Loading each dataset
-            for filename in dataset_path.iterdir():
-                if filename.name.startswith("train_"):
-                    idx = get_partition_index(filename.name)
-                    train_inputs, train_outputs = self._read_file(filename)
-                    partition_list[idx]["train_inputs"] = train_inputs
-                    partition_list[idx]["train_outputs"] = train_outputs
-
-                elif filename.name.startswith("test_"):
-                    idx = get_partition_index(filename.name)
-                    test_inputs, test_outputs = self._read_file(filename)
-                    partition_list[idx]["test_inputs"] = test_inputs
-                    partition_list[idx]["test_outputs"] = test_outputs
-
-        except OSError:
-            raise ValueError(f"No such file or directory: '{dataset_path}'")
-
-        except KeyError:
-            raise RuntimeError(
-                f"Found partition without train files: partition {filename.name}"
-            )
-
-        # Saving partitions as a sorted list of (index, partition) tuples
-        sorted_list: list[tuple[str, dict[str, Any]]] = sorted(
-            partition_list.items(),
-            key=lambda t: int(t[0]) if t[0].lstrip("-").isdigit() else t[0],
-        )
-
-        return sorted_list
-
-    def _read_file(self, filename: Path) -> tuple[np.ndarray, np.ndarray]:
-        """Read a CSV containing partitions, or full datasets.
-
-        Train and test files must be previously divided for the experiment to run.
-
-        Parameters
-        ----------
-        filename : str or Path
-            Full path to train or test file.
-
-        Returns
-        -------
-        inputs : {array-like, sparse-matrix} of shape (n_samples, n_features)
-            Vector of sample's features.
-
-        outputs : array-like of shape (n_samples)
-            Target vector relative to inputs.
-
-        """
-        # Separator is automatically found
-        f = pd.read_csv(filename, header=None, engine="python")
-
-        inputs = f.values[:, 0:(-1)]
-        outputs = f.values[:, (-1)]
-
-        return inputs, outputs
-
-    def _check_dataset_list(self) -> None:
-        """Check if there is some inconsistency in the dataset list.
-
-        It also simplifies running all datasets inside one folder.
-
-        Raises
-        ------
-        ValueError
-            If the dataset list is inconsistent or contains non-string values.
-
-        """
-        base_path = Path(self.data_path)
-
-        # Check if home path is shortened
-        if str(base_path).startswith("~"):
-            base_path = Path.home() / str(base_path)[1:]
-
-        dataset_list = self.datasets
-
-        # Check if 'all' is the only value, and if it is, expand it
-        if len(dataset_list) == 1 and dataset_list[0] == "all":
-            dataset_list = [item.name for item in base_path.iterdir() if item.is_dir()]
-
-        elif not all(isinstance(item, str) for item in dataset_list):
-            raise ValueError("Dataset list can only contain strings")
-
-        self.data_path = str(base_path)
-        self.datasets = dataset_list
 
     def write_report(self) -> None:
         """Save summarized information about experiment through Results class."""

--- a/skordinal/experiments/_utilities.py
+++ b/skordinal/experiments/_utilities.py
@@ -11,7 +11,6 @@ from typing import Any, cast
 import numpy as np
 import pandas as pd
 from sklearn import preprocessing
-from sklearn.base import BaseEstimator
 from sklearn.model_selection import GridSearchCV
 
 from skordinal.model_selection import load_classifier
@@ -186,7 +185,7 @@ class Utilities:
             print("\tRunning Experiment")
             print("###############################")
 
-        # Iterating over Datasets
+        # Iterate over datasets.
         for x in self.datasets:
             dataset_name = x.strip()
             dataset_path = Path(self.data_path) / dataset_name
@@ -197,117 +196,188 @@ class Utilities:
                 print("\nRunning", dataset_name, "dataset")
                 print("--------------------------")
 
-            # Iterating over Configurations
+            # Iterate over configurations.
             for conf_name, configuration in self.configurations.items():
                 if self.verbose:
                     print("Running", conf_name, "...")
 
-                # Iterating over partitions
+                # Iterate over partitions.
                 for part_idx, partition in dataset:
                     if self.verbose:
                         print("  Running Partition", part_idx)
 
-                    # Normalisation or standardisation of the partition if requested
-                    if self.input_preprocessing == "norm":
-                        partition["train_inputs"], partition["test_inputs"] = (
-                            self._normalize_data(
-                                partition["train_inputs"], partition["test_inputs"]
-                            )
-                        )
-                    elif self.input_preprocessing == "std":
-                        partition["train_inputs"], partition["test_inputs"] = (
-                            self._standardize_data(
-                                partition["train_inputs"], partition["test_inputs"]
-                            )
-                        )
-
-                    optimal_estimator = self._get_optimal_estimator(
+                    result = self._run_single(
                         partition["train_inputs"],
                         partition["train_outputs"],
-                        configuration["classifier"],
-                        configuration["parameters"],
+                        partition.get("test_inputs"),
+                        partition.get("test_outputs"),
+                        configuration,
+                        dataset_name=dataset_name,
+                        conf_name=conf_name,
+                        resample_id=part_idx,
                     )
+                    self._results.save(result)
 
-                    # Getting train and test predictions
-                    train_predicted_y = optimal_estimator.predict(
-                        partition["train_inputs"]
-                    )
+    def _run_single(
+        self,
+        X_train: np.ndarray,
+        y_train: np.ndarray,
+        X_test: np.ndarray | None,
+        y_test: np.ndarray | None,
+        configuration: dict[str, Any],
+        *,
+        dataset_name: str,
+        conf_name: str,
+        resample_id: str,
+    ) -> ExperimentResult:
+        """Run one classifier configuration on a single train/test partition.
 
-                    test_predicted_y = None
-                    elapsed = np.nan
-                    if "test_outputs" in partition:
-                        start = time()
-                        test_predicted_y = np.asarray(
-                            optimal_estimator.predict(partition["test_inputs"])
-                        )
-                        elapsed = time() - start
+        This is the single-partition execution unit. It applies optional
+        preprocessing, selects and fits the best estimator, predicts on train
+        and (when present) test splits, computes all evaluation metrics and
+        timing keys, and returns an :class:`ExperimentResult`. It does **not**
+        persist anything to disk; the caller is responsible for calling
+        ``self._results.save(result)`` after this method returns.
 
-                    # Obtaining train and test metrics values.
-                    train_metrics = OrderedDict()
-                    test_metrics = OrderedDict()
-                    for metric_name in self.eval_metrics:
-                        # Get train scores
-                        train_score = _compute_metric(
-                            metric_name,
-                            partition["train_outputs"],
-                            train_predicted_y,
-                        )
-                        train_metrics[metric_name.strip() + "_train"] = train_score
+        Parameters
+        ----------
+        X_train : ndarray of shape (n_train_samples, n_features)
+            Training feature matrix.
 
-                        # Get test scores
-                        test_metrics[metric_name.strip() + "_test"] = np.nan
-                        if "test_outputs" in partition:
-                            assert test_predicted_y is not None
-                            test_score = _compute_metric(
-                                metric_name, partition["test_outputs"], test_predicted_y
-                            )
-                            test_metrics[metric_name.strip() + "_test"] = test_score
+        y_train : ndarray of shape (n_train_samples,)
+            Training labels.
 
-                    # Cross-validation was performed to tune hyper-parameters
-                    if isinstance(optimal_estimator, GridSearchCV):
-                        train_metrics["cv_time_train"] = optimal_estimator.cv_results_[
-                            "mean_fit_time"
-                        ].mean()
-                        test_metrics["cv_time_test"] = optimal_estimator.cv_results_[
-                            "mean_score_time"
-                        ].mean()
-                        train_metrics["time_train"] = optimal_estimator.refit_time_
-                        test_metrics["time_test"] = elapsed
+        X_test : ndarray of shape (n_test_samples, n_features) or None
+            Test feature matrix. When ``None`` no test metrics are computed.
 
-                    else:
-                        optimal_estimator.best_params_ = configuration["parameters"]
-                        optimal_estimator.best_estimator_ = optimal_estimator
+        y_test : ndarray of shape (n_test_samples,) or None
+            Test labels. When ``None`` no test metrics are computed.
 
-                        train_metrics["cv_time_train"] = np.nan
-                        test_metrics["cv_time_test"] = np.nan
-                        train_metrics["time_train"] = optimal_estimator.refit_time_
-                        test_metrics["time_test"] = elapsed
+        configuration : dict
+            Single configuration entry with the form
+            ``{"classifier": str, "parameters": dict}``.
 
-                    y_proba = None
-                    if "test_outputs" in partition and hasattr(
-                        optimal_estimator.best_estimator_, "predict_proba"
-                    ):
-                        y_proba = optimal_estimator.best_estimator_.predict_proba(
-                            partition["test_inputs"]
-                        )
+        dataset_name : str
+            Name of the dataset, forwarded to the returned
+            :class:`ExperimentResult`.
 
-                    # Saving the results for this partition
-                    self._results.save(
-                        ExperimentResult(
-                            dataset_name=dataset_name,
-                            classifier_name=conf_name,
-                            resample_id=part_idx,
-                            train_predicted_y=train_predicted_y,
-                            test_predicted_y=test_predicted_y,
-                            y_proba=y_proba,
-                            train_metrics=train_metrics,
-                            test_metrics=test_metrics,
-                            best_params=optimal_estimator.best_params_,
-                            best_model=optimal_estimator.best_estimator_,
-                            train_true_y=partition["train_outputs"],
-                            test_true_y=partition.get("test_outputs"),
-                        )
-                    )
+        conf_name : str
+            Configuration label, used as ``classifier_name`` in the returned
+            :class:`ExperimentResult`.
+
+        resample_id : str
+            Partition index string, forwarded to the returned
+            :class:`ExperimentResult`.
+
+        Returns
+        -------
+        ExperimentResult
+            Fully populated result for this partition. No side effects.
+
+        """
+        # Apply preprocessing on local copies so the caller's arrays are not mutated.
+        train_inputs: np.ndarray = X_train
+        test_inputs: np.ndarray | None = X_test
+
+        if self.input_preprocessing == "norm":
+            scaler = preprocessing.MinMaxScaler().fit(train_inputs)
+            train_inputs = scaler.transform(train_inputs)
+            test_inputs = scaler.transform(cast(np.ndarray, X_test))
+        elif self.input_preprocessing == "std":
+            scaler = preprocessing.StandardScaler().fit(train_inputs)
+            train_inputs = scaler.transform(train_inputs)
+            test_inputs = scaler.transform(cast(np.ndarray, X_test))
+
+        # Select and fit the best estimator via GridSearchCV or direct fit.
+        optimal_estimator: Any = load_classifier(
+            classifier_name=configuration["classifier"],
+            random_state=self.random_state,
+            n_jobs=self.n_jobs,
+            cv_n_folds=self.cv,
+            cv_metric=self.tuning_metric,
+            param_grid=configuration["parameters"],
+        )
+
+        _fit_start = time()
+        optimal_estimator.fit(train_inputs, y_train)
+        _fit_elapsed = time() - _fit_start
+
+        if not isinstance(optimal_estimator, GridSearchCV):
+            optimal_estimator.refit_time_ = _fit_elapsed
+            optimal_estimator.best_params_ = configuration["parameters"]
+            optimal_estimator.best_estimator_ = optimal_estimator
+
+        # Predict on the training split.
+        train_predicted_y = optimal_estimator.predict(train_inputs)
+
+        # Predict on the test split when it is present.
+        test_predicted_y = None
+        elapsed = np.nan
+        if y_test is not None:
+            assert test_inputs is not None
+            start = time()
+            test_predicted_y = np.asarray(optimal_estimator.predict(test_inputs))
+            elapsed = time() - start
+
+        # Compute evaluation metrics for both splits.
+        train_metrics: OrderedDict[str, Any] = OrderedDict()
+        test_metrics: OrderedDict[str, Any] = OrderedDict()
+        for metric_name in self.eval_metrics:
+            train_score = _compute_metric(
+                metric_name,
+                y_train,
+                train_predicted_y,
+            )
+            train_metrics[metric_name.strip() + "_train"] = train_score
+
+            test_metrics[metric_name.strip() + "_test"] = np.nan
+            if y_test is not None:
+                assert test_predicted_y is not None
+                test_score = _compute_metric(metric_name, y_test, test_predicted_y)
+                test_metrics[metric_name.strip() + "_test"] = test_score
+
+        # Assemble timing keys (GridSearchCV vs direct-fit branches).
+        if isinstance(optimal_estimator, GridSearchCV):
+            train_metrics["cv_time_train"] = optimal_estimator.cv_results_[
+                "mean_fit_time"
+            ].mean()
+            test_metrics["cv_time_test"] = optimal_estimator.cv_results_[
+                "mean_score_time"
+            ].mean()
+            train_metrics["time_train"] = optimal_estimator.refit_time_
+            test_metrics["time_test"] = elapsed
+        else:
+            optimal_estimator.best_params_ = configuration["parameters"]
+            optimal_estimator.best_estimator_ = optimal_estimator
+
+            train_metrics["cv_time_train"] = np.nan
+            test_metrics["cv_time_test"] = np.nan
+            train_metrics["time_train"] = optimal_estimator.refit_time_
+            test_metrics["time_test"] = elapsed
+
+        # Compute class probabilities when available.
+        y_proba = None
+        if y_test is not None and hasattr(
+            optimal_estimator.best_estimator_, "predict_proba"
+        ):
+            assert test_inputs is not None
+            y_proba = optimal_estimator.best_estimator_.predict_proba(test_inputs)
+
+        # Build and return the ExperimentResult; no persistence here.
+        return ExperimentResult(
+            dataset_name=dataset_name,
+            classifier_name=conf_name,
+            resample_id=resample_id,
+            train_predicted_y=train_predicted_y,
+            test_predicted_y=test_predicted_y,
+            y_proba=y_proba,
+            train_metrics=train_metrics,
+            test_metrics=test_metrics,
+            best_params=optimal_estimator.best_params_,
+            best_model=optimal_estimator.best_estimator_,
+            train_true_y=y_train,
+            test_true_y=y_test,
+        )
 
     def _load_dataset(self, dataset_path: Path) -> list[tuple[str, dict[str, Any]]]:
         """Load all dataset's files, divided into train and test.
@@ -430,127 +500,6 @@ class Utilities:
 
         self.data_path = str(base_path)
         self.datasets = dataset_list
-
-    def _normalize_data(
-        self, train_data: np.ndarray, test_data: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray]:
-        """Normalize the data.
-
-        Test data normalization will be based on train data.
-
-        Parameters
-        ----------
-        train_data : 2d array
-            Contain the train data features.
-
-        test_data : 2d array
-            Contain the test data features.
-
-        Returns
-        -------
-        train_normalized : np.ndarray
-            Normalized training data.
-
-        test_normalized : np.ndarray
-            Normalized test data.
-
-        """
-        mm_scaler = preprocessing.MinMaxScaler().fit(train_data)
-
-        return mm_scaler.transform(train_data), mm_scaler.transform(test_data)
-
-    def _standardize_data(
-        self, train_data: np.ndarray, test_data: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray]:
-        """Standardize the data.
-
-        Test data standardization will be based on train data.
-
-        Parameters
-        ----------
-        train_data : 2d array
-            Contain the train data features.
-
-        test_data : 2d array
-            Contain the test data features.
-
-        Returns
-        -------
-        train_standardized : np.ndarray
-            Standardized training data.
-
-        test_standardized : np.ndarray
-            Standardized test data.
-
-        """
-        std_scaler = preprocessing.StandardScaler().fit(train_data)
-
-        return std_scaler.transform(train_data), std_scaler.transform(test_data)
-
-    def _get_optimal_estimator(
-        self,
-        train_inputs: np.ndarray,
-        train_outputs: np.ndarray,
-        classifier_name: str,
-        parameters: dict[str, Any],
-    ) -> BaseEstimator | GridSearchCV:
-        """Perform cross-validation over one dataset and configuration.
-
-        Each configuration consists of one classifier and none, one or multiple
-        hyper-parameters, that, in turn, can contain one or multiple values used
-        to optimize the resulting model.
-
-        At the end of cross-validation phase, the model with the specific
-        combination of values from the hyper-parameters that achieved the best
-        metrics from all the combinations will remain.
-
-        Parameters
-        ----------
-        train_inputs : {array-like, sparse-matrix} of shape (n_samples, n_features)
-            Vector of features for each sample for this dataset.
-
-        train_outputs : array-like of shape (n_samples)
-            Target vector relative to train_inputs.
-
-        classifier_name : str
-            Name of the classification algorithm being employed.
-
-        parameters : dict
-            Dictionary containing parameters to optimize as keys, and the list
-            of values that we want to compare as values.
-
-        Returns
-        -------
-        optimal : GridSearchCV object or classifier object
-            An already fitted model of the given classifier, with the best found
-            parameters after cross-validation. If cross-validation is not needed,
-            it will return the classifier model already trained.
-
-        Raises
-        ------
-        ValueError
-            If the classifier name is unknown or a hyper-parameter is invalid.
-
-        """
-        estimator = load_classifier(
-            classifier_name=classifier_name,
-            random_state=self.random_state,
-            n_jobs=self.n_jobs,
-            cv_n_folds=self.cv,
-            cv_metric=self.tuning_metric,
-            param_grid=parameters,
-        )
-
-        start = time()
-        estimator.fit(train_inputs, train_outputs)
-        elapsed = time() - start
-
-        if not isinstance(estimator, GridSearchCV):
-            estimator.refit_time_ = elapsed
-            estimator.best_params_ = parameters
-            estimator.best_estimator_ = estimator
-
-        return estimator
 
     def write_report(self) -> None:
         """Save summarized information about experiment through Results class."""

--- a/skordinal/experiments/tests/test_utilities.py
+++ b/skordinal/experiments/tests/test_utilities.py
@@ -9,25 +9,10 @@ import pandas as pd
 import pytest
 
 from skordinal.experiments import ExperimentResult, Utilities
+from skordinal.experiments._utilities import _load_dataset
 
 _MINIMAL_CONF = {"cfg": {"classifier": "SVC", "parameters": {}}}
 _CONF_CV: dict = {"classifier": "SVC", "parameters": {"C": [0.1, 1.0]}}
-
-
-def _minimal_util(results_path: Path) -> Utilities:
-    """Return a Utilities instance with stub args sufficient to pass validation.
-
-    Used by tests that only exercise helper methods (_load_dataset,
-    _read_file) and therefore do not need real dataset paths or metric
-    names beyond the minimum to construct.
-    """
-    return Utilities(
-        _MINIMAL_CONF,
-        data_path=".",
-        datasets=["x"],
-        eval_metrics=["mean_absolute_error"],
-        results_path=str(results_path),
-    )
 
 
 def create_csv(path, filename):
@@ -62,12 +47,6 @@ def _from_general_conf(general_conf: dict, configurations: dict, **kwargs) -> Ut
         input_preprocessing=general_conf.get("input_preprocessing"),
         **kwargs,
     )
-
-
-@pytest.fixture
-def util(tmp_path):
-    """Minimal valid Utilities instance for testing internal helper methods."""
-    return _minimal_util(tmp_path)
 
 
 @pytest.fixture
@@ -139,7 +118,7 @@ def test_run_experiment(tmp_path, experiment_conf, svm_conf):
     assert all(test_summary[c].dtype == np.float64 for c in test_summary.columns[2:-1])
 
 
-def test_load_complete_dataset(tmp_path, util):
+def test_load_complete_dataset(tmp_path):
     """Load a dataset of 5 partitions, each with a train and a test file."""
     dataset_path = tmp_path / "complete"
     dataset_path.mkdir()
@@ -148,14 +127,14 @@ def test_load_complete_dataset(tmp_path, util):
         create_csv(dataset_path, f"train_complete.{i}")
         create_csv(dataset_path, f"test_complete.{i}")
 
-    partition_list = util._load_dataset(dataset_path)
+    partition_list = _load_dataset(dataset_path)
 
     # Every partition holds train and test inputs and outputs (4 entries).
     assert len(partition_list) == len(list(dataset_path.iterdir())) / 2
     assert all(len(partition[1]) == 4 for partition in partition_list)
 
 
-def test_load_partitionless_dataset(tmp_path, util):
+def test_load_partitionless_dataset(tmp_path):
     """Load a dataset of a single train and test file."""
     dataset_path = tmp_path / "partitionless"
     dataset_path.mkdir()
@@ -163,13 +142,13 @@ def test_load_partitionless_dataset(tmp_path, util):
     create_csv(dataset_path, "train_partitionless.csv")
     create_csv(dataset_path, "test_partitionless.csv")
 
-    partition_list = util._load_dataset(dataset_path)
+    partition_list = _load_dataset(dataset_path)
 
     assert len(partition_list) == 1
     assert all(len(partition[1]) == 4 for partition in partition_list)
 
 
-def test_load_nontestfile_dataset(tmp_path, util):
+def test_load_nontestfile_dataset(tmp_path):
     """Load a dataset of five train files with no test files."""
     dataset_path = tmp_path / "nontestfile"
     dataset_path.mkdir()
@@ -177,13 +156,13 @@ def test_load_nontestfile_dataset(tmp_path, util):
     for i in range(5):
         create_csv(dataset_path, f"train_nontestfile.{i}")
 
-    partition_list = util._load_dataset(dataset_path)
+    partition_list = _load_dataset(dataset_path)
 
     assert len(partition_list) == len(list(dataset_path.iterdir()))
     assert all(len(partition[1]) == 2 for partition in partition_list)
 
 
-def test_load_nontrainfile_dataset(tmp_path, util):
+def test_load_nontrainfile_dataset(tmp_path):
     """A partition lacking its train file raises RuntimeError."""
     dataset_path = tmp_path / "nontrainfile"
     dataset_path.mkdir()
@@ -192,7 +171,7 @@ def test_load_nontrainfile_dataset(tmp_path, util):
         create_csv(dataset_path, f"test_nontrainfile.{i}")
 
     with pytest.raises(RuntimeError):
-        util._load_dataset(dataset_path)
+        _load_dataset(dataset_path)
 
 
 def test_empty_configurations_raises(tmp_path):

--- a/skordinal/experiments/tests/test_utilities.py
+++ b/skordinal/experiments/tests/test_utilities.py
@@ -1,5 +1,6 @@
 """Tests for the experiment utilities module."""
 
+import math
 from pathlib import Path
 
 import numpy as np
@@ -7,18 +8,18 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from skordinal.experiments import Utilities
-from skordinal.utils._testing import make_balance_scale_split
+from skordinal.experiments import ExperimentResult, Utilities
 
 _MINIMAL_CONF = {"cfg": {"classifier": "SVC", "parameters": {}}}
+_CONF_CV: dict = {"classifier": "SVC", "parameters": {"C": [0.1, 1.0]}}
 
 
 def _minimal_util(results_path: Path) -> Utilities:
     """Return a Utilities instance with stub args sufficient to pass validation.
 
     Used by tests that only exercise helper methods (_load_dataset,
-    _read_file, _normalize_data, _standardize_data) and therefore do not
-    need real dataset paths or metric names beyond the minimum to construct.
+    _read_file) and therefore do not need real dataset paths or metric
+    names beyond the minimum to construct.
     """
     return Utilities(
         _MINIMAL_CONF,
@@ -194,26 +195,6 @@ def test_load_nontrainfile_dataset(tmp_path, util):
         util._load_dataset(dataset_path)
 
 
-def test_normalize_data(util):
-    """Min-max normalisation maps training features into [0, 1]."""
-    X_train, X_test, _, _ = make_balance_scale_split()
-
-    norm_X_train, _ = util._normalize_data(X_train, X_test)
-
-    assert (norm_X_train >= 0).all()
-    assert (norm_X_train <= 1).all()
-
-
-def test_standardize_data(util):
-    """Standardisation gives training features zero mean and unit variance."""
-    X_train, X_test, _, _ = make_balance_scale_split()
-
-    std_X_train, _ = util._standardize_data(X_train, X_test)
-
-    npt.assert_almost_equal(np.mean(std_X_train), 0)
-    npt.assert_almost_equal(np.std(std_X_train), 1)
-
-
 def test_empty_configurations_raises(tmp_path):
     """An empty configurations dict raises ValueError."""
     with pytest.raises(ValueError, match="'configurations' must be a non-empty dict"):
@@ -325,3 +306,174 @@ def test_configurations_is_deep_copied(tmp_path):
     )
     original["cfg"]["parameters"]["C"].append(10)
     assert util.configurations["cfg"]["parameters"]["C"] == [1]
+
+
+@pytest.fixture
+def run_single_util(tmp_path):
+    """Minimal Utilities instance configured for _run_single seam tests."""
+    return Utilities(
+        _MINIMAL_CONF,
+        data_path=".",
+        datasets=["x"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=str(tmp_path),
+    )
+
+
+@pytest.fixture
+def run_single_util_std(tmp_path):
+    """Utilities instance with input_preprocessing='std' for mutation tests."""
+    return Utilities(
+        _MINIMAL_CONF,
+        data_path=".",
+        datasets=["x"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=str(tmp_path),
+        input_preprocessing="std",
+    )
+
+
+@pytest.fixture
+def split_with_test():
+    """Return (X_train, y_train, X_test, y_test) with three balanced classes."""
+    rng = np.random.default_rng(0)
+    X_train = rng.standard_normal((30, 4))
+    y_train = np.tile([0, 1, 2], 10)
+    X_test = rng.standard_normal((15, 4))
+    y_test = np.tile([0, 1, 2], 5)
+    return X_train, y_train, X_test, y_test
+
+
+@pytest.fixture
+def split_train_only():
+    """Return (X_train, y_train, None, None) for train-only partition tests."""
+    rng = np.random.default_rng(0)
+    X_train = rng.standard_normal((30, 4))
+    y_train = np.tile([0, 1, 2], 10)
+    return X_train, y_train, None, None
+
+
+def _call_run_single(util, X_train, y_train, X_test, y_test, conf=None):
+    """Invoke _run_single with fixed identity kwargs; returns the ExperimentResult."""
+    if conf is None:
+        conf = _MINIMAL_CONF["cfg"]
+    return util._run_single(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        conf,
+        dataset_name="ds",
+        conf_name="cfg",
+        resample_id="0",
+    )
+
+
+def test_run_single_returns_experiment_result_and_does_not_persist(
+    tmp_path, run_single_util, split_with_test
+):
+    """_run_single returns an ExperimentResult without writing any files."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _call_run_single(run_single_util, X_train, y_train, X_test, y_test)
+
+    assert isinstance(result, ExperimentResult)
+    written = list(tmp_path.iterdir())
+    assert written == [], f"_run_single wrote files unexpectedly: {written}"
+
+
+def test_run_single_identity_passthrough(run_single_util, split_with_test):
+    """dataset_name, classifier_name, and resample_id are forwarded verbatim."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = run_single_util._run_single(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        _MINIMAL_CONF["cfg"],
+        dataset_name="my_dataset",
+        conf_name="my_conf",
+        resample_id="42",
+    )
+
+    assert result.dataset_name == "my_dataset"
+    assert result.classifier_name == "my_conf"
+    assert result.resample_id == "42"
+
+
+@pytest.mark.parametrize("has_test", [True, False])
+def test_run_single_test_present_vs_absent(
+    run_single_util, split_with_test, split_train_only, has_test
+):
+    """With test data: test_predicted_y is an array and metrics are finite; without: None and NaN."""
+    X_train, y_train, X_test, y_test = split_with_test if has_test else split_train_only
+    result = _call_run_single(run_single_util, X_train, y_train, X_test, y_test)
+
+    metric_test_key = "mean_absolute_error_test"
+    if has_test:
+        assert result.test_predicted_y is not None
+        assert result.test_predicted_y.shape == (15,)
+        assert math.isfinite(result.test_metrics[metric_test_key])
+        assert math.isfinite(result.test_metrics["time_test"])
+    else:
+        assert result.test_predicted_y is None
+        assert math.isnan(result.test_metrics[metric_test_key])
+
+
+def test_run_single_timing_no_cv(run_single_util, split_with_test):
+    """Singleton param grid produces NaN cv_time_* and best_params echoes the config."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _call_run_single(run_single_util, X_train, y_train, X_test, y_test)
+
+    assert math.isnan(result.train_metrics["cv_time_train"])
+    assert math.isnan(result.test_metrics["cv_time_test"])
+    assert math.isfinite(result.train_metrics["time_train"])
+    assert math.isfinite(result.test_metrics["time_test"])
+    assert result.best_params == _MINIMAL_CONF["cfg"]["parameters"]
+
+
+def test_run_single_timing_with_cv(run_single_util, split_with_test):
+    """Multi-value param grid produces finite cv_time_* and best_params reflects a searched value."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _call_run_single(
+        run_single_util, X_train, y_train, X_test, y_test, conf=_CONF_CV
+    )
+
+    assert math.isfinite(result.train_metrics["cv_time_train"])
+    assert not math.isnan(result.train_metrics["cv_time_train"])
+    assert math.isfinite(result.test_metrics["cv_time_test"])
+    assert not math.isnan(result.test_metrics["cv_time_test"])
+    assert math.isfinite(result.train_metrics["time_train"])
+    assert math.isfinite(result.test_metrics["time_test"])
+    assert result.best_params.get("C") in _CONF_CV["parameters"]["C"]
+
+
+@pytest.mark.parametrize("preprocessing", ["std", "norm"])
+def test_run_single_preprocessing_train_only_raises(
+    tmp_path, split_train_only, preprocessing
+):
+    """input_preprocessing with X_test=None raises ValueError."""
+    util = Utilities(
+        _MINIMAL_CONF,
+        data_path=".",
+        datasets=["x"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=str(tmp_path),
+        input_preprocessing=preprocessing,
+    )
+    X_train, y_train, X_test, y_test = split_train_only
+    with pytest.raises(ValueError):
+        _call_run_single(util, X_train, y_train, X_test, y_test)
+
+
+def test_run_single_preprocessing_does_not_mutate_inputs(
+    run_single_util_std, split_with_test
+):
+    """input_preprocessing='std' operates on copies; caller's arrays are unchanged."""
+    X_train, y_train, X_test, y_test = split_with_test
+    train_before = X_train.copy()
+    test_before = X_test.copy()
+
+    _call_run_single(run_single_util_std, X_train, y_train, X_test, y_test)
+
+    npt.assert_array_equal(X_train, train_before)
+    npt.assert_array_equal(X_test, test_before)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Extracts the per-partition execution from `run_experiment` into a `_run_single` method that returns an `ExperimentResult` without persisting. Promotes the data-loading helpers to module-level functions.