### PR TITLE
REF: Rename encodings module to coding

### DIFF
--- a/skordinal/preprocessing/__init__.py
+++ b/skordinal/preprocessing/__init__.py
@@ -1,6 +1,6 @@
 """Ordinal preprocessing utilities."""
 
-from ._encodings import (
+from ._coding import (
     binary_cumulative_to_ordinal,
     build_coding_matrix,
     ordinal_to_binary_cumulative,

--- a/skordinal/preprocessing/_coding.py
+++ b/skordinal/preprocessing/_coding.py
@@ -1,4 +1,4 @@
-"""Ordinal encoding utilities."""
+"""Ordinal coding utilities."""
 
 from __future__ import annotations
 

--- a/skordinal/preprocessing/tests/test_coding.py
+++ b/skordinal/preprocessing/tests/test_coding.py
@@ -1,4 +1,4 @@
-"""Tests for the ordinal encoding utilities."""
+"""Tests for the ordinal coding utilities."""
 
 import numpy as np
 import numpy.testing as npt


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Renames the private preprocessing module `_encodings.py` to `_coding.py`. The public `skordinal.preprocessing` API is unchanged.