### PR TITLE
REF: Switch benchmark recipes from JSON to Python modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ All dependencies are managed through `pyproject.toml` and include:
 Test your installation with the provided example:
 
 ```bash
-python config.py examples/recipes/full_demo.json
+python config.py examples/recipes/full_demo.py
 ```
 
 ## Quick Start
@@ -74,23 +74,27 @@ skordinal includes sample datasets with pre-partitioned train/test splits using 
 
 **Basic experiment configuration:**
 
-```json
-{
+A recipe is a Python file that defines a top-level `RECIPE` dict with two
+sections: `general_conf` (run-wide settings) and `configurations` (classifier
+definitions).
+
+```python
+RECIPE = {
     "general_conf": {
         "basedir": "skordinal/datasets/data",
         "datasets": ["balance_scale", "era", "esl"],
         "hyperparam_cv_nfolds": 3,
         "output_folder": "results/",
         "metrics": ["accuracy_score", "mean_absolute_error", "average_mean_absolute_error"],
-        "cv_metric": "neg_mean_absolute_error"
+        "cv_metric": "neg_mean_absolute_error",
     },
     "configurations": {
         "SVM": {
             "classifier": "SVC",
             "parameters": {
                 "C": [0.001, 0.1, 1, 10, 100],
-                "gamma": [0.1, 1, 10]
-            }
+                "gamma": [0.1, 1, 10],
+            },
         },
         "SVMOP": {
             "classifier": "OrdinalDecomposition",
@@ -101,24 +105,24 @@ skordinal includes sample datasets with pre-partitioned train/test splits using 
                 "parameters": {
                     "C": [0.01, 0.1, 1, 10],
                     "gamma": [0.01, 0.1, 1, 10],
-                    "probability": [true]
-                }
-            }
-        }
-    }
+                    "probability": [True],
+                },
+            },
+        },
+    },
 }
 ```
 
 **Run the experiment:**
 ```bash
-python config.py my_experiment.json
+python config.py my_experiment.py
 ```
 
 Results are saved in `results/` folder with performance metrics for each dataset-classifier combination. The framework automatically performs cross-validation, hyperparameter tuning, and evaluation on test sets.
 
 ## Configuration Files
 
-Experiments are defined using JSON configuration files with two main sections: general_conf for experiment settings and configurations for classifier definitions.
+Experiments are defined using Python recipe files (a module exposing a top-level `RECIPE` dict) with two main sections: general_conf for experiment settings and configurations for classifier definitions.
 
 ### general-conf
 
@@ -149,7 +153,7 @@ Defines classifiers and their hyperparameters for GridSearchCV. Each configurati
 ### Basic Usage
 
 ```bash
-python config.py experiment_file.json
+python config.py experiment_file.py
 ```
 
 ### Example Output

--- a/config.py
+++ b/config.py
@@ -1,11 +1,62 @@
+"""Command-line runner for skordinal benchmark recipes."""
+
 import argparse
-import json
+import importlib.util
+import sys
 from pathlib import Path
+from typing import Any
 
 from skordinal.experiments import Benchmark
 
 
-def main(general_conf, configurations):
+def load_recipe(path: str | Path) -> dict[str, Any]:
+    """Import a recipe ``.py`` file and return its ``RECIPE`` dict.
+
+    The module is imported under a synthetic name and removed from
+    ``sys.modules`` after the call, so successive loads of recipes placed at
+    the same path always pick up fresh state.
+
+    Parameters
+    ----------
+    path : str or Path
+        Filesystem path to the recipe file.
+
+    Returns
+    -------
+    recipe : dict
+        The recipe's top-level ``RECIPE`` dict, with ``general_conf`` and
+        ``configurations`` keys.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist or is not a file, or if the module spec
+        cannot be created.
+    AttributeError
+        If the module does not expose a ``RECIPE`` attribute.
+    """
+    recipe_path = Path(path).expanduser()
+    if not recipe_path.is_file():
+        raise FileNotFoundError(f"Recipe file not found: {recipe_path}.")
+
+    module_name = f"_skordinal_recipe_{recipe_path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, recipe_path)
+    if spec is None or spec.loader is None:
+        raise FileNotFoundError(f"Could not load recipe module at {recipe_path}.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        if not hasattr(module, "RECIPE"):
+            raise AttributeError(
+                f"Recipe at {recipe_path} does not define a top-level RECIPE dict."
+            )
+        return module.RECIPE
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def main(general_conf: dict[str, Any], configurations: dict[str, Any]) -> None:
     if not general_conf["basedir"] or not general_conf["datasets"]:
         raise RuntimeError(
             "A dataset has to be defined to run this program.\n"
@@ -36,10 +87,9 @@ def main(general_conf, configurations):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run a skordinal experiment.")
-    parser.add_argument("config", type=Path, help="Path to a JSON configuration file.")
+    parser.add_argument("config", type=Path, help="Path to a Python recipe file (.py).")
     args = parser.parse_args()
 
-    with args.config.open() as f:
-        recipe = json.load(f)
+    recipe = load_recipe(args.config)
 
     main(recipe["general_conf"], recipe["configurations"])

--- a/examples/recipes/full_demo.py
+++ b/examples/recipes/full_demo.py
@@ -1,4 +1,6 @@
-{
+"""Several ordinal classifiers and a nominal baseline across three datasets."""
+
+RECIPE = {
     "general_conf": {
         "basedir": "skordinal/datasets/data",
         "datasets": ["balance_scale", "era", "esl"],
@@ -6,16 +8,21 @@
         "jobs": 1,
         "input_preprocessing": "std",
         "output_folder": "results/",
-        "metrics": ["accuracy_score", "mean_absolute_error", "average_mean_absolute_error", "mean_zero_one_error"],
-        "cv_metric": "neg_mean_absolute_error"
+        "metrics": [
+            "accuracy_score",
+            "mean_absolute_error",
+            "average_mean_absolute_error",
+            "mean_zero_one_error",
+        ],
+        "cv_metric": "neg_mean_absolute_error",
     },
     "configurations": {
         "SVM": {
             "classifier": "SVC",
             "parameters": {
                 "C": [0.001, 0.1, 1, 10, 100],
-                "gamma": [0.1, 1, 10]
-            }
+                "gamma": [0.1, 1, 10],
+            },
         },
         "SVMOP": {
             "classifier": "OrdinalDecomposition",
@@ -26,9 +33,9 @@
                 "parameters": {
                     "C": [0.01, 0.1, 1, 10],
                     "gamma": [0.01, 0.1, 1, 10],
-                    "probability": [true]
-                }
-            }
+                    "probability": [True],
+                },
+            },
         },
         "LR": {
             "classifier": "OrdinalDecomposition",
@@ -37,9 +44,9 @@
                 "decision_method": "exponential_loss",
                 "base_classifier": "LogisticRegression",
                 "parameters": {
-                    "C": [0.01, 0.1, 1, 10]
-                }
-            }
+                    "C": [0.01, 0.1, 1, 10],
+                },
+            },
         },
         "REDSVM": {
             "classifier": "REDSVM",
@@ -50,8 +57,8 @@
                 "coef0": 0,
                 "C": 1,
                 "tol": 0.001,
-                "shrinking": true
-            }
+                "shrinking": True,
+            },
         },
         "SVOREX": {
             "classifier": "SVOREX",
@@ -59,8 +66,8 @@
                 "kernel": "rbf",
                 "C": [0.1, 1, 10],
                 "gamma": [0.1, 1, 10],
-                "tol": 0.001
-            }
-        }
-    }
+                "tol": 0.001,
+            },
+        },
+    },
 }

--- a/examples/recipes/nnop_demo.py
+++ b/examples/recipes/nnop_demo.py
@@ -1,4 +1,6 @@
-{
+"""NNOP ordinal neural network classifier on balance_scale."""
+
+RECIPE = {
     "general_conf": {
         "basedir": "skordinal/datasets/data",
         "datasets": ["balance_scale"],
@@ -6,18 +8,22 @@
         "jobs": 1,
         "input_preprocessing": "std",
         "output_folder": "results/",
-        "metrics": ["accuracy_score", "mean_absolute_error", "mean_zero_one_error"],
-        "cv_metric": "neg_mean_absolute_error"
+        "metrics": [
+            "accuracy_score",
+            "mean_absolute_error",
+            "mean_zero_one_error",
+        ],
+        "cv_metric": "neg_mean_absolute_error",
     },
     "configurations": {
-        "NNPOM": {
-            "classifier": "NNPOM",
+        "NNOP": {
+            "classifier": "NNOP",
             "parameters": {
                 "epsilon_init": 0.5,
                 "n_hidden": [5, 10, 20, 30, 40, 50],
                 "max_iter": [250, 500],
-                "alpha": [0.001, 0.01, 1]
-            }
-        }
-    }
+                "alpha": [0.001, 0.01, 1],
+            },
+        },
+    },
 }

--- a/examples/recipes/nnpom_demo.py
+++ b/examples/recipes/nnpom_demo.py
@@ -1,4 +1,6 @@
-{
+"""NNPOM ordinal neural network classifier on balance_scale."""
+
+RECIPE = {
     "general_conf": {
         "basedir": "skordinal/datasets/data",
         "datasets": ["balance_scale"],
@@ -6,18 +8,22 @@
         "jobs": 1,
         "input_preprocessing": "std",
         "output_folder": "results/",
-        "metrics": ["accuracy_score", "mean_absolute_error", "mean_zero_one_error"],
-        "cv_metric": "neg_mean_absolute_error"
+        "metrics": [
+            "accuracy_score",
+            "mean_absolute_error",
+            "mean_zero_one_error",
+        ],
+        "cv_metric": "neg_mean_absolute_error",
     },
     "configurations": {
-        "NNOP": {
-            "classifier": "NNOP",
+        "NNPOM": {
+            "classifier": "NNPOM",
             "parameters": {
                 "epsilon_init": 0.5,
                 "n_hidden": [5, 10, 20, 30, 40, 50],
                 "max_iter": [250, 500],
-                "alpha": [0.001, 0.01, 1]
-            }
-        }
-    }
+                "alpha": [0.001, 0.01, 1],
+            },
+        },
+    },
 }

--- a/examples/recipes/redsvm_demo.py
+++ b/examples/recipes/redsvm_demo.py
@@ -1,4 +1,6 @@
-{
+"""REDSVM SVM-based ordinal classifier on balance_scale."""
+
+RECIPE = {
     "general_conf": {
         "basedir": "skordinal/datasets/data",
         "datasets": ["balance_scale"],
@@ -6,8 +8,12 @@
         "jobs": 1,
         "input_preprocessing": "std",
         "output_folder": "results/",
-        "metrics": ["accuracy_score", "mean_absolute_error", "mean_zero_one_error"],
-        "cv_metric": "neg_mean_absolute_error"
+        "metrics": [
+            "accuracy_score",
+            "mean_absolute_error",
+            "mean_zero_one_error",
+        ],
+        "cv_metric": "neg_mean_absolute_error",
     },
     "configurations": {
         "REDSVM": {
@@ -15,8 +21,8 @@
             "parameters": {
                 "kernel": "rbf",
                 "C": [0.001, 0.01, 0.1, 1, 10, 100, 1000],
-                "gamma": [0.001, 0.01, 0.1, 1, 10, 100, 1000]
-            }
-        }
-    }
+                "gamma": [0.001, 0.01, 0.1, 1, 10, 100, 1000],
+            },
+        },
+    },
 }

--- a/examples/recipes/svmop_demo.py
+++ b/examples/recipes/svmop_demo.py
@@ -1,4 +1,6 @@
-{
+"""SVMOP ordered-partitions SVC decomposition on balance_scale."""
+
+RECIPE = {
     "general_conf": {
         "basedir": "skordinal/datasets/data",
         "datasets": ["balance_scale"],
@@ -6,8 +8,12 @@
         "jobs": 1,
         "input_preprocessing": "std",
         "output_folder": "results/",
-        "metrics": ["accuracy_score", "mean_absolute_error", "mean_zero_one_error"],
-        "cv_metric": "neg_mean_absolute_error"
+        "metrics": [
+            "accuracy_score",
+            "mean_absolute_error",
+            "mean_zero_one_error",
+        ],
+        "cv_metric": "neg_mean_absolute_error",
     },
     "configurations": {
         "SVMOP": {
@@ -19,9 +25,9 @@
                 "parameters": {
                     "C": [0.1, 1, 10],
                     "gamma": [0.1, 1, 10],
-                    "probability": [true]
-                }
-            }
-        }
-    }
+                    "probability": [True],
+                },
+            },
+        },
+    },
 }

--- a/examples/recipes/svorex_demo.py
+++ b/examples/recipes/svorex_demo.py
@@ -1,4 +1,6 @@
-{
+"""SVOREX kernel and regularisation grid search on balance_scale."""
+
+RECIPE = {
     "general_conf": {
         "basedir": "skordinal/datasets/data",
         "datasets": ["balance_scale"],
@@ -6,8 +8,12 @@
         "jobs": 1,
         "input_preprocessing": "std",
         "output_folder": "results/",
-        "metrics": ["accuracy_score", "mean_absolute_error", "mean_zero_one_error"],
-        "cv_metric": "neg_mean_absolute_error"
+        "metrics": [
+            "accuracy_score",
+            "mean_absolute_error",
+            "mean_zero_one_error",
+        ],
+        "cv_metric": "neg_mean_absolute_error",
     },
     "configurations": {
         "SVOREX": {
@@ -15,8 +21,8 @@
             "parameters": {
                 "kernel": "rbf",
                 "C": [0.001, 0.01, 0.1, 1, 10, 100, 1000],
-                "gamma": [0.001, 0.01, 0.1, 1, 10, 100, 1000]
-            }
-        }
-    }
+                "gamma": [0.001, 0.01, 0.1, 1, 10, 100, 1000],
+            },
+        },
+    },
 }


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Switches benchmark recipes from JSON files to Python modules. Each recipe is now a `.py` file exposing a top-level `RECIPE` dict (`general_conf` + `configurations`); `config.py` imports it via `load_recipe` instead of `json.load`. The schema is unchanged, so `Benchmark` behaves identically. Converts the six example recipes and updates the README.