### PR TITLE
FIX: Point coverage source to skordinal

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,5 +3,5 @@ show_missing = True
 
 [run]
 branch = True
-source = orca_python
+source = skordinal
 parallel = True


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Points the coverage `source` in `.coveragerc` to `skordinal`, replacing the stale `orca_python` from the project rename. That package no longer exists, so coverage runs driven by the config file collected no data.