### PR TITLE
ENH: Add RegressorWrapper and CostSensitiveWrapper

### DIFF
--- a/skordinal/classifiers/__init__.py
+++ b/skordinal/classifiers/__init__.py
@@ -4,6 +4,7 @@ from ._nnop import NNOP
 from ._nnpom import NNPOM
 from ._ordinal_decomposition import OrdinalDecomposition
 from ._redsvm import REDSVM
+from ._regressor_wrapper import RegressorWrapper
 from ._svorex import SVOREX
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     "NNPOM",
     "OrdinalDecomposition",
     "REDSVM",
+    "RegressorWrapper",
     "SVOREX",
 ]

--- a/skordinal/classifiers/__init__.py
+++ b/skordinal/classifiers/__init__.py
@@ -1,5 +1,6 @@
 """Ordinal classification classifiers module."""
 
+from ._cost_sensitive_wrapper import CostSensitiveWrapper
 from ._nnop import NNOP
 from ._nnpom import NNPOM
 from ._ordinal_decomposition import OrdinalDecomposition
@@ -8,6 +9,7 @@ from ._regressor_wrapper import RegressorWrapper
 from ._svorex import SVOREX
 
 __all__ = [
+    "CostSensitiveWrapper",
     "NNOP",
     "NNPOM",
     "OrdinalDecomposition",

--- a/skordinal/classifiers/_cost_sensitive_wrapper.py
+++ b/skordinal/classifiers/_cost_sensitive_wrapper.py
@@ -1,0 +1,227 @@
+"""Cost-sensitive wrapper meta-estimator for ordinal classification."""
+
+from __future__ import annotations
+
+import inspect
+
+import numpy as np
+from numpy.typing import ArrayLike
+from sklearn.base import (
+    BaseEstimator,
+    ClassifierMixin,
+    MetaEstimatorMixin,
+    _fit_context,
+    clone,
+)
+from sklearn.linear_model import LogisticRegression
+from sklearn.utils._param_validation import HasMethods
+from sklearn.utils.validation import check_is_fitted
+
+from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.validation import check_ordinal_targets
+
+
+def _ordinal_weights(p: int, y_enc: np.ndarray) -> np.ndarray:
+    """Return per-sample weights for the one-vs-rest sub-problem of class p.
+
+    Positive samples get weight 1; negative samples get a weight proportional
+    to their ordinal distance to p, rescaled to sum to the negative count.
+
+    """
+    neg_mask = y_enc != p
+    n_neg = neg_mask.sum()
+    unnorm = np.abs(p - y_enc).astype(np.float64) + 1.0
+    S = unnorm[neg_mask].sum()
+    return np.where(neg_mask, unnorm * (n_neg / S), 1.0)
+
+
+class CostSensitiveWrapper(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
+    """Cost-sensitive one-vs-rest meta-estimator for ordinal classification.
+
+    Trains one binary one-vs-rest sub-classifier per ordinal class, reweighting
+    negative samples by their ordinal distance to the focal class so that
+    farther classes cost more. Predictions take the argmax over the per-class
+    score matrix. The default base classifier is LogisticRegression.
+
+    Parameters
+    ----------
+    estimator : estimator instance or None, default=None
+        Base binary classifier. Must implement a ``fit`` method that accepts a
+        ``sample_weight`` keyword argument. If ``None``, a LogisticRegression
+        with default hyperparameters is used.
+
+    Attributes
+    ----------
+    classes_ : ndarray of shape (n_classes,)
+        Class labels for each output.
+
+    estimators_ : list of length n_classes
+        Fitted clones of the base estimator, one per ordinal class.
+
+    n_features_in_ : int
+        Number of features seen during fit.
+
+    feature_names_in_ : ndarray of shape (n_features_in_,)
+        Names of features seen during fit. Defined only when X has feature
+        names that are all strings.
+
+    References
+    ----------
+    .. [1] P. A. Gutiérrez, M. Pérez-Ortiz, J. Sánchez-Monedero,
+       F. Fernández-Navarro, and C. Hervás-Martínez, "Ordinal Regression
+       Methods: Survey and Experimental Study", IEEE Transactions on
+       Knowledge and Data Engineering, vol. 28, no. 1, pp. 127-146, 2016,
+       https://doi.org/10.1109/TKDE.2015.2457911
+
+    """
+
+    _parameter_constraints: dict = {
+        "estimator": [HasMethods(["fit"]), None],
+    }
+
+    def __init__(self, estimator=None) -> None:
+        self.estimator = estimator
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X: ArrayLike, y: ArrayLike) -> CostSensitiveWrapper:
+        """Fit one cost-sensitive binary classifier per ordinal class.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input data.
+
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If the base estimator's ``fit`` does not accept ``sample_weight``.
+
+        """
+        X, y = validate_data(
+            self, X, y, accept_sparse=False, ensure_2d=True, dtype=None
+        )
+
+        self.classes_, y_enc = check_ordinal_targets(y)
+        K = self.classes_.size
+
+        base = self.estimator if self.estimator is not None else LogisticRegression()
+
+        if "sample_weight" not in inspect.signature(base.fit).parameters:
+            raise ValueError(
+                f"Estimator {type(base).__name__} does not accept sample_weight "
+                f"in fit; CostSensitiveWrapper requires it."
+            )
+
+        self.estimators_ = []
+        for p in range(K):
+            y_bin = (y_enc == p).astype(np.intp)
+            est_p = clone(base)
+            est_p.fit(X, y_bin, sample_weight=_ordinal_weights(p, y_enc))
+            self.estimators_.append(est_p)
+
+        return self
+
+    def predict(self, X: ArrayLike) -> np.ndarray:
+        """Predict ordinal class labels for samples in X.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            The predicted classes.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+
+        AttributeError
+            If no sub-estimator exposes ``decision_function`` or ``predict_proba``.
+
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, ensure_2d=True, dtype=None)
+
+        n = X.shape[0]
+        K = len(self.estimators_)
+
+        use_df = all(hasattr(e, "decision_function") for e in self.estimators_)
+        use_proba = all(hasattr(e, "predict_proba") for e in self.estimators_)
+
+        if not use_df and not use_proba:
+            raise AttributeError(
+                "Base estimators expose neither decision_function nor "
+                "predict_proba; CostSensitiveWrapper.predict requires one of them."
+            )
+
+        S = np.empty((n, K), dtype=np.float64)
+        if use_df:
+            for p, est_p in enumerate(self.estimators_):
+                S[:, p] = est_p.decision_function(X)
+        else:
+            for p, est_p in enumerate(self.estimators_):
+                idx = int(np.searchsorted(est_p.classes_, 1))
+                S[:, p] = est_p.predict_proba(X)[:, idx]
+
+        return self.classes_[S.argmax(axis=1)]
+
+    def predict_proba(self, X: ArrayLike) -> np.ndarray:
+        """Return class-probability estimates for samples in X.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        y_proba : ndarray of shape (n_samples, n_classes)
+            Class probabilities. Each row is non-negative and sums to one.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+
+        AttributeError
+            If any sub-estimator does not expose ``predict_proba``.
+
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, ensure_2d=True, dtype=None)
+
+        if not all(hasattr(e, "predict_proba") for e in self.estimators_):
+            raise AttributeError(
+                "predict_proba is only available when every base estimator "
+                "implements predict_proba."
+            )
+
+        n = X.shape[0]
+        K = len(self.estimators_)
+
+        P = np.empty((n, K), dtype=np.float64)
+        for p, est_p in enumerate(self.estimators_):
+            idx = int(np.searchsorted(est_p.classes_, 1))
+            P[:, p] = est_p.predict_proba(X)[:, idx]
+
+        # Replace all-zero rows with the uniform distribution
+        zero_rows = P.sum(axis=1) == 0.0
+        P[zero_rows] = 1.0 / K
+
+        # Clip to a tiny floor and renormalise each row to sum to one
+        np.clip(P, np.finfo(float).tiny, None, out=P)
+        P /= P.sum(axis=1, keepdims=True)
+
+        return P

--- a/skordinal/classifiers/_regressor_wrapper.py
+++ b/skordinal/classifiers/_regressor_wrapper.py
@@ -1,0 +1,135 @@
+"""Regressor wrapper meta-estimator for ordinal classification."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
+from sklearn.base import (
+    BaseEstimator,
+    ClassifierMixin,
+    MetaEstimatorMixin,
+    _fit_context,
+    clone,
+    is_regressor,
+)
+from sklearn.svm import SVR
+from sklearn.utils._param_validation import HasMethods
+from sklearn.utils.validation import check_is_fitted
+
+from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.validation import check_ordinal_targets
+
+
+class RegressorWrapper(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
+    """Regressor-based meta-estimator for ordinal classification.
+
+    Wraps any scikit-learn regressor and adapts it for ordinal classification
+    by training on the zero-based rank encoding of the labels and rounding each
+    continuous prediction to the nearest rank, breaking ties toward the lower
+    class. The default base estimator is an SVR.
+
+    Parameters
+    ----------
+    estimator : regressor instance or None, default=None
+        Base regressor. Must implement ``fit`` and ``predict``. If ``None``,
+        an SVR with default hyperparameters is used.
+
+    Attributes
+    ----------
+    classes_ : ndarray of shape (n_classes,)
+        Class labels for each output.
+
+    estimator_ : regressor instance
+        Fitted clone of the base estimator.
+
+    n_features_in_ : int
+        Number of features seen during fit.
+
+    feature_names_in_ : ndarray of shape (n_features_in_,)
+        Names of features seen during fit. Defined only when X has feature
+        names that are all strings.
+
+    References
+    ----------
+    .. [1] P. A. Gutiérrez, M. Pérez-Ortiz, J. Sánchez-Monedero,
+       F. Fernández-Navarro, and C. Hervás-Martínez, "Ordinal Regression
+       Methods: Survey and Experimental Study", IEEE Transactions on
+       Knowledge and Data Engineering, vol. 28, no. 1, pp. 127-146, 2016,
+       https://doi.org/10.1109/TKDE.2015.2457911
+
+    """
+
+    _parameter_constraints: dict = {
+        "estimator": [HasMethods(["fit", "predict"]), None],
+    }
+
+    def __init__(self, estimator=None) -> None:
+        self.estimator = estimator
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X: ArrayLike, y: ArrayLike) -> RegressorWrapper:
+        """Fit the wrapped regressor to ``(X, y)``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input data.
+
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If the resolved base estimator is not a regressor.
+
+        """
+        X, y = validate_data(
+            self, X, y, accept_sparse=False, ensure_2d=True, dtype=None
+        )
+
+        self.classes_, y_enc = check_ordinal_targets(y)
+
+        base = self.estimator if self.estimator is not None else SVR()
+
+        if not is_regressor(base):
+            raise ValueError(
+                f"estimator must be a regressor; got {type(base).__name__}"
+            )
+
+        self.estimator_ = clone(base)
+        self.estimator_.fit(X, y_enc)
+
+        return self
+
+    def predict(self, X: ArrayLike) -> np.ndarray:
+        """Predict ordinal class labels by rounding regressor outputs.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            The predicted classes.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, ensure_2d=True, dtype=None)
+
+        y_cont = self.estimator_.predict(X)
+        ranks = np.arange(self.classes_.size, dtype=float)
+        idx = np.abs(y_cont[:, None] - ranks[None, :]).argmin(axis=1)
+        return self.classes_[idx]

--- a/skordinal/classifiers/tests/test_cost_sensitive_wrapper.py
+++ b/skordinal/classifiers/tests/test_cost_sensitive_wrapper.py
@@ -1,0 +1,150 @@
+"""Tests for the CostSensitiveWrapper classifier."""
+
+import inspect
+
+import numpy as np
+import numpy.testing as npt
+import pandas as pd
+import pytest
+from sklearn.linear_model import LogisticRegression
+from sklearn.neighbors import KNeighborsClassifier
+
+from skordinal.classifiers import CostSensitiveWrapper
+
+
+@pytest.fixture
+def X():
+    """Create sample feature patterns for testing."""
+    return np.array([[0, 1], [1, 0], [1, 1], [0, 0], [1, 2]])
+
+
+@pytest.fixture
+def y():
+    """Create sample target variables for testing."""
+    return np.array([0, 1, 1, 0, 1])
+
+
+def test_cost_sensitive_wrapper_predict_matches_expected():
+    """Test that predictions match expected values."""
+    X = np.array([[0.0], [1.0], [2.0], [8.0], [9.0], [10.0]])
+    y = np.array([0, 0, 0, 1, 1, 1])
+
+    classifier = CostSensitiveWrapper(LogisticRegression()).fit(X, y)
+    npt.assert_array_equal(classifier.predict(X), y)
+
+
+@pytest.mark.parametrize("invalid_value", [5, "logistic", object()])
+def test_cost_sensitive_wrapper_hyperparameter_type_validation(X, y, invalid_value):
+    """Test that CostSensitiveWrapper raises ValueError for invalid types of hyperparameters."""
+    classifier = CostSensitiveWrapper(estimator=invalid_value)
+
+    with pytest.raises(ValueError, match=r"The 'estimator' parameter.*"):
+        classifier.fit(X, y)
+
+
+def test_cost_sensitive_wrapper_fit_input_validation(X, y):
+    """Test that input data is validated."""
+    classifier = CostSensitiveWrapper()
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, y[:-1])
+
+    with pytest.raises(ValueError):
+        classifier.fit([], y)
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, [])
+
+
+def test_cost_sensitive_wrapper_requires_sample_weight_support(X, y):
+    """Test that a base estimator without sample_weight support is rejected."""
+    classifier = CostSensitiveWrapper(KNeighborsClassifier())
+
+    with pytest.raises(ValueError, match="sample_weight"):
+        classifier.fit(X, y)
+
+
+def test_cost_sensitive_wrapper_predict_invalid_input_raises_error(X, y):
+    """Test that invalid input raises an error."""
+    classifier = CostSensitiveWrapper().fit(X, y)
+
+    with pytest.raises(ValueError):
+        classifier.predict([])
+
+
+def test_cost_sensitive_wrapper_predict_proba_sums_to_one(X, y):
+    """Test that predict_proba returns rows that sum to one."""
+    classifier = CostSensitiveWrapper().fit(X, y)
+    proba = classifier.predict_proba(X)
+
+    assert proba.shape == (X.shape[0], classifier.classes_.size)
+    npt.assert_allclose(proba.sum(axis=1), np.ones(X.shape[0]))
+    assert np.all(proba >= 0.0)
+
+
+def test_cost_sensitive_wrapper_sets_classes_and_n_features_in_after_fit(X, y):
+    """Test that classes_ and n_features_in_ are set after fit."""
+    classifier = CostSensitiveWrapper().fit(X, y)
+
+    assert isinstance(classifier.classes_, np.ndarray)
+    np.testing.assert_array_equal(classifier.classes_, np.unique(y))
+    assert isinstance(classifier.n_features_in_, int)
+    assert classifier.n_features_in_ == X.shape[1]
+
+
+def test_cost_sensitive_wrapper_predict_raises_if_not_fitted(X):
+    """Test that predict raises when the model is not fitted."""
+    from sklearn.exceptions import NotFittedError
+
+    classifier = CostSensitiveWrapper()
+    with pytest.raises(NotFittedError):
+        classifier.predict(X)
+
+
+def test_cost_sensitive_wrapper_feature_names_in_when_dataframe(X, y):
+    """Test that feature_names_in_ is set when X is a DataFrame."""
+    df = pd.DataFrame(X, columns=["f0", "f1"])
+    classifier = CostSensitiveWrapper().fit(df, y)
+
+    assert hasattr(classifier, "feature_names_in_")
+    np.testing.assert_array_equal(
+        classifier.feature_names_in_, np.array(["f0", "f1"], dtype=object)
+    )
+
+
+def test_cost_sensitive_wrapper_parameter_constraints_match_init_params():
+    """Test that _parameter_constraints keys match __init__ parameters."""
+    init_params = set(inspect.signature(CostSensitiveWrapper.__init__).parameters) - {
+        "self"
+    }
+    assert set(CostSensitiveWrapper._parameter_constraints) == init_params
+
+
+def test_cost_sensitive_wrapper_predict_rejects_wrong_n_features(X, y):
+    """Test that predict rejects input with mismatched n_features."""
+    classifier = CostSensitiveWrapper().fit(X, y)
+    with pytest.raises(ValueError):
+        classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_cost_sensitive_wrapper_label_roundtrip(labels):
+    """Test that CostSensitiveWrapper preserves arbitrary ordinal label sets through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = CostSensitiveWrapper().fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))

--- a/skordinal/classifiers/tests/test_regressor_wrapper.py
+++ b/skordinal/classifiers/tests/test_regressor_wrapper.py
@@ -1,0 +1,139 @@
+"""Tests for the RegressorWrapper classifier."""
+
+import inspect
+
+import numpy as np
+import numpy.testing as npt
+import pandas as pd
+import pytest
+from sklearn.linear_model import LinearRegression, LogisticRegression
+
+from skordinal.classifiers import RegressorWrapper
+
+
+@pytest.fixture
+def X():
+    """Create sample feature patterns for testing."""
+    return np.array([[0, 1], [1, 0], [1, 1], [0, 0], [1, 2]], dtype=float)
+
+
+@pytest.fixture
+def y():
+    """Create sample target variables for testing."""
+    return np.array([0, 1, 1, 0, 1])
+
+
+def test_regressor_wrapper_predict_matches_expected():
+    """Test that predictions match expected values."""
+    X = np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]])
+    y = np.array([0, 0, 1, 1, 2, 2])
+
+    classifier = RegressorWrapper(LinearRegression()).fit(X, y)
+    npt.assert_array_equal(classifier.predict(X), y)
+
+
+@pytest.mark.parametrize("invalid_value", [5, "svr", object()])
+def test_regressor_wrapper_hyperparameter_type_validation(X, y, invalid_value):
+    """Test that RegressorWrapper raises ValueError for invalid types of hyperparameters."""
+    classifier = RegressorWrapper(estimator=invalid_value)
+
+    with pytest.raises(ValueError, match=r"The 'estimator' parameter.*"):
+        classifier.fit(X, y)
+
+
+def test_regressor_wrapper_fit_input_validation(X, y):
+    """Test that input data is validated."""
+    classifier = RegressorWrapper()
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, y[:-1])
+
+    with pytest.raises(ValueError):
+        classifier.fit([], y)
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, [])
+
+
+def test_regressor_wrapper_rejects_non_regressor(X, y):
+    """Test that a base estimator that is not a regressor is rejected."""
+    classifier = RegressorWrapper(LogisticRegression())
+
+    with pytest.raises(ValueError, match="must be a regressor"):
+        classifier.fit(X, y)
+
+
+def test_regressor_wrapper_predict_invalid_input_raises_error(X, y):
+    """Test that invalid input raises an error."""
+    classifier = RegressorWrapper().fit(X, y)
+
+    with pytest.raises(ValueError):
+        classifier.predict([])
+
+
+def test_regressor_wrapper_sets_classes_and_n_features_in_after_fit(X, y):
+    """Test that classes_ and n_features_in_ are set after fit."""
+    classifier = RegressorWrapper().fit(X, y)
+
+    assert isinstance(classifier.classes_, np.ndarray)
+    np.testing.assert_array_equal(classifier.classes_, np.unique(y))
+    assert isinstance(classifier.n_features_in_, int)
+    assert classifier.n_features_in_ == X.shape[1]
+
+
+def test_regressor_wrapper_predict_raises_if_not_fitted(X):
+    """Test that predict raises when the model is not fitted."""
+    from sklearn.exceptions import NotFittedError
+
+    classifier = RegressorWrapper()
+    with pytest.raises(NotFittedError):
+        classifier.predict(X)
+
+
+def test_regressor_wrapper_feature_names_in_when_dataframe(X, y):
+    """Test that feature_names_in_ is set when X is a DataFrame."""
+    df = pd.DataFrame(X, columns=["f0", "f1"])
+    classifier = RegressorWrapper().fit(df, y)
+
+    assert hasattr(classifier, "feature_names_in_")
+    np.testing.assert_array_equal(
+        classifier.feature_names_in_, np.array(["f0", "f1"], dtype=object)
+    )
+
+
+def test_regressor_wrapper_parameter_constraints_match_init_params():
+    """Test that _parameter_constraints keys match __init__ parameters."""
+    init_params = set(inspect.signature(RegressorWrapper.__init__).parameters) - {
+        "self"
+    }
+    assert set(RegressorWrapper._parameter_constraints) == init_params
+
+
+def test_regressor_wrapper_predict_rejects_wrong_n_features(X, y):
+    """Test that predict rejects input with mismatched n_features."""
+    classifier = RegressorWrapper().fit(X, y)
+    with pytest.raises(ValueError):
+        classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_regressor_wrapper_label_roundtrip(labels):
+    """Test that RegressorWrapper preserves arbitrary ordinal label sets through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = RegressorWrapper(LinearRegression()).fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds two ordinal classifiers. `RegressorWrapper` fits any scikit-learn regressor on the rank-encoded labels and maps each prediction to the nearest class (default `SVR`). `CostSensitiveWrapper` trains one one-vs-rest model per class, weighting negatives by their ordinal distance to the focal class, and predicts the argmax of the per-class scores (default `LogisticRegression`).