### PR TITLE
REF: Rename Utilities to Benchmark

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from pathlib import Path
 
-from skordinal.experiments import Utilities
+from skordinal.experiments import Benchmark
 
 
 def main(general_conf, configurations):
@@ -18,7 +18,7 @@ def main(general_conf, configurations):
             + "For more information about using this framework, please refer to the README."
         )
 
-    interface = Utilities(
+    benchmark = Benchmark(
         configurations,
         data_path=general_conf["basedir"],
         datasets=general_conf["datasets"],
@@ -30,8 +30,8 @@ def main(general_conf, configurations):
         input_preprocessing=general_conf.get("input_preprocessing"),
         random_state=general_conf.get("random_state"),
     )
-    interface.run_experiment()
-    interface.write_report()
+    benchmark.run()
+    benchmark.summarize()
 
 
 if __name__ == "__main__":

--- a/skordinal/experiments/__init__.py
+++ b/skordinal/experiments/__init__.py
@@ -1,7 +1,7 @@
 """Experiments orchestration module."""
 
+from ._benchmark import Benchmark
 from ._experiment import Experiment
 from ._results import ExperimentResult, Results
-from ._utilities import Utilities
 
-__all__ = ["Experiment", "ExperimentResult", "Results", "Utilities"]
+__all__ = ["Benchmark", "Experiment", "ExperimentResult", "Results"]

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -1,4 +1,4 @@
-"""Utility class for running experiments."""
+"""Benchmark runner for ordinal classification experiments."""
 
 from __future__ import annotations
 
@@ -100,15 +100,14 @@ def _load_dataset(dataset_path: Path) -> list[tuple[str, dict[str, Any]]]:
     return sorted_list
 
 
-class Utilities:
-    """Run experiments over N datasets with M different configurations.
+class Benchmark:
+    """Run a benchmark of M configurations across N datasets and their partitions.
 
-    Configurations are composed of a classifier method and different parameters,
-    where it may be multiple values for every one of them.
-
-    Running the main function of this class will perform cross-validation for
-    each partition per dataset-configuration pair, obtaining the most optimal
-    model, which is then used to infer labels for the test sets.
+    Each configuration pairs a classifier method with one or more hyper-parameter
+    values. Calling :meth:`run` performs cross-validation for every partition of
+    each dataset-configuration pair, fits the selected model, predicts the test
+    labels, and stores all metrics in a :class:`Results` object. :meth:`summarize`
+    then writes the aggregated train and test summaries.
 
     Parameters
     ----------
@@ -169,15 +168,16 @@ class Utilities:
 
     Examples
     --------
-    >>> from skordinal.experiments import Utilities  # doctest: +SKIP
-    >>> u = Utilities(  # doctest: +SKIP
+    >>> from skordinal.experiments import Benchmark  # doctest: +SKIP
+    >>> benchmark = Benchmark(  # doctest: +SKIP
     ...     configurations={"SVM": {"classifier": "svc", "parameters": {"C": [1]}}},
     ...     data_path="/data/ordinal",
     ...     datasets=["balance-scale"],
     ...     eval_metrics=["mean_absolute_error"],
     ...     results_path="/tmp/results",
     ... )
-    >>> u.run_experiment()  # doctest: +SKIP
+    >>> benchmark.run()  # doctest: +SKIP
+    >>> benchmark.summarize()  # doctest: +SKIP
 
     """
 
@@ -231,8 +231,8 @@ class Utilities:
         self.random_state = random_state
         self.verbose = verbose
 
-    def run_experiment(self) -> None:
-        """Run an experiment. Main method of this framework.
+    def run(self) -> None:
+        """Run the benchmark over every dataset, configuration and partition.
 
         Loads all datasets, which can be fragmented in partitions. Builds a model
         per partition, using cross-validation to find the optimal values among the
@@ -259,7 +259,7 @@ class Utilities:
 
         if self.verbose:
             print("\n###############################")
-            print("\tRunning Experiment")
+            print("\tRunning Benchmark")
             print("###############################")
 
         # Iterate over datasets.
@@ -304,10 +304,10 @@ class Utilities:
                     )
                     self._results.save(result)
 
-    def write_report(self) -> None:
-        """Save summarized information about experiment through Results class."""
+    def summarize(self) -> None:
+        """Write the aggregated train and test summaries via the Results object."""
         if self.verbose:
-            print("\nSaving Results...")
+            print("\nSaving summary...")
 
         for split in ("train", "test"):
             try:

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -1,4 +1,4 @@
-"""Tests for the experiment utilities module."""
+"""Tests for the benchmark runner module."""
 
 from pathlib import Path
 
@@ -6,8 +6,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from skordinal.experiments import Utilities
-from skordinal.experiments._utilities import _load_dataset
+from skordinal.experiments import Benchmark
+from skordinal.experiments._benchmark import _load_dataset
 
 _MINIMAL_CONF = {"cfg": {"classifier": "SVC", "parameters": {}}}
 
@@ -27,12 +27,12 @@ def _write_partition_csv(directory, filename, n_per_class=10):
     np.savetxt(directory / filename, data, delimiter=",", fmt="%d")
 
 
-def _from_general_conf(general_conf: dict, configurations: dict, **kwargs) -> Utilities:
-    """Construct Utilities from an old-style ``general_conf`` dict.
+def _from_general_conf(general_conf: dict, configurations: dict, **kwargs) -> Benchmark:
+    """Construct Benchmark from an old-style ``general_conf`` dict.
 
     Keeps test call-sites readable without duplicating the key mapping.
     """
-    return Utilities(
+    return Benchmark(
         configurations,
         data_path=general_conf["basedir"],
         datasets=general_conf["datasets"],
@@ -85,11 +85,11 @@ def svm_conf():
     }
 
 
-def test_run_experiment(tmp_path, experiment_conf, svm_conf):
-    """run_experiment and write_report produce the expected on-disk layout."""
-    util = _from_general_conf(experiment_conf, svm_conf, verbose=False)
-    util.run_experiment()
-    util.write_report()
+def test_run_and_summarize(tmp_path, experiment_conf, svm_conf):
+    """run and summarize produce the expected on-disk layout."""
+    benchmark = _from_general_conf(experiment_conf, svm_conf, verbose=False)
+    benchmark.run()
+    benchmark.summarize()
 
     runs_dir = Path(experiment_conf["output_folder"])
     assert runs_dir.exists()
@@ -174,7 +174,7 @@ def test_load_nontrainfile_dataset(tmp_path):
 def test_empty_configurations_raises(tmp_path):
     """An empty configurations dict raises ValueError."""
     with pytest.raises(ValueError, match="'configurations' must be a non-empty dict"):
-        Utilities(
+        Benchmark(
             {},
             data_path=".",
             datasets=["x"],
@@ -186,7 +186,7 @@ def test_empty_configurations_raises(tmp_path):
 def test_none_configurations_raises(tmp_path):
     """None configurations is rejected by the non-empty check (ValueError)."""
     with pytest.raises(ValueError, match="'configurations' must be a non-empty dict"):
-        Utilities(
+        Benchmark(
             None,  # type: ignore[arg-type]
             data_path=".",
             datasets=["x"],
@@ -198,7 +198,7 @@ def test_none_configurations_raises(tmp_path):
 def test_empty_datasets_raises(tmp_path):
     """An empty datasets list raises ValueError."""
     with pytest.raises(ValueError, match="'datasets' must be a non-empty list"):
-        Utilities(
+        Benchmark(
             _MINIMAL_CONF,
             data_path=".",
             datasets=[],
@@ -210,7 +210,7 @@ def test_empty_datasets_raises(tmp_path):
 def test_empty_eval_metrics_raises(tmp_path):
     """An empty eval_metrics list raises ValueError."""
     with pytest.raises(ValueError, match="'eval_metrics' must be a non-empty list"):
-        Utilities(
+        Benchmark(
             _MINIMAL_CONF,
             data_path=".",
             datasets=["x"],
@@ -231,7 +231,7 @@ def test_empty_eval_metrics_raises(tmp_path):
 )
 def test_input_preprocessing_accepted_and_normalized(tmp_path, raw, expected):
     """Valid input_preprocessing values are accepted and lower-stripped."""
-    util = Utilities(
+    benchmark = Benchmark(
         _MINIMAL_CONF,
         data_path=".",
         datasets=["x"],
@@ -239,14 +239,14 @@ def test_input_preprocessing_accepted_and_normalized(tmp_path, raw, expected):
         results_path=str(tmp_path),
         input_preprocessing=raw,
     )
-    assert util.input_preprocessing == expected
+    assert benchmark.input_preprocessing == expected
 
 
 @pytest.mark.parametrize("bad_value", ["minmax", ""])
 def test_input_preprocessing_invalid_raises(tmp_path, bad_value):
     """Unrecognised input_preprocessing values raise ValueError."""
     with pytest.raises(ValueError, match="'input_preprocessing' must be one of"):
-        Utilities(
+        Benchmark(
             _MINIMAL_CONF,
             data_path=".",
             datasets=["x"],
@@ -259,7 +259,7 @@ def test_input_preprocessing_invalid_raises(tmp_path, bad_value):
 @pytest.mark.parametrize("kwargs, expected", [({}, None), ({"random_state": 42}, 42)])
 def test_random_state_stored(tmp_path, kwargs, expected):
     """random_state defaults to None and is stored as given on the instance."""
-    util = Utilities(
+    benchmark = Benchmark(
         _MINIMAL_CONF,
         data_path=".",
         datasets=["x"],
@@ -267,13 +267,13 @@ def test_random_state_stored(tmp_path, kwargs, expected):
         results_path=str(tmp_path),
         **kwargs,
     )
-    assert util.random_state == expected
+    assert benchmark.random_state == expected
 
 
 def test_configurations_is_deep_copied(tmp_path):
     """Mutating the original configurations dict does not affect the stored copy."""
     original = {"cfg": {"classifier": "SVC", "parameters": {"C": [1]}}}
-    util = Utilities(
+    benchmark = Benchmark(
         original,
         data_path=".",
         datasets=["x"],
@@ -281,4 +281,4 @@ def test_configurations_is_deep_copied(tmp_path):
         results_path=str(tmp_path),
     )
     original["cfg"]["parameters"]["C"].append(10)
-    assert util.configurations["cfg"]["parameters"]["C"] == [1]
+    assert benchmark.configurations["cfg"]["parameters"]["C"] == [1]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Renames the `Utilities` runner to `Benchmark`, with `run_experiment` and `write_report` becoming `run` and `summarize`. Parameters, behaviour, and outputs are unchanged. The `config.py` CLI driver is updated to match.