### PR TITLE
FIX: Guard REDSVM gamma=scale against zero variance

### DIFF
--- a/skordinal/classifiers/_redsvm.py
+++ b/skordinal/classifiers/_redsvm.py
@@ -43,7 +43,7 @@ class REDSVM(ClassifierMixin, BaseEstimator):
     degree : int, default=3
         Set degree in kernel function.
 
-    gamma : {'scale', 'auto'} or float, default=1.0
+    gamma : {'scale', 'auto'} or float, default='auto'
         Kernel coefficient determining the influence of individual training samples:
         - 'scale': 1 / (n_features * X.var())
         - 'auto': 1 / n_features
@@ -163,7 +163,8 @@ class REDSVM(ClassifierMixin, BaseEstimator):
         if self.gamma == "auto":
             gamma_value = 1.0 / X.shape[1]
         elif self.gamma == "scale":
-            gamma_value = 1.0 / (X.shape[1] * X.var())
+            x_var = X.var()
+            gamma_value = 1.0 / (X.shape[1] * x_var) if x_var != 0.0 else 1.0
 
         # Map kernel type
         kernel_type_mapping = {

--- a/skordinal/classifiers/tests/test_redsvm.py
+++ b/skordinal/classifiers/tests/test_redsvm.py
@@ -1,6 +1,7 @@
 """Tests for the REDSVM classifier."""
 
 import inspect
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -203,3 +204,13 @@ def test_redsvm_label_roundtrip(labels):
 
     assert np.array_equal(classifier.classes_, np.unique(labels_array))
     assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_redsvm_gamma_scale_zero_variance(X, y):
+    """Test that gamma='scale' handles zero-variance input without dividing by zero."""
+    X_constant = np.ones_like(X)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        classifier = REDSVM(gamma="scale", kernel="rbf").fit(X_constant, y)
+
+    assert set(classifier.predict(X_constant)).issubset(set(classifier.classes_))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Guards REDSVM's `gamma='scale'` against a zero-variance input, falling back to 1.0 instead of dividing by zero, as scikit-learn does. It also corrects the `gamma` docstring default to `'auto'`.