### PR TITLE
ENH: Add ModelConfig to experiments

### DIFF
--- a/skordinal/experiments/__init__.py
+++ b/skordinal/experiments/__init__.py
@@ -2,6 +2,7 @@
 
 from ._benchmark import Benchmark
 from ._experiment import Experiment
+from ._model_config import ModelConfig
 from ._results import ExperimentResult, Results
 
-__all__ = ["Benchmark", "Experiment", "ExperimentResult", "Results"]
+__all__ = ["Benchmark", "Experiment", "ExperimentResult", "ModelConfig", "Results"]

--- a/skordinal/experiments/_model_config.py
+++ b/skordinal/experiments/_model_config.py
@@ -1,0 +1,135 @@
+"""Per-algorithm configuration: estimator binding and hyper-parameter grid."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from sklearn.base import BaseEstimator, clone
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    """Bind a sklearn estimator to an optional hyper-parameter grid.
+
+    ``ModelConfig`` is a pure, immutable description of what to run.
+    It carries no evaluation protocol (cv folds, metric, seed) — those
+    live on the orchestrator that consumes it.
+
+    Parameters
+    ----------
+    estimator : BaseEstimator
+        Untrained sklearn-compatible estimator instance.
+
+    param_grid : dict[str, Any] or None, keyword-only, default=None
+        Hyper-parameter grid mapping parameter names to a value or list
+        of values.  ``None`` means the estimator is fitted as-is.
+
+    Raises
+    ------
+    TypeError
+        If ``estimator`` is not a ``BaseEstimator`` instance, or if
+        ``param_grid`` is neither a ``dict`` nor ``None``.
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> cfg = ModelConfig(LogisticRegression())
+    >>> cfg.param_grid is None
+    True
+    >>> cfg_grid = ModelConfig(
+    ...     LogisticRegression(),
+    ...     param_grid={"C": [0.1, 1.0, 10.0]},
+    ... )
+    >>> cfg_grid.needs_search
+    True
+    """
+
+    estimator: BaseEstimator
+    param_grid: dict[str, Any] | None = field(kw_only=True, default=None)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.estimator, BaseEstimator):
+            raise TypeError(
+                "estimator must be a sklearn-compatible BaseEstimator instance."
+            )
+        if self.param_grid is not None and not isinstance(self.param_grid, dict):
+            raise TypeError("param_grid must be a dict or None.")
+
+    @property
+    def needs_search(self) -> bool:
+        """Return ``True`` iff the grid has at least one multi-value entry.
+
+        A multi-value entry is a list or tuple with more than one element.
+        When ``param_grid`` is ``None`` or empty, or every value is a scalar
+        or singleton list/tuple, returns ``False``.
+
+        Returns
+        -------
+        needs_search : bool
+            ``True`` when at least one grid value is a list or tuple
+            with more than one element; ``False`` otherwise.
+        """
+        if not self.param_grid:
+            return False
+        return any(
+            isinstance(v, (list, tuple)) and len(v) > 1
+            for v in self.param_grid.values()
+        )
+
+    def fixed_params(self) -> dict[str, Any]:
+        """Return a flat parameter dict, unwrapping singleton lists/tuples.
+
+        Singleton list or tuple values (``len == 1``) are unwrapped to their
+        scalar element.  Empty list/tuple values are skipped.  Scalar values
+        are passed through unchanged.  When ``param_grid`` is ``None``,
+        an empty dict is returned.
+
+        Returns
+        -------
+        params : dict[str, Any]
+            Flat parameter dict ready to pass to ``set_params``.
+        """
+        if self.param_grid is None:
+            return {}
+        out: dict[str, Any] = {}
+        for key, value in self.param_grid.items():
+            if isinstance(value, (list, tuple)):
+                if len(value) == 0:
+                    continue
+                out[key] = value[0]
+            else:
+                out[key] = value
+        return out
+
+    def build(self, random_state: int | None = None) -> BaseEstimator:
+        """Return a fresh clone of the estimator, optionally seeded.
+
+        Creates a clone via ``sklearn.base.clone`` so ``self.estimator``
+        is never mutated.  When ``random_state`` is not ``None``, the
+        seed is forwarded to the clone, using the first match:
+
+        1. If the clone exposes ``random_state`` directly, it is set.
+        2. Else if the clone exposes ``clf__random_state`` (Pipeline
+           with a ``clf`` step), that is set.
+        3. Otherwise the seed is silently ignored.
+
+        Parameters
+        ----------
+        random_state : int or None, default=None
+            Seed to forward to the cloned estimator.  Passing ``None``
+            leaves the estimator's own default unchanged.
+
+        Returns
+        -------
+        estimator : BaseEstimator
+            An unfitted clone ready for ``fit``.
+        """
+        est = clone(self.estimator)
+        if random_state is not None:
+            params = est.get_params(deep=True)
+            if "random_state" in params:
+                est.set_params(random_state=random_state)
+            elif "clf__random_state" in params:
+                est.set_params(clf__random_state=random_state)
+        return est

--- a/skordinal/experiments/tests/test_model_config.py
+++ b/skordinal/experiments/tests/test_model_config.py
@@ -1,0 +1,151 @@
+"""Tests for the ModelConfig frozen dataclass."""
+
+from __future__ import annotations
+
+import pytest
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.tree import DecisionTreeClassifier
+
+from skordinal.experiments import ModelConfig
+
+
+def test_modelconfig_stores_estimator_and_grid():
+    """Store estimator by identity and param_grid (None default, verbatim)."""
+    lr = LogisticRegression(max_iter=200)
+    cfg_default = ModelConfig(lr)
+    assert cfg_default.estimator is lr
+    assert cfg_default.param_grid is None
+
+    grid = {"C": [0.1, 1.0, 10.0]}
+    cfg_with_grid = ModelConfig(LogisticRegression(), param_grid=grid)
+    assert cfg_with_grid.param_grid is grid
+
+
+def test_modelconfig_fields_are_frozen():
+    """Assigning to a field of a frozen ``ModelConfig`` raises an error."""
+    cfg = ModelConfig(LogisticRegression(), param_grid={"C": [1.0]})
+    with pytest.raises((AttributeError, TypeError)):
+        cfg.estimator = LogisticRegression(max_iter=500)  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "bad_estimator",
+    ["not an estimator", 42, None],
+    ids=["string", "int", "none"],
+)
+def test_modelconfig_rejects_non_estimator(bad_estimator):
+    """Reject a non-``BaseEstimator`` with a ``TypeError``."""
+    with pytest.raises(TypeError, match="BaseEstimator"):
+        ModelConfig(bad_estimator)
+
+
+@pytest.mark.parametrize(
+    "bad_grid",
+    [[1, 2], "C=0.1", 42],
+    ids=["list", "string", "int"],
+)
+def test_modelconfig_rejects_bad_param_grid(bad_grid):
+    """Reject a non-dict, non-None ``param_grid`` with a ``TypeError``."""
+    with pytest.raises(TypeError, match="param_grid"):
+        ModelConfig(LogisticRegression(), param_grid=bad_grid)
+
+
+def test_modelconfig_param_grid_is_keyword_only():
+    """``param_grid`` as a second positional argument raises ``TypeError``."""
+    with pytest.raises(TypeError):
+        ModelConfig(LogisticRegression(), {"C": [1]})  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize(
+    "param_grid, expected",
+    [
+        (None, False),
+        ({}, False),
+        ({"C": [0.5]}, False),
+        ({"C": [0.1, 1.0]}, True),
+        ({"C": [0.1, 1.0], "max_iter": 200}, True),
+    ],
+    ids=["none", "empty", "singleton", "multi_value", "mixed_multi"],
+)
+def test_needs_search(param_grid, expected):
+    """Return True iff a grid value is a multi-element list or tuple."""
+    cfg = ModelConfig(LogisticRegression(), param_grid=param_grid)
+    assert cfg.needs_search is expected
+
+
+@pytest.mark.parametrize(
+    "param_grid, expected",
+    [
+        (None, {}),
+        ({}, {}),
+        ({"C": [0.5]}, {"C": 0.5}),
+        ({"C": 0.5}, {"C": 0.5}),
+        ({"C": []}, {}),
+    ],
+    ids=["none", "empty", "singleton_list", "scalar", "empty_list"],
+)
+def test_fixed_params(param_grid, expected):
+    """Unwrap singleton lists, pass scalars through, skip empty lists."""
+    cfg = ModelConfig(LogisticRegression(), param_grid=param_grid)
+    assert cfg.fixed_params() == expected
+
+
+def test_build_returns_distinct_clone_without_mutating_source():
+    """``build`` returns a fresh clone and does not mutate the source."""
+    cfg = ModelConfig(DecisionTreeClassifier(random_state=0))
+    built = cfg.build(7)
+    assert built is not cfg.estimator
+    assert cfg.estimator.random_state == 0
+
+
+@pytest.mark.parametrize(
+    "estimator, check",
+    [
+        (
+            DecisionTreeClassifier(),
+            lambda built: built.random_state == 7,
+        ),
+        (
+            Pipeline([("scaler", StandardScaler()), ("clf", DecisionTreeClassifier())]),
+            lambda built: built.named_steps["clf"].random_state == 7,
+        ),
+    ],
+    ids=["direct_estimator", "pipeline_clf_step"],
+)
+def test_build_forwards_random_state(estimator, check):
+    """``build(7)`` sets the seed on the clone (direct or Pipeline)."""
+    cfg = ModelConfig(estimator)
+    built = cfg.build(7)
+    assert check(built)
+
+
+@pytest.mark.parametrize(
+    "estimator, check",
+    [
+        (
+            StandardScaler(),
+            lambda built: "random_state" not in built.get_params(),
+        ),
+        (
+            Pipeline([("scaler", StandardScaler()), ("model", LogisticRegression())]),
+            lambda built: built.named_steps["model"].random_state is None,
+        ),
+    ],
+    ids=["no_random_state", "pipeline_step_not_clf"],
+)
+def test_build_ignores_random_state_when_absent(estimator, check):
+    """``build(7)`` returns a clone and injects no seed when none applies."""
+    cfg = ModelConfig(estimator)
+    built = cfg.build(7)
+    assert built is not cfg.estimator
+    assert check(built)
+
+
+def test_build_none_seed_preserves_defaults():
+    """``build(None)`` returns a distinct clone, keeping defaults."""
+    cfg = ModelConfig(DecisionTreeClassifier(random_state=5))
+    built = cfg.build(None)
+    assert built is not cfg.estimator
+    assert built.random_state == 5


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `ModelConfig`, a frozen dataclass that pairs a scikit-learn estimator with an optional hyper-parameter grid. It provides `needs_search` (does the grid require `GridSearchCV`?), `fixed_params` (the flat parameters when it does not), and `build` (an optionally seeded clone of the estimator). The class describes only what to run; the evaluation protocol (cv, metric, seed) stays on the orchestrator.