### PR TITLE
ENH: Add Experiment runner and route Utilities through it

### DIFF
--- a/skordinal/experiments/__init__.py
+++ b/skordinal/experiments/__init__.py
@@ -1,6 +1,7 @@
 """Experiments orchestration module."""
 
+from ._experiment import Experiment
 from ._results import ExperimentResult, Results
 from ._utilities import Utilities
 
-__all__ = ["ExperimentResult", "Results", "Utilities"]
+__all__ = ["Experiment", "ExperimentResult", "Results", "Utilities"]

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -1,0 +1,279 @@
+"""Experiment runner for a single classifier configuration."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from copy import deepcopy
+from time import time
+from typing import Any, cast
+
+import numpy as np
+from sklearn import preprocessing
+from sklearn.model_selection import GridSearchCV
+
+from skordinal.model_selection import load_classifier
+
+from ._results import ExperimentResult
+
+
+def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    from skordinal.metrics import get_ordinal_scorer
+
+    scorer = cast(Any, get_ordinal_scorer(metric_name.strip()))
+    return scorer._score_func(y_true, y_pred, **scorer._kwargs)
+
+
+class Experiment:
+    """Run a single classifier configuration on one train/test partition.
+
+    Wraps one configuration (a classifier name and its hyper-parameter grid)
+    together with the cross-validation and preprocessing settings shared across
+    partitions. Calling :meth:`run` applies optional preprocessing, selects and
+    fits the best estimator via
+    :func:`~skordinal.model_selection.load_classifier`, predicts on the train
+    and (when present) test splits, computes all evaluation metrics and timing
+    keys, and returns an :class:`ExperimentResult`. Nothing is written to disk.
+
+    Parameters
+    ----------
+    configuration : dict
+        Single configuration entry with the form
+        ``{"classifier": str, "parameters": dict}``, where ``"classifier"`` is
+        the registered name of the classification algorithm and ``"parameters"``
+        is a dictionary of hyper-parameter grids (lists of values to search
+        over) or fixed values. A deep copy is taken at construction time.
+
+    eval_metrics : list of str
+        Metric names to compute for every partition (e.g.
+        ``["mean_absolute_error", "average_mean_absolute_error"]``). Names must
+        be recognised by ``skordinal.metrics.get_ordinal_scorer``.
+
+    tuning_metric : str, default="neg_mean_absolute_error"
+        Metric used as the cross-validation scoring criterion when selecting the
+        best hyper-parameter combination. Must be recognised by
+        ``skordinal.metrics.get_ordinal_scorer``; validation is deferred to
+        runtime.
+
+    cv : int, default=3
+        Number of folds used in hyper-parameter cross-validation.
+
+    n_jobs : int, default=1
+        Number of parallel jobs forwarded to ``GridSearchCV``.
+
+    input_preprocessing : {"std", "norm"} or None, default=None
+        Optional feature preprocessing applied to every partition before
+        fitting: ``"norm"`` applies min-max normalisation and ``"std"`` applies
+        z-score standardisation. Both scalers are fitted on the training split
+        only, then applied to both train and test splits. ``None`` means no
+        preprocessing.
+
+    random_state : int or None, default=None
+        Seed used for two sources of randomness: the base estimator and the
+        cross-validation splitter (``StratifiedKFold``) used during
+        hyper-parameter search. When ``None``, both use their own default
+        random behaviour.
+
+    Examples
+    --------
+    >>> from skordinal.experiments import Experiment  # doctest: +SKIP
+    >>> exp = Experiment(  # doctest: +SKIP
+    ...     {"classifier": "svc", "parameters": {"C": [1]}},
+    ...     eval_metrics=["mean_absolute_error"],
+    ... )
+    >>> result = exp.run(  # doctest: +SKIP
+    ...     X_train, y_train, X_test, y_test,
+    ...     dataset_name="balance-scale",
+    ...     classifier_name="SVM",
+    ...     resample_id="0",
+    ... )
+
+    """
+
+    def __init__(
+        self,
+        configuration: dict[str, Any],
+        *,
+        eval_metrics: list[str],
+        tuning_metric: str = "neg_mean_absolute_error",
+        cv: int = 3,
+        n_jobs: int = 1,
+        input_preprocessing: str | None = None,
+        random_state: int | None = None,
+    ) -> None:
+        if not eval_metrics:
+            raise ValueError(
+                "'eval_metrics' must be a non-empty list; got an empty sequence."
+            )
+
+        _allowed_preproc = {"std", "norm"}
+        if input_preprocessing is not None:
+            _normalized = str(input_preprocessing).strip().lower()
+            if _normalized not in _allowed_preproc:
+                raise ValueError(
+                    f"'input_preprocessing' must be one of {None, 'std', 'norm'}; "
+                    f"got '{input_preprocessing}'."
+                )
+            input_preprocessing = _normalized
+
+        self.configuration = deepcopy(configuration)
+        self.eval_metrics: list[str] = list(eval_metrics)
+        self.tuning_metric = tuning_metric
+        self.cv = cv
+        self.n_jobs = n_jobs
+        self.input_preprocessing = input_preprocessing
+        self.random_state = random_state
+
+    def run(
+        self,
+        X_train: np.ndarray,
+        y_train: np.ndarray,
+        X_test: np.ndarray | None,
+        y_test: np.ndarray | None,
+        *,
+        dataset_name: str,
+        classifier_name: str,
+        resample_id: str,
+    ) -> ExperimentResult:
+        """Run the configuration on a single train/test partition.
+
+        Applies optional preprocessing, selects and fits the best estimator,
+        predicts on train and (when present) test splits, computes all
+        evaluation metrics and timing keys, and returns an
+        :class:`ExperimentResult`. It does **not** persist anything to disk; the
+        caller is responsible for saving the result.
+
+        Parameters
+        ----------
+        X_train : ndarray of shape (n_train_samples, n_features)
+            Training feature matrix.
+
+        y_train : ndarray of shape (n_train_samples,)
+            Training labels.
+
+        X_test : ndarray of shape (n_test_samples, n_features) or None
+            Test feature matrix. When ``None`` no test metrics are computed.
+
+        y_test : ndarray of shape (n_test_samples,) or None
+            Test labels. When ``None`` no test metrics are computed.
+
+        dataset_name : str
+            Name of the dataset, forwarded to the returned
+            :class:`ExperimentResult`.
+
+        classifier_name : str
+            Configuration label, used as ``classifier_name`` in the returned
+            :class:`ExperimentResult`.
+
+        resample_id : str
+            Partition index string, forwarded to the returned
+            :class:`ExperimentResult`.
+
+        Returns
+        -------
+        ExperimentResult
+            Fully populated result for this partition. No side effects.
+
+        """
+        # Apply preprocessing on local copies so the caller's arrays are not mutated.
+        train_inputs: np.ndarray = X_train
+        test_inputs: np.ndarray | None = X_test
+
+        if self.input_preprocessing == "norm":
+            scaler = preprocessing.MinMaxScaler().fit(train_inputs)
+            train_inputs = scaler.transform(train_inputs)
+            test_inputs = scaler.transform(cast(np.ndarray, X_test))
+        elif self.input_preprocessing == "std":
+            scaler = preprocessing.StandardScaler().fit(train_inputs)
+            train_inputs = scaler.transform(train_inputs)
+            test_inputs = scaler.transform(cast(np.ndarray, X_test))
+
+        # Select and fit the best estimator via GridSearchCV or direct fit.
+        optimal_estimator: Any = load_classifier(
+            classifier_name=self.configuration["classifier"],
+            random_state=self.random_state,
+            n_jobs=self.n_jobs,
+            cv_n_folds=self.cv,
+            cv_metric=self.tuning_metric,
+            param_grid=self.configuration["parameters"],
+        )
+
+        _fit_start = time()
+        optimal_estimator.fit(train_inputs, y_train)
+        _fit_elapsed = time() - _fit_start
+
+        if not isinstance(optimal_estimator, GridSearchCV):
+            optimal_estimator.refit_time_ = _fit_elapsed
+            optimal_estimator.best_params_ = self.configuration["parameters"]
+            optimal_estimator.best_estimator_ = optimal_estimator
+
+        # Predict on the training split.
+        train_predicted_y = optimal_estimator.predict(train_inputs)
+
+        # Predict on the test split when it is present.
+        test_predicted_y = None
+        elapsed = np.nan
+        if y_test is not None:
+            assert test_inputs is not None
+            start = time()
+            test_predicted_y = np.asarray(optimal_estimator.predict(test_inputs))
+            elapsed = time() - start
+
+        # Compute evaluation metrics for both splits.
+        train_metrics: OrderedDict[str, Any] = OrderedDict()
+        test_metrics: OrderedDict[str, Any] = OrderedDict()
+        for metric_name in self.eval_metrics:
+            train_score = _compute_metric(
+                metric_name,
+                y_train,
+                train_predicted_y,
+            )
+            train_metrics[metric_name.strip() + "_train"] = train_score
+
+            test_metrics[metric_name.strip() + "_test"] = np.nan
+            if y_test is not None:
+                assert test_predicted_y is not None
+                test_score = _compute_metric(metric_name, y_test, test_predicted_y)
+                test_metrics[metric_name.strip() + "_test"] = test_score
+
+        # Assemble timing keys (GridSearchCV vs direct-fit branches).
+        if isinstance(optimal_estimator, GridSearchCV):
+            train_metrics["cv_time_train"] = optimal_estimator.cv_results_[
+                "mean_fit_time"
+            ].mean()
+            test_metrics["cv_time_test"] = optimal_estimator.cv_results_[
+                "mean_score_time"
+            ].mean()
+            train_metrics["time_train"] = optimal_estimator.refit_time_
+            test_metrics["time_test"] = elapsed
+        else:
+            optimal_estimator.best_params_ = self.configuration["parameters"]
+            optimal_estimator.best_estimator_ = optimal_estimator
+
+            train_metrics["cv_time_train"] = np.nan
+            test_metrics["cv_time_test"] = np.nan
+            train_metrics["time_train"] = optimal_estimator.refit_time_
+            test_metrics["time_test"] = elapsed
+
+        # Compute class probabilities when available.
+        y_proba = None
+        if y_test is not None and hasattr(
+            optimal_estimator.best_estimator_, "predict_proba"
+        ):
+            assert test_inputs is not None
+            y_proba = optimal_estimator.best_estimator_.predict_proba(test_inputs)
+
+        # Build and return the ExperimentResult; no persistence here.
+        return ExperimentResult(
+            dataset_name=dataset_name,
+            classifier_name=classifier_name,
+            resample_id=resample_id,
+            train_predicted_y=train_predicted_y,
+            test_predicted_y=test_predicted_y,
+            y_proba=y_proba,
+            train_metrics=train_metrics,
+            test_metrics=test_metrics,
+            best_params=optimal_estimator.best_params_,
+            best_model=optimal_estimator.best_estimator_,
+            train_true_y=y_train,
+            test_true_y=y_test,
+        )

--- a/skordinal/experiments/_utilities.py
+++ b/skordinal/experiments/_utilities.py
@@ -2,27 +2,15 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
 from copy import deepcopy
 from pathlib import Path
-from time import time
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 import pandas as pd
-from sklearn import preprocessing
-from sklearn.model_selection import GridSearchCV
 
-from skordinal.model_selection import load_classifier
-
-from ._results import ExperimentResult, Results
-
-
-def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) -> float:
-    from skordinal.metrics import get_ordinal_scorer
-
-    scorer = cast(Any, get_ordinal_scorer(metric_name.strip()))
-    return scorer._score_func(y_true, y_pred, **scorer._kwargs)
+from ._experiment import Experiment
+from ._results import Results
 
 
 def _read_file(filename: Path) -> tuple[np.ndarray, np.ndarray]:
@@ -290,183 +278,31 @@ class Utilities:
                 if self.verbose:
                     print("Running", conf_name, "...")
 
+                experiment = Experiment(
+                    configuration,
+                    eval_metrics=self.eval_metrics,
+                    tuning_metric=self.tuning_metric,
+                    cv=self.cv,
+                    n_jobs=self.n_jobs,
+                    input_preprocessing=self.input_preprocessing,
+                    random_state=self.random_state,
+                )
+
                 # Iterate over partitions.
                 for part_idx, partition in dataset:
                     if self.verbose:
                         print("  Running Partition", part_idx)
 
-                    result = self._run_single(
+                    result = experiment.run(
                         partition["train_inputs"],
                         partition["train_outputs"],
                         partition.get("test_inputs"),
                         partition.get("test_outputs"),
-                        configuration,
                         dataset_name=dataset_name,
-                        conf_name=conf_name,
+                        classifier_name=conf_name,
                         resample_id=part_idx,
                     )
                     self._results.save(result)
-
-    def _run_single(
-        self,
-        X_train: np.ndarray,
-        y_train: np.ndarray,
-        X_test: np.ndarray | None,
-        y_test: np.ndarray | None,
-        configuration: dict[str, Any],
-        *,
-        dataset_name: str,
-        conf_name: str,
-        resample_id: str,
-    ) -> ExperimentResult:
-        """Run one classifier configuration on a single train/test partition.
-
-        This is the single-partition execution unit. It applies optional
-        preprocessing, selects and fits the best estimator, predicts on train
-        and (when present) test splits, computes all evaluation metrics and
-        timing keys, and returns an :class:`ExperimentResult`. It does **not**
-        persist anything to disk; the caller is responsible for calling
-        ``self._results.save(result)`` after this method returns.
-
-        Parameters
-        ----------
-        X_train : ndarray of shape (n_train_samples, n_features)
-            Training feature matrix.
-
-        y_train : ndarray of shape (n_train_samples,)
-            Training labels.
-
-        X_test : ndarray of shape (n_test_samples, n_features) or None
-            Test feature matrix. When ``None`` no test metrics are computed.
-
-        y_test : ndarray of shape (n_test_samples,) or None
-            Test labels. When ``None`` no test metrics are computed.
-
-        configuration : dict
-            Single configuration entry with the form
-            ``{"classifier": str, "parameters": dict}``.
-
-        dataset_name : str
-            Name of the dataset, forwarded to the returned
-            :class:`ExperimentResult`.
-
-        conf_name : str
-            Configuration label, used as ``classifier_name`` in the returned
-            :class:`ExperimentResult`.
-
-        resample_id : str
-            Partition index string, forwarded to the returned
-            :class:`ExperimentResult`.
-
-        Returns
-        -------
-        ExperimentResult
-            Fully populated result for this partition. No side effects.
-
-        """
-        # Apply preprocessing on local copies so the caller's arrays are not mutated.
-        train_inputs: np.ndarray = X_train
-        test_inputs: np.ndarray | None = X_test
-
-        if self.input_preprocessing == "norm":
-            scaler = preprocessing.MinMaxScaler().fit(train_inputs)
-            train_inputs = scaler.transform(train_inputs)
-            test_inputs = scaler.transform(cast(np.ndarray, X_test))
-        elif self.input_preprocessing == "std":
-            scaler = preprocessing.StandardScaler().fit(train_inputs)
-            train_inputs = scaler.transform(train_inputs)
-            test_inputs = scaler.transform(cast(np.ndarray, X_test))
-
-        # Select and fit the best estimator via GridSearchCV or direct fit.
-        optimal_estimator: Any = load_classifier(
-            classifier_name=configuration["classifier"],
-            random_state=self.random_state,
-            n_jobs=self.n_jobs,
-            cv_n_folds=self.cv,
-            cv_metric=self.tuning_metric,
-            param_grid=configuration["parameters"],
-        )
-
-        _fit_start = time()
-        optimal_estimator.fit(train_inputs, y_train)
-        _fit_elapsed = time() - _fit_start
-
-        if not isinstance(optimal_estimator, GridSearchCV):
-            optimal_estimator.refit_time_ = _fit_elapsed
-            optimal_estimator.best_params_ = configuration["parameters"]
-            optimal_estimator.best_estimator_ = optimal_estimator
-
-        # Predict on the training split.
-        train_predicted_y = optimal_estimator.predict(train_inputs)
-
-        # Predict on the test split when it is present.
-        test_predicted_y = None
-        elapsed = np.nan
-        if y_test is not None:
-            assert test_inputs is not None
-            start = time()
-            test_predicted_y = np.asarray(optimal_estimator.predict(test_inputs))
-            elapsed = time() - start
-
-        # Compute evaluation metrics for both splits.
-        train_metrics: OrderedDict[str, Any] = OrderedDict()
-        test_metrics: OrderedDict[str, Any] = OrderedDict()
-        for metric_name in self.eval_metrics:
-            train_score = _compute_metric(
-                metric_name,
-                y_train,
-                train_predicted_y,
-            )
-            train_metrics[metric_name.strip() + "_train"] = train_score
-
-            test_metrics[metric_name.strip() + "_test"] = np.nan
-            if y_test is not None:
-                assert test_predicted_y is not None
-                test_score = _compute_metric(metric_name, y_test, test_predicted_y)
-                test_metrics[metric_name.strip() + "_test"] = test_score
-
-        # Assemble timing keys (GridSearchCV vs direct-fit branches).
-        if isinstance(optimal_estimator, GridSearchCV):
-            train_metrics["cv_time_train"] = optimal_estimator.cv_results_[
-                "mean_fit_time"
-            ].mean()
-            test_metrics["cv_time_test"] = optimal_estimator.cv_results_[
-                "mean_score_time"
-            ].mean()
-            train_metrics["time_train"] = optimal_estimator.refit_time_
-            test_metrics["time_test"] = elapsed
-        else:
-            optimal_estimator.best_params_ = configuration["parameters"]
-            optimal_estimator.best_estimator_ = optimal_estimator
-
-            train_metrics["cv_time_train"] = np.nan
-            test_metrics["cv_time_test"] = np.nan
-            train_metrics["time_train"] = optimal_estimator.refit_time_
-            test_metrics["time_test"] = elapsed
-
-        # Compute class probabilities when available.
-        y_proba = None
-        if y_test is not None and hasattr(
-            optimal_estimator.best_estimator_, "predict_proba"
-        ):
-            assert test_inputs is not None
-            y_proba = optimal_estimator.best_estimator_.predict_proba(test_inputs)
-
-        # Build and return the ExperimentResult; no persistence here.
-        return ExperimentResult(
-            dataset_name=dataset_name,
-            classifier_name=conf_name,
-            resample_id=resample_id,
-            train_predicted_y=train_predicted_y,
-            test_predicted_y=test_predicted_y,
-            y_proba=y_proba,
-            train_metrics=train_metrics,
-            test_metrics=test_metrics,
-            best_params=optimal_estimator.best_params_,
-            best_model=optimal_estimator.best_estimator_,
-            train_true_y=y_train,
-            test_true_y=y_test,
-        )
 
     def write_report(self) -> None:
         """Save summarized information about experiment through Results class."""

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -1,0 +1,223 @@
+"""Tests for the experiment runner module."""
+
+import math
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from skordinal.experiments import Experiment, ExperimentResult
+
+_MINIMAL_CONF: dict = {"classifier": "SVC", "parameters": {}}
+_CONF_CV: dict = {"classifier": "SVC", "parameters": {"C": [0.1, 1.0]}}
+
+
+@pytest.fixture
+def split_with_test():
+    """Return (X_train, y_train, X_test, y_test) with three balanced classes."""
+    rng = np.random.default_rng(0)
+    X_train = rng.standard_normal((30, 4))
+    y_train = np.tile([0, 1, 2], 10)
+    X_test = rng.standard_normal((15, 4))
+    y_test = np.tile([0, 1, 2], 5)
+    return X_train, y_train, X_test, y_test
+
+
+@pytest.fixture
+def split_train_only():
+    """Return (X_train, y_train, None, None) for train-only partition tests."""
+    rng = np.random.default_rng(0)
+    X_train = rng.standard_normal((30, 4))
+    y_train = np.tile([0, 1, 2], 10)
+    return X_train, y_train, None, None
+
+
+def _make_experiment(configuration=None, **kwargs):
+    """Build an Experiment with default eval_metrics for run() seam tests."""
+    if configuration is None:
+        configuration = _MINIMAL_CONF
+    kwargs.setdefault("eval_metrics", ["mean_absolute_error"])
+    return Experiment(configuration, **kwargs)
+
+
+def _call_run(experiment, X_train, y_train, X_test, y_test):
+    """Invoke run() with fixed identity kwargs; returns the ExperimentResult."""
+    return experiment.run(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        dataset_name="ds",
+        classifier_name="cfg",
+        resample_id="0",
+    )
+
+
+def test_empty_eval_metrics_raises():
+    """An empty eval_metrics list raises ValueError."""
+    with pytest.raises(ValueError, match="'eval_metrics' must be a non-empty list"):
+        Experiment(_MINIMAL_CONF, eval_metrics=[])
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, None),
+        ("std", "std"),
+        ("norm", "norm"),
+        (" STD ", "std"),
+        ("NORM", "norm"),
+    ],
+)
+def test_input_preprocessing_accepted_and_normalized(raw, expected):
+    """Valid input_preprocessing values are accepted and lower-stripped."""
+    exp = Experiment(
+        _MINIMAL_CONF, eval_metrics=["mean_absolute_error"], input_preprocessing=raw
+    )
+    assert exp.input_preprocessing == expected
+
+
+@pytest.mark.parametrize("bad_value", ["minmax", ""])
+def test_input_preprocessing_invalid_raises(bad_value):
+    """Unrecognised input_preprocessing values raise ValueError."""
+    with pytest.raises(ValueError, match="'input_preprocessing' must be one of"):
+        Experiment(
+            _MINIMAL_CONF,
+            eval_metrics=["mean_absolute_error"],
+            input_preprocessing=bad_value,
+        )
+
+
+@pytest.mark.parametrize("kwargs, expected", [({}, None), ({"random_state": 42}, 42)])
+def test_random_state_stored(kwargs, expected):
+    """random_state defaults to None and is stored as given on the instance."""
+    exp = Experiment(_MINIMAL_CONF, eval_metrics=["mean_absolute_error"], **kwargs)
+    assert exp.random_state == expected
+
+
+def test_configuration_is_deep_copied():
+    """Mutating the original configuration dict does not affect the stored copy."""
+    original = {"classifier": "SVC", "parameters": {"C": [1]}}
+    exp = Experiment(original, eval_metrics=["mean_absolute_error"])
+    original["parameters"]["C"].append(10)
+    assert exp.configuration["parameters"]["C"] == [1]
+
+
+def test_run_returns_experiment_result(split_with_test):
+    """run returns a populated ExperimentResult."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
+
+    assert isinstance(result, ExperimentResult)
+    assert result.train_predicted_y.shape == (30,)
+
+
+def test_run_identity_passthrough(split_with_test):
+    """dataset_name, classifier_name, and resample_id are forwarded verbatim."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _make_experiment().run(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        dataset_name="my_dataset",
+        classifier_name="my_conf",
+        resample_id="42",
+    )
+
+    assert result.dataset_name == "my_dataset"
+    assert result.classifier_name == "my_conf"
+    assert result.resample_id == "42"
+
+
+@pytest.mark.parametrize("has_test", [True, False])
+def test_run_test_present_vs_absent(split_with_test, split_train_only, has_test):
+    """With test data: test_predicted_y is an array and metrics are finite; without: None and NaN."""
+    X_train, y_train, X_test, y_test = split_with_test if has_test else split_train_only
+    result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
+
+    metric_test_key = "mean_absolute_error_test"
+    if has_test:
+        assert result.test_predicted_y is not None
+        assert result.test_predicted_y.shape == (15,)
+        assert math.isfinite(result.test_metrics[metric_test_key])
+        assert math.isfinite(result.test_metrics["time_test"])
+    else:
+        assert result.test_predicted_y is None
+        assert math.isnan(result.test_metrics[metric_test_key])
+
+
+def test_run_timing_no_cv(split_with_test):
+    """Singleton param grid produces NaN cv_time_* and best_params echoes the config."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
+
+    assert math.isnan(result.train_metrics["cv_time_train"])
+    assert math.isnan(result.test_metrics["cv_time_test"])
+    assert math.isfinite(result.train_metrics["time_train"])
+    assert math.isfinite(result.test_metrics["time_test"])
+    assert result.best_params == _MINIMAL_CONF["parameters"]
+
+
+def test_run_timing_with_cv(split_with_test):
+    """Multi-value param grid produces finite cv_time_* and best_params reflects a searched value."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _call_run(_make_experiment(_CONF_CV), X_train, y_train, X_test, y_test)
+
+    assert math.isfinite(result.train_metrics["cv_time_train"])
+    assert not math.isnan(result.train_metrics["cv_time_train"])
+    assert math.isfinite(result.test_metrics["cv_time_test"])
+    assert math.isfinite(result.train_metrics["time_train"])
+    assert math.isfinite(result.test_metrics["time_test"])
+    assert result.best_params.get("C") in _CONF_CV["parameters"]["C"]
+
+
+@pytest.mark.parametrize("preprocessing", ["std", "norm"])
+def test_run_preprocessing_train_only_raises(split_train_only, preprocessing):
+    """input_preprocessing with X_test=None raises ValueError."""
+    exp = _make_experiment(input_preprocessing=preprocessing)
+    X_train, y_train, X_test, y_test = split_train_only
+    with pytest.raises(ValueError):
+        _call_run(exp, X_train, y_train, X_test, y_test)
+
+
+def test_run_preprocessing_does_not_mutate_inputs(split_with_test):
+    """input_preprocessing='std' operates on copies; caller's arrays are unchanged."""
+    exp = _make_experiment(input_preprocessing="std")
+    X_train, y_train, X_test, y_test = split_with_test
+    train_before = X_train.copy()
+    test_before = X_test.copy()
+
+    _call_run(exp, X_train, y_train, X_test, y_test)
+
+    npt.assert_array_equal(X_train, train_before)
+    npt.assert_array_equal(X_test, test_before)
+
+
+def test_run_metric_keys_for_each_eval_metric(split_with_test):
+    """Each eval metric yields a _train and a _test key in the result."""
+    X_train, y_train, X_test, y_test = split_with_test
+    exp = _make_experiment(eval_metrics=["mean_absolute_error", "accuracy_score"])
+    result = _call_run(exp, X_train, y_train, X_test, y_test)
+
+    for name in ("mean_absolute_error", "accuracy_score"):
+        assert name + "_train" in result.train_metrics
+        assert name + "_test" in result.test_metrics
+
+
+def test_run_y_proba_absent_without_predict_proba(split_with_test):
+    """y_proba is None when the fitted estimator has no predict_proba."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
+
+    assert result.y_proba is None
+
+
+def test_run_y_proba_present_with_predict_proba(split_with_test):
+    """y_proba is populated when the estimator supports predict_proba."""
+    X_train, y_train, X_test, y_test = split_with_test
+    conf = {"classifier": "SVC", "parameters": {"probability": [True]}}
+    result = _call_run(_make_experiment(conf), X_train, y_train, X_test, y_test)
+
+    assert result.y_proba is not None
+    assert result.y_proba.shape[0] == X_test.shape[0]

--- a/skordinal/experiments/tests/test_utilities.py
+++ b/skordinal/experiments/tests/test_utilities.py
@@ -1,18 +1,15 @@
 """Tests for the experiment utilities module."""
 
-import math
 from pathlib import Path
 
 import numpy as np
-import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from skordinal.experiments import ExperimentResult, Utilities
+from skordinal.experiments import Utilities
 from skordinal.experiments._utilities import _load_dataset
 
 _MINIMAL_CONF = {"cfg": {"classifier": "SVC", "parameters": {}}}
-_CONF_CV: dict = {"classifier": "SVC", "parameters": {"C": [0.1, 1.0]}}
 
 
 def create_csv(path, filename):
@@ -285,174 +282,3 @@ def test_configurations_is_deep_copied(tmp_path):
     )
     original["cfg"]["parameters"]["C"].append(10)
     assert util.configurations["cfg"]["parameters"]["C"] == [1]
-
-
-@pytest.fixture
-def run_single_util(tmp_path):
-    """Minimal Utilities instance configured for _run_single seam tests."""
-    return Utilities(
-        _MINIMAL_CONF,
-        data_path=".",
-        datasets=["x"],
-        eval_metrics=["mean_absolute_error"],
-        results_path=str(tmp_path),
-    )
-
-
-@pytest.fixture
-def run_single_util_std(tmp_path):
-    """Utilities instance with input_preprocessing='std' for mutation tests."""
-    return Utilities(
-        _MINIMAL_CONF,
-        data_path=".",
-        datasets=["x"],
-        eval_metrics=["mean_absolute_error"],
-        results_path=str(tmp_path),
-        input_preprocessing="std",
-    )
-
-
-@pytest.fixture
-def split_with_test():
-    """Return (X_train, y_train, X_test, y_test) with three balanced classes."""
-    rng = np.random.default_rng(0)
-    X_train = rng.standard_normal((30, 4))
-    y_train = np.tile([0, 1, 2], 10)
-    X_test = rng.standard_normal((15, 4))
-    y_test = np.tile([0, 1, 2], 5)
-    return X_train, y_train, X_test, y_test
-
-
-@pytest.fixture
-def split_train_only():
-    """Return (X_train, y_train, None, None) for train-only partition tests."""
-    rng = np.random.default_rng(0)
-    X_train = rng.standard_normal((30, 4))
-    y_train = np.tile([0, 1, 2], 10)
-    return X_train, y_train, None, None
-
-
-def _call_run_single(util, X_train, y_train, X_test, y_test, conf=None):
-    """Invoke _run_single with fixed identity kwargs; returns the ExperimentResult."""
-    if conf is None:
-        conf = _MINIMAL_CONF["cfg"]
-    return util._run_single(
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        conf,
-        dataset_name="ds",
-        conf_name="cfg",
-        resample_id="0",
-    )
-
-
-def test_run_single_returns_experiment_result_and_does_not_persist(
-    tmp_path, run_single_util, split_with_test
-):
-    """_run_single returns an ExperimentResult without writing any files."""
-    X_train, y_train, X_test, y_test = split_with_test
-    result = _call_run_single(run_single_util, X_train, y_train, X_test, y_test)
-
-    assert isinstance(result, ExperimentResult)
-    written = list(tmp_path.iterdir())
-    assert written == [], f"_run_single wrote files unexpectedly: {written}"
-
-
-def test_run_single_identity_passthrough(run_single_util, split_with_test):
-    """dataset_name, classifier_name, and resample_id are forwarded verbatim."""
-    X_train, y_train, X_test, y_test = split_with_test
-    result = run_single_util._run_single(
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        _MINIMAL_CONF["cfg"],
-        dataset_name="my_dataset",
-        conf_name="my_conf",
-        resample_id="42",
-    )
-
-    assert result.dataset_name == "my_dataset"
-    assert result.classifier_name == "my_conf"
-    assert result.resample_id == "42"
-
-
-@pytest.mark.parametrize("has_test", [True, False])
-def test_run_single_test_present_vs_absent(
-    run_single_util, split_with_test, split_train_only, has_test
-):
-    """With test data: test_predicted_y is an array and metrics are finite; without: None and NaN."""
-    X_train, y_train, X_test, y_test = split_with_test if has_test else split_train_only
-    result = _call_run_single(run_single_util, X_train, y_train, X_test, y_test)
-
-    metric_test_key = "mean_absolute_error_test"
-    if has_test:
-        assert result.test_predicted_y is not None
-        assert result.test_predicted_y.shape == (15,)
-        assert math.isfinite(result.test_metrics[metric_test_key])
-        assert math.isfinite(result.test_metrics["time_test"])
-    else:
-        assert result.test_predicted_y is None
-        assert math.isnan(result.test_metrics[metric_test_key])
-
-
-def test_run_single_timing_no_cv(run_single_util, split_with_test):
-    """Singleton param grid produces NaN cv_time_* and best_params echoes the config."""
-    X_train, y_train, X_test, y_test = split_with_test
-    result = _call_run_single(run_single_util, X_train, y_train, X_test, y_test)
-
-    assert math.isnan(result.train_metrics["cv_time_train"])
-    assert math.isnan(result.test_metrics["cv_time_test"])
-    assert math.isfinite(result.train_metrics["time_train"])
-    assert math.isfinite(result.test_metrics["time_test"])
-    assert result.best_params == _MINIMAL_CONF["cfg"]["parameters"]
-
-
-def test_run_single_timing_with_cv(run_single_util, split_with_test):
-    """Multi-value param grid produces finite cv_time_* and best_params reflects a searched value."""
-    X_train, y_train, X_test, y_test = split_with_test
-    result = _call_run_single(
-        run_single_util, X_train, y_train, X_test, y_test, conf=_CONF_CV
-    )
-
-    assert math.isfinite(result.train_metrics["cv_time_train"])
-    assert not math.isnan(result.train_metrics["cv_time_train"])
-    assert math.isfinite(result.test_metrics["cv_time_test"])
-    assert not math.isnan(result.test_metrics["cv_time_test"])
-    assert math.isfinite(result.train_metrics["time_train"])
-    assert math.isfinite(result.test_metrics["time_test"])
-    assert result.best_params.get("C") in _CONF_CV["parameters"]["C"]
-
-
-@pytest.mark.parametrize("preprocessing", ["std", "norm"])
-def test_run_single_preprocessing_train_only_raises(
-    tmp_path, split_train_only, preprocessing
-):
-    """input_preprocessing with X_test=None raises ValueError."""
-    util = Utilities(
-        _MINIMAL_CONF,
-        data_path=".",
-        datasets=["x"],
-        eval_metrics=["mean_absolute_error"],
-        results_path=str(tmp_path),
-        input_preprocessing=preprocessing,
-    )
-    X_train, y_train, X_test, y_test = split_train_only
-    with pytest.raises(ValueError):
-        _call_run_single(util, X_train, y_train, X_test, y_test)
-
-
-def test_run_single_preprocessing_does_not_mutate_inputs(
-    run_single_util_std, split_with_test
-):
-    """input_preprocessing='std' operates on copies; caller's arrays are unchanged."""
-    X_train, y_train, X_test, y_test = split_with_test
-    train_before = X_train.copy()
-    test_before = X_test.copy()
-
-    _call_run_single(run_single_util_std, X_train, y_train, X_test, y_test)
-
-    npt.assert_array_equal(X_train, train_before)
-    npt.assert_array_equal(X_test, test_before)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `Experiment`, a runner that fits one classifier configuration on a single train/test partition and returns an `ExperimentResult` (predictions, metrics, timings, best params and model) without writing to disk.

`Utilities` now delegates each partition run to `Experiment`, dropping its duplicated single-partition logic. Behavior is unchanged.