### PR TITLE
ENH: Add generic dataset-loading layer

### DIFF
--- a/skordinal/datasets/__init__.py
+++ b/skordinal/datasets/__init__.py
@@ -1,5 +1,11 @@
-"""Bundled ordinal classification datasets."""
+"""Load and generate ordinal classification datasets."""
 
+from ._base import (
+    clear_data_home,
+    get_data_home,
+    load_dataset,
+    load_partitions,
+)
 from ._loaders import (
     load_balance_scale,
     load_era,
@@ -10,10 +16,14 @@ from ._loaders import (
 from ._samples_generator import make_ordinal_classification
 
 __all__ = [
+    "clear_data_home",
+    "get_data_home",
     "load_balance_scale",
+    "load_dataset",
     "load_era",
     "load_esl",
     "load_lev",
+    "load_partitions",
     "load_swd",
     "make_ordinal_classification",
 ]

--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -1,0 +1,513 @@
+"""Base IO code and shared machinery for skordinal datasets."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import shutil
+from collections.abc import Iterator
+from importlib import resources
+from numbers import Integral
+from pathlib import Path
+
+import numpy as np
+from sklearn.model_selection import StratifiedKFold
+from sklearn.utils import Bunch
+from sklearn.utils._param_validation import Interval, validate_params
+
+DATA_MODULE = "skordinal.datasets.data"
+DESCR_MODULE = "skordinal.datasets.descr"
+
+
+def _read_csv_any(path):
+    """Read an ordinal-classification CSV, auto-detecting the header style."""
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        rows = list(csv.reader(fh))
+
+    if not rows:
+        raise ValueError(f"CSV file is empty: {path}")
+
+    header_class_names = None
+
+    def _is_int(s):
+        try:
+            int(s)
+            return True
+        except ValueError:
+            return False
+
+    def _is_float(s):
+        try:
+            float(s)
+            return True
+        except ValueError:
+            return False
+
+    def _is_metadata_header(r0, r1):
+        """Return True if r0 is ``n_samples, n_features, *class_names``."""
+        if len(r0) < 2:
+            return False
+        if not (_is_int(r0[0]) and _is_int(r0[1])):
+            return False
+        return int(r0[1]) == len(r1) - 1
+
+    if len(rows) < 2:
+        # With only one row there is no header, so treat it as data
+        r0 = rows[0]
+        data_rows = rows
+        feature_names = [f"x{i}" for i in range(len(r0) - 1)]
+    else:
+        r0, r1 = rows[0], rows[1]
+        if _is_metadata_header(r0, r1):
+            # Metadata header holds n_samples, n_features then the class names
+            n_features = int(r0[1])
+            feature_names = [f"x{i}" for i in range(n_features)]
+            header_class_names = np.array(r0[2:])
+            data_rows = rows[1:]
+        elif any(not _is_float(tok) for tok in r0):
+            # Named header, with at least one non-numeric token
+            feature_names = r0[:-1]
+            data_rows = rows[1:]
+        else:
+            # No header row, so generate feature names
+            feature_names = [f"x{i}" for i in range(len(r0) - 1)]
+            data_rows = rows
+
+    n_features = len(feature_names)
+    # Parse every data row in one vectorised pass, the first n_features
+    # columns are the features and the last column is the target
+    table = np.asarray(data_rows, dtype=np.float64)
+    X = np.ascontiguousarray(table[:, :n_features])
+    y = table[:, -1].astype(np.int64)
+    return X, y, feature_names, header_class_names
+
+
+def _resolve_csv_path(name, data_home=None):
+    """Resolve a dataset name or path to its CSV file path."""
+    name_str = str(name)
+    if data_home is not None:
+        fname = name_str if name_str.endswith(".csv") else f"{name_str}.csv"
+        return Path(data_home) / fname, None
+    if Path(name_str).is_file():
+        return Path(name_str), None
+    stem = name_str.removesuffix(".csv")
+    bundled_dir = Path(str(resources.files(DATA_MODULE)))
+    return bundled_dir / f"{stem}.csv", DATA_MODULE
+
+
+def _load_descr(csv_path):
+    """Return the ``.rst`` description for a CSV path, or None."""
+    sidecar = csv_path.with_suffix(".rst")
+    if sidecar.exists():
+        return sidecar.read_text(encoding="utf-8")
+    bundled = Path(str(resources.files(DESCR_MODULE))) / f"{csv_path.stem}.rst"
+    if bundled.exists():
+        return bundled.read_text(encoding="utf-8")
+    return None
+
+
+def _resolve_target_names(header_class_names, target):
+    """Return header class names, or sorted unique targets as strings."""
+    if header_class_names is not None:
+        return header_class_names
+    return np.unique(target).astype(str)
+
+
+def _convert_data_dataframe(caller_name, data, target, feature_names, target_columns):
+    """Build a pandas frame from ``data`` and ``target`` for ``as_frame``."""
+    try:
+        import pandas as pd
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover - exercised in environments without pandas
+        raise ImportError(f"{caller_name} with as_frame=True requires pandas.") from exc
+    data_df = pd.DataFrame(data, columns=feature_names, copy=False)
+    target_df = pd.DataFrame(target, columns=target_columns)
+    combined_df = pd.concat([data_df, target_df], axis=1)
+    X = combined_df[feature_names]
+    y = combined_df[target_columns]
+    if y.shape[1] == 1:  # pragma: no branch
+        y = y.iloc[:, 0]
+    return combined_df, X, y
+
+
+def _load_keyed_masks(csv_dir):
+    """Return the keyed ``train_masks.json`` dict near a CSV dir, or None."""
+    for candidate in (
+        csv_dir / "train_masks.json",
+        csv_dir.parent / "train_masks.json",
+    ):
+        if candidate.exists():
+            with candidate.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+    return None
+
+
+def _resolve_train_masks(csv_path, X, y, ids, random_state):
+    """Return one boolean train-mask per requested resample id."""
+
+    # Coerce a raw mask to a boolean array and validate its length
+    def _as_mask(raw, label):
+        mask = np.asarray(raw, dtype=bool)
+        if len(mask) != len(y):
+            raise ValueError(
+                f"Mask for {label} has length {len(mask)}; "
+                f"expected {len(y)} (number of samples)."
+            )
+        return mask
+
+    # First choice is a per-dataset masks file <stem>.masks.json with one
+    # boolean train-mask per resample
+    per_dataset_path = csv_path.parent / f"{csv_path.stem}.masks.json"
+    if per_dataset_path.exists():
+        with per_dataset_path.open("r", encoding="utf-8") as fh:
+            masks_list = json.load(fh)
+        masks = []
+        for rid in ids:
+            if not (0 <= rid < len(masks_list)):
+                raise IndexError(
+                    f"No mask for resample {rid}: {per_dataset_path.name} "
+                    f"contains {len(masks_list)} entries."
+                )
+            masks.append(_as_mask(masks_list[rid], f"resample {rid}"))
+        return masks
+
+    # Otherwise, a shared train_masks.json keyed by "<stem>_seed_<rid>"
+    keyed = _load_keyed_masks(csv_path.parent)
+    if keyed is not None:
+        masks = []
+        for rid in ids:
+            key = f"{csv_path.stem}_seed_{rid}"
+            if key not in keyed:
+                raise KeyError(f"No mask found for key {key!r} in train_masks.json.")
+            masks.append(_as_mask(keyed[key], f"key {key!r}"))
+        return masks
+
+    # Otherwise, generate masks with StratifiedKFold (one fold per resample)
+    if len(ids) < 2:
+        raise ValueError(
+            f"When generating CV masks, resamples must be >= 2; got {len(ids)}."
+        )
+    skf = StratifiedKFold(n_splits=len(ids), shuffle=True, random_state=random_state)
+    masks = []
+    for train_indices, _ in skf.split(X, y):
+        mask = np.zeros(len(y), dtype=bool)
+        mask[train_indices] = True
+        masks.append(mask)
+    return masks
+
+
+@validate_params(
+    {"data_home": [str, os.PathLike, None]},
+    prefer_skip_nested_validation=True,
+)
+def get_data_home(data_home=None) -> str:
+    """Return the path of the skordinal data directory.
+
+    Mirrors ``sklearn.datasets.get_data_home``. Resolution order:
+    ``data_home`` argument → ``$SKORDINAL_DATA`` environment variable →
+    ``~/skordinal_data``. The directory is created if it does not exist.
+
+    Parameters
+    ----------
+    data_home : str, os.PathLike, or None, default=None
+        Path to the skordinal data directory; ``None`` triggers the
+        resolution order described above.
+
+    Returns
+    -------
+    data_home : str
+        Path to the data directory.
+
+    Examples
+    --------
+    >>> import os
+    >>> from skordinal.datasets import get_data_home
+    >>> os.path.isdir(get_data_home())
+    True
+    """
+    if data_home is None:
+        data_home = os.environ.get("SKORDINAL_DATA", Path.home() / "skordinal_data")
+    data_home = Path(data_home).expanduser()
+    data_home.mkdir(parents=True, exist_ok=True)
+    return str(data_home)
+
+
+@validate_params(
+    {"data_home": [str, os.PathLike, None]},
+    prefer_skip_nested_validation=True,
+)
+def clear_data_home(data_home=None) -> None:
+    """Delete all content from the skordinal data cache.
+
+    Parameters
+    ----------
+    data_home : str, os.PathLike, or None, default=None
+        Path to the skordinal data directory. When ``None``, uses the
+        default resolved by ``get_data_home``.
+
+    Examples
+    --------
+    >>> from skordinal.datasets import clear_data_home
+    >>> clear_data_home()  # doctest: +SKIP
+    """
+    shutil.rmtree(get_data_home(data_home))
+
+
+@validate_params(
+    {
+        "name": [str, os.PathLike],
+        "data_home": [str, os.PathLike, None],
+        "return_X_y": ["boolean"],
+        "as_frame": ["boolean"],
+    },
+    prefer_skip_nested_validation=True,
+)
+def load_dataset(name, *, data_home=None, return_X_y=False, as_frame=False):
+    """Load any ordinal dataset by name or path, auto-detecting CSV format.
+
+    Resolution order:
+
+    1. If ``data_home`` is given, look for ``<data_home>/<name>.csv`` (or
+       ``<data_home>/<name>`` when ``name`` already ends with ``.csv``).
+    2. Otherwise, if ``name`` is an existing file path, open it directly.
+    3. Otherwise, resolve against the bundled data directory.
+
+    Three CSV header styles are accepted automatically:
+
+    - metadata header (bundled style): the first row contains
+      ``n_samples, n_features, target_name_0, ...``.
+    - named header: the first row holds column names
+      with at least one non-numeric token.
+    - no header: every row is a data row; feature names are generated
+      as ``x0, x1, ...``.
+
+    Parameters
+    ----------
+    name : str or path-like
+        Dataset stem (e.g. ``"era"``), filename (``"era.csv"``), or a
+        concrete file path when ``data_home`` is ``None``.
+
+    data_home : str, path-like, or None, default=None
+        Directory to search when ``name`` is a stem or filename. When
+        ``None`` the bundled data directory is used.
+
+    return_X_y : bool, default=False
+        If ``True``, returns ``(data, target)`` instead of a Bunch.
+
+    as_frame : bool, default=False
+        If ``True``, ``data`` is a ``pandas.DataFrame`` and ``target``
+        is a ``pandas.Series``.
+
+    Returns
+    -------
+    bunch : ``sklearn.utils.Bunch``
+        Object with the following attributes.
+
+        data : ndarray of shape (n_samples, n_features)
+            Feature matrix (float64). A DataFrame when ``as_frame`` is True.
+        target : ndarray of shape (n_samples,)
+            Integer target labels (int64). A Series when ``as_frame`` is True.
+        frame : DataFrame or None
+            Combined frame when ``as_frame`` is True; otherwise ``None``.
+        feature_names : list of str
+            One name per feature column.
+        target_names : ndarray of str
+            Class names from the metadata header when present; otherwise
+            the sorted unique target values as strings.
+        n_classes : int
+            Number of distinct classes.
+        DESCR : str
+            Human-readable description sourced from a ``.rst`` sidecar
+            file, or a generated one-line summary when none is found.
+        filename : str
+            Basename of the CSV file.
+        data_module : str or None
+            Python module path used by ``importlib.resources`` to
+            locate the file when resolved from the bundled directory;
+            ``None`` for external files.
+
+    (data, target) : tuple if ``return_X_y`` is True
+
+    Raises
+    ------
+    FileNotFoundError
+        When the resolved path does not exist.
+
+    Examples
+    --------
+    >>> from skordinal.datasets import load_dataset  # doctest: +SKIP
+    >>> bunch = load_dataset("era")                   # doctest: +SKIP
+    >>> bunch.data.shape                              # doctest: +SKIP
+    (1000, 4)
+
+    Load from a custom directory:
+
+    >>> load_dataset("era", data_home="/my/data").data.shape  # doctest: +SKIP
+    (1000, 4)
+    """
+    path, data_module_value = _resolve_csv_path(name, data_home)
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset file not found: {path}")
+
+    data, target, feature_names, header_class_names = _read_csv_any(path)
+    target_names = _resolve_target_names(header_class_names, target)
+    n_classes = len(target_names)
+
+    descr = _load_descr(path)
+    if descr is None:
+        descr = (
+            f"Dataset '{path.stem}': {data.shape[0]} samples, "
+            f"{data.shape[1]} features, {n_classes} classes."
+        )
+
+    filename = path.name
+    frame = None
+    if as_frame:
+        frame, data, target = _convert_data_dataframe(
+            "load_dataset", data, target, feature_names, ["target"]
+        )
+    if return_X_y:
+        return data, target
+    return Bunch(
+        data=data,
+        target=target,
+        frame=frame,
+        feature_names=feature_names,
+        target_names=target_names,
+        n_classes=n_classes,
+        DESCR=descr,
+        filename=filename,
+        data_module=data_module_value,
+    )
+
+
+@validate_params(
+    {
+        "name": [str, os.PathLike],
+        "data_home": [str, os.PathLike, None],
+        "resamples": [Interval(Integral, 1, None, closed="left"), list],
+        "random_state": ["random_state"],
+    },
+    prefer_skip_nested_validation=True,
+)
+def load_partitions(
+    name,
+    *,
+    data_home=None,
+    resamples=30,
+    random_state=0,
+) -> Iterator[Bunch]:
+    """Yield one train/test partition per resample of an ordinal dataset.
+
+    The dataset is a single CSV resolved like ``load_dataset``
+    (``<data_home>/<name>.csv``, a direct path, or the bundled data
+    directory). Train/test splits come from boolean train-masks, resolved
+    in this order:
+
+    1. A per-dataset masks file ``<csv_dir>/<stem>.masks.json``: a JSON
+       list whose k-th element is the boolean train-mask of resample k.
+    2. A shared keyed masks file ``train_masks.json`` in ``<csv_dir>`` or
+       its parent, keyed as ``f"{stem}_seed_{k}"``.
+    3. Otherwise generated with
+       ``sklearn.model_selection.StratifiedKFold``: one fold per requested
+       resample, ``shuffle=True``, seeded by ``random_state``.
+
+    Parameters
+    ----------
+    name : str or path-like
+        Dataset stem (e.g. ``"era"``), filename, or concrete path.
+
+    data_home : str, path-like, or None, default=None
+        Directory to search when ``name`` is a stem or filename. When
+        ``None``, the bundled data directory is used.
+
+    resamples : int or list of int, default=30
+        When an ``int``, resample ids are ``range(resamples)``. When a
+        list, those ids are used directly. Must be >= 2 when masks are
+        generated by cross-validation.
+
+    random_state : int, RandomState instance, or None, default=0
+        Seed passed to ``sklearn.model_selection.StratifiedKFold``
+        when CV masks are generated. Ignored otherwise.
+
+    Yields
+    ------
+    bunch : ``sklearn.utils.Bunch``
+        Dictionary-like object with the following attributes.
+
+        data_train : ndarray of shape (n_train, n_features)
+            Training features (float64).
+        target_train : ndarray of shape (n_train,)
+            Training targets (int64).
+        data_test : ndarray of shape (n_test, n_features)
+            Test features (float64).
+        target_test : ndarray of shape (n_test,)
+            Test targets (int64).
+        feature_names : list of str
+            Feature column names.
+        target_names : ndarray of str
+            Class names from the metadata header when present; otherwise
+            the sorted unique target values as strings.
+        dataset_name : str
+            Echo of the requested dataset name.
+        resample_id : int
+            Identifier of the current resample, taken from
+            ``range(resamples)`` or from the supplied list of ids.
+        n_classes : int
+            Number of ordinal classes.
+        DESCR : str
+            One-line description of this resample.
+
+    Raises
+    ------
+    FileNotFoundError
+        When the CSV cannot be located.
+    ValueError
+        When ``resamples < 2`` and CV masks must be generated, or when a
+        mask length does not match the number of samples.
+    KeyError
+        When a keyed masks file exists but does not contain the expected key.
+    IndexError
+        When a per-dataset masks file (``<stem>.masks.json``) contains
+        fewer entries than the largest requested resample id.
+
+    Examples
+    --------
+    >>> from skordinal.datasets import load_partitions  # doctest: +SKIP
+    >>> for bunch in load_partitions("era", resamples=3):  # doctest: +SKIP
+    ...     print(bunch.resample_id, bunch.data_train.shape[0])
+    """
+    csv_path, _ = _resolve_csv_path(name, data_home)
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Dataset file not found: {csv_path}")
+
+    X, y, feature_names, header_class_names = _read_csv_any(csv_path)
+    target_names = _resolve_target_names(header_class_names, y)
+    n_classes = len(target_names)
+
+    ids = list(range(resamples)) if isinstance(resamples, Integral) else list(resamples)
+    train_masks = _resolve_train_masks(csv_path, X, y, ids, random_state)
+
+    def _iter():
+        for resample_id, train_mask in zip(ids, train_masks):
+            n_train = int(train_mask.sum())
+            n_test = int((~train_mask).sum())
+            yield Bunch(
+                data_train=X[train_mask],
+                target_train=y[train_mask],
+                data_test=X[~train_mask],
+                target_test=y[~train_mask],
+                feature_names=feature_names,
+                target_names=target_names,
+                dataset_name=str(name),
+                resample_id=int(resample_id),
+                n_classes=n_classes,
+                DESCR=(
+                    f"{name} resample {resample_id}: "
+                    f"{n_train}/{n_test} samples, {n_classes} classes."
+                ),
+            )
+
+    return _iter()

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -1,0 +1,463 @@
+"""Tests for the dataset loading utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from sklearn.utils import Bunch
+
+from skordinal.datasets import (
+    _base,
+    clear_data_home,
+    get_data_home,
+    load_dataset,
+    load_partitions,
+)
+from skordinal.datasets._base import _resolve_target_names
+
+_NAMED_CSV = """\
+x_0,x_1,y
+1.0,2.0,0
+3.0,4.0,1
+5.0,6.0,2
+7.0,8.0,0
+9.0,10.0,1
+"""
+
+_N_SAMPLES = 20
+_N_FEATURES = 2
+
+
+def _make_csv_content(n_samples=_N_SAMPLES):
+    """Return a deterministic named-header CSV string with 3 classes."""
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((n_samples, _N_FEATURES))
+    y = (np.arange(n_samples) % 3).astype(int)
+    lines = ["x_0,x_1,y"]
+    for i in range(n_samples):
+        lines.append(f"{X[i, 0]:.6f},{X[i, 1]:.6f},{y[i]}")
+    return "\n".join(lines) + "\n"
+
+
+def _write_csv(directory, name, n_samples=_N_SAMPLES):
+    """Write a named-header CSV and return its path."""
+    path = directory / f"{name}.csv"
+    path.write_text(_make_csv_content(n_samples), encoding="utf-8")
+    return path
+
+
+def _write_masks(directory, name, masks):
+    """Write a per-dataset ``<name>.masks.json`` and return its path."""
+    path = directory / f"{name}.masks.json"
+    path.write_text(json.dumps(masks), encoding="utf-8")
+    return path
+
+
+def _write_keyed_masks(directory, keyed):
+    """Write a keyed ``train_masks.json`` and return its path."""
+    path = directory / "train_masks.json"
+    path.write_text(json.dumps(keyed), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def named_csv(tmp_path):
+    """Minimal named-header CSV: two features, three classes, five rows."""
+    path = tmp_path / "toy_dataset.csv"
+    path.write_text(_NAMED_CSV, encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize(
+    "env_sub, arg_sub, expected_sub",
+    [
+        (None, "arg", "arg"),
+        ("env", None, "env"),
+        ("env", "arg", "arg"),
+    ],
+    ids=["explicit-only", "env-var", "explicit-overrides-env"],
+)
+def test_get_data_home_resolution(
+    tmp_path, monkeypatch, env_sub, arg_sub, expected_sub
+):
+    """Resolve data_home from the argument, else ``SKORDINAL_DATA``."""
+    if env_sub is not None:
+        monkeypatch.setenv("SKORDINAL_DATA", str(tmp_path / env_sub))
+    else:
+        monkeypatch.delenv("SKORDINAL_DATA", raising=False)
+    arg = (tmp_path / arg_sub) if arg_sub is not None else None
+    result = get_data_home(arg)
+    assert Path(result) == tmp_path / expected_sub
+    assert Path(result).is_dir()
+    assert isinstance(result, str)
+
+
+def test_clear_data_home_removes_directory(tmp_path):
+    """``clear_data_home`` deletes the cache directory."""
+    target = tmp_path / "cache"
+    target.mkdir()
+    (target / "dummy.txt").write_text("x")
+    clear_data_home(target)
+    assert not target.exists()
+
+
+def test_load_dataset_named_csv_bunch_contract(named_csv):
+    """Named-header CSV yields a Bunch with correct shape, names, dtype."""
+    bunch = load_dataset(named_csv)
+    assert isinstance(bunch, Bunch)
+    for key in (
+        "data",
+        "target",
+        "feature_names",
+        "target_names",
+        "n_classes",
+        "DESCR",
+        "filename",
+    ):
+        assert key in bunch, f"Missing key: {key!r}"
+    assert bunch.data.shape == (5, 2)
+    assert bunch.target.shape == (5,)
+    assert bunch.feature_names == ["x_0", "x_1"]
+    assert bunch.n_classes == len(np.unique(bunch.target))
+    assert np.issubdtype(bunch.target.dtype, np.integer)
+    assert bunch.filename == named_csv.name
+
+
+@pytest.mark.parametrize(
+    "csv_text, expected_feature_names, expected_target_names",
+    [
+        (
+            "3,2,low,mid,high\n1.0,2.0,0\n3.0,4.0,1\n5.0,6.0,2\n",
+            ["x0", "x1"],
+            ["low", "mid", "high"],
+        ),
+        (
+            "x_0,x_1,y\n1.0,2.0,0\n3.0,4.0,1\n5.0,6.0,2\n",
+            ["x_0", "x_1"],
+            ["0", "1", "2"],
+        ),
+        (
+            "1.0,2.0,0\n3.0,4.0,1\n5.0,6.0,2\n",
+            ["x0", "x1"],
+            ["0", "1", "2"],
+        ),
+    ],
+    ids=["metadata-header", "named-header", "no-header"],
+)
+def test_load_dataset_header_styles(
+    tmp_path, csv_text, expected_feature_names, expected_target_names
+):
+    """Each header style yields correct feature_names and target_names."""
+    path = tmp_path / "style.csv"
+    path.write_text(csv_text, encoding="utf-8")
+    bunch = load_dataset(path)
+    assert bunch.feature_names == expected_feature_names
+    assert list(bunch.target_names) == expected_target_names
+    assert bunch.data.shape == (3, 2)
+
+
+def test_load_dataset_bundled_era():
+    """Bundled ``era`` dataset loads with correct shape and rst DESCR."""
+    bunch = load_dataset("era")
+    assert bunch.data.shape == (1000, 4)
+    # The bundled sidecar era.rst exists; DESCR must come from it, not the
+    # generated "Dataset '...':" fallback
+    assert not bunch.DESCR.startswith("Dataset '")
+    assert len(bunch.DESCR) > 10
+
+
+@pytest.mark.parametrize(
+    "csv_text, expected_feature_names, expected_shape",
+    [
+        ("1.0,2.0,0\n", ["x0", "x1"], (1, 2)),
+        ("5\n3\n6\n", [], (3, 0)),
+    ],
+    ids=["single-row", "single-column"],
+)
+def test_load_dataset_degenerate_shapes(
+    tmp_path, csv_text, expected_feature_names, expected_shape
+):
+    """Single-row and single-column CSVs parse as headerless data."""
+    path = tmp_path / "edge.csv"
+    path.write_text(csv_text, encoding="utf-8")
+    bunch = load_dataset(path)
+    assert bunch.feature_names == expected_feature_names
+    assert bunch.data.shape == expected_shape
+
+
+def test_load_dataset_uses_colocated_rst_sidecar(tmp_path):
+    """Co-located ``.rst`` sidecar is used as ``DESCR``."""
+    path = tmp_path / "ds.csv"
+    path.write_text("x_0,x_1,y\n1.0,2.0,0\n3.0,4.0,1\n", encoding="utf-8")
+    sidecar = tmp_path / "ds.rst"
+    sidecar.write_text("Distinctive sidecar description.", encoding="utf-8")
+    bunch = load_dataset(path)
+    assert "Distinctive sidecar description." in bunch.DESCR
+
+
+def test_load_dataset_return_X_y(named_csv):
+    """``return_X_y=True`` returns an (ndarray, ndarray) tuple."""
+    result = load_dataset(named_csv, return_X_y=True)
+    assert isinstance(result, tuple) and len(result) == 2
+    X, y = result
+    assert isinstance(X, np.ndarray) and X.ndim == 2
+    assert isinstance(y, np.ndarray) and y.ndim == 1
+    assert X.shape[0] == y.shape[0]
+
+
+def test_load_dataset_as_frame(named_csv):
+    """``as_frame=True`` returns a DataFrame and a Series."""
+    pd = pytest.importorskip("pandas")
+    bunch = load_dataset(named_csv, as_frame=True)
+    assert isinstance(bunch.data, pd.DataFrame)
+    assert isinstance(bunch.target, pd.Series)
+    assert bunch.data.shape[1] == len(bunch.feature_names)
+    assert bunch.frame is not None
+
+
+@pytest.mark.parametrize("name", ["ds_home", "ds_home.csv"], ids=["stem", "filename"])
+def test_load_dataset_data_home(tmp_path, name):
+    """Stem or filename resolves against an explicit ``data_home`` directory."""
+    _write_csv(tmp_path, "ds_home")
+    bunch = load_dataset(name, data_home=tmp_path)
+    assert bunch.data.shape == (_N_SAMPLES, _N_FEATURES)
+
+
+def test_load_dataset_missing_file_raises(tmp_path):
+    """``load_dataset`` raises ``FileNotFoundError`` if absent."""
+    missing = tmp_path / "no_such_file.csv"
+    with pytest.raises(FileNotFoundError, match="Dataset file not found"):
+        load_dataset(missing)
+
+
+def test_load_dataset_empty_csv_raises(tmp_path):
+    """An empty CSV file raises ``ValueError`` matching ``'empty'``."""
+    path = tmp_path / "empty.csv"
+    path.write_text("", encoding="utf-8")
+    with pytest.raises(ValueError, match="empty"):
+        load_dataset(path)
+
+
+def test_cv_fallback_era():
+    """CV fallback on ``era`` yields 3 folds (ids, counts, classes)."""
+    bunches = list(load_partitions("era", resamples=3))
+    assert len(bunches) == 3
+    assert [b.resample_id for b in bunches] == [0, 1, 2]
+    for bunch in bunches:
+        assert bunch.data_train.shape[0] + bunch.data_test.shape[0] == 1000
+        assert bunch.n_classes == 9
+    # Test sizes across all folds sum to the full dataset
+    assert sum(b.data_test.shape[0] for b in bunches) == 1000
+
+
+def test_per_dataset_masks(tmp_path):
+    """Per-dataset masks.json sets exact train/test counts, complement."""
+    name = "ds_perdataset"
+    _write_csv(tmp_path, name)
+    mask0 = [True] * 14 + [False] * 6
+    mask1 = [False] * 8 + [True] * 12
+    _write_masks(tmp_path, name, [mask0, mask1])
+    bunches = list(load_partitions(name, resamples=2, data_home=tmp_path))
+    assert bunches[0].data_train.shape[0] == 14
+    assert bunches[0].data_test.shape[0] == 6
+    assert bunches[1].data_train.shape[0] == 12
+    assert bunches[1].data_test.shape[0] == 8
+    # Train and test sizes sum to the full sample count
+    total = bunches[0].data_train.shape[0] + bunches[0].data_test.shape[0]
+    assert total == _N_SAMPLES
+
+
+@pytest.mark.parametrize(
+    "place_in_parent",
+    [False, True],
+    ids=["same-dir", "parent-dir"],
+)
+def test_keyed_masks_location(tmp_path, place_in_parent):
+    """``train_masks.json`` is found in the CSV dir or its parent."""
+    if place_in_parent:
+        csv_dir = tmp_path / "data"
+        csv_dir.mkdir()
+        mask_dir = tmp_path
+    else:
+        csv_dir = tmp_path
+        mask_dir = tmp_path
+    name = "ds_keyed"
+    _write_csv(csv_dir, name)
+    keyed = {
+        f"{name}_seed_0": [True] * 15 + [False] * 5,
+        f"{name}_seed_1": [True] * 10 + [False] * 10,
+    }
+    _write_keyed_masks(mask_dir, keyed)
+    bunches = list(load_partitions(name, resamples=2, data_home=csv_dir))
+    assert bunches[0].data_train.shape[0] == 15
+    assert bunches[1].data_train.shape[0] == 10
+
+
+def test_partition_bunch_contract(tmp_path):
+    """Yielded Bunch has all required fields with correct shapes and dtypes."""
+    required = {
+        "data_train",
+        "target_train",
+        "data_test",
+        "target_test",
+        "feature_names",
+        "target_names",
+        "dataset_name",
+        "resample_id",
+        "n_classes",
+        "DESCR",
+    }
+    name = "ds_contract"
+    _write_csv(tmp_path, name)
+    mask = [True] * 14 + [False] * 6
+    _write_masks(tmp_path, name, [mask])
+    (bunch,) = list(load_partitions(name, resamples=1, data_home=tmp_path))
+    assert isinstance(bunch, Bunch)
+    assert required <= set(bunch.keys())
+    # Feature count is consistent across train and test splits
+    assert bunch.data_train.shape[1] == bunch.data_test.shape[1]
+    # Targets are integer arrays
+    assert np.issubdtype(bunch.target_train.dtype, np.integer)
+    assert np.issubdtype(bunch.target_test.dtype, np.integer)
+    # dataset_name and resample_id echo the requested values
+    assert bunch.dataset_name == name
+    assert bunch.resample_id == 0
+    # DESCR is a non-empty string
+    assert isinstance(bunch.DESCR, str) and len(bunch.DESCR) > 0
+
+
+def _setup_missing_csv(tmp_path):
+    """Return args for missing-CSV error case; no files written."""
+    return "nonexistent_calltime", {}
+
+
+def _setup_bad_mask(tmp_path):
+    """Return args for mask-length-mismatch error case."""
+    name = "ds_calltime_badmask"
+    _write_csv(tmp_path, name, n_samples=_N_SAMPLES)
+    bad_mask = [True] * (_N_SAMPLES - 1)
+    _write_masks(tmp_path, name, [bad_mask])
+    return name, {}
+
+
+def _setup_missing_keyed_entry(tmp_path):
+    """Return args for missing keyed-entry error case."""
+    name = "ds_calltime_missingkey"
+    _write_csv(tmp_path, name)
+    keyed = {f"{name}_seed_0": [True] * 14 + [False] * 6}
+    _write_keyed_masks(tmp_path, keyed)
+    return name, {"resamples": 2}
+
+
+def _setup_cv_resamples_1(tmp_path):
+    """Return args for CV-resamples-1 error case."""
+    name = "ds_calltime_cv1"
+    _write_csv(tmp_path, name)
+    return name, {"resamples": 1}
+
+
+def _setup_short_per_dataset_masks(tmp_path):
+    """Return args for short per-dataset-masks IndexError case."""
+    name = "ds_short_masks"
+    _write_csv(tmp_path, name)
+    mask0 = [True] * 14 + [False] * 6
+    _write_masks(tmp_path, name, [mask0])
+    return name, {"resamples": 2}
+
+
+@pytest.mark.parametrize(
+    "setup_fn, exc_type, match",
+    [
+        (_setup_missing_csv, FileNotFoundError, "Dataset file not found"),
+        (_setup_bad_mask, ValueError, "Mask for resample 0"),
+        (_setup_missing_keyed_entry, KeyError, r"_seed_1"),
+        (_setup_cv_resamples_1, ValueError, "resamples must be >= 2"),
+        (_setup_short_per_dataset_masks, IndexError, r"\.masks\.json"),
+    ],
+    ids=[
+        "missing-csv",
+        "mask-length-mismatch",
+        "missing-keyed-entry",
+        "cv-resamples-lt-2",
+        "short-per-dataset-masks",
+    ],
+)
+def test_load_partitions_eager_errors(tmp_path, setup_fn, exc_type, match):
+    """Errors raise eagerly at ``load_partitions`` call time."""
+    name, extra_kwargs = setup_fn(tmp_path)
+    with pytest.raises(exc_type, match=match):
+        load_partitions(name, data_home=tmp_path, **extra_kwargs)
+
+
+def test_load_partitions_reads_csv_once(tmp_path, monkeypatch):
+    """The CSV is parsed exactly once regardless of the number of resamples."""
+    calls = 0
+    original = _base._read_csv_any
+
+    def counting_read_csv(path):
+        """Count CSV reads and delegate to the original ``_read_csv_any``."""
+        nonlocal calls
+        calls += 1
+        return original(path)
+
+    monkeypatch.setattr(_base, "_read_csv_any", counting_read_csv)
+    name = "ds_read_once"
+    _write_csv(tmp_path, name)
+    mask = [True] * 14 + [False] * 6
+    _write_masks(tmp_path, name, [mask, mask])
+    list(load_partitions(name, resamples=2, data_home=tmp_path))
+    assert calls == 1
+
+
+@pytest.mark.parametrize(
+    "resamples, expected_ids",
+    [
+        (3, [0, 1, 2]),
+        (np.int64(3), [0, 1, 2]),
+        ([0, 2], [0, 2]),
+    ],
+    ids=["int", "np.int64", "list"],
+)
+def test_resamples_input_types(resamples, expected_ids):
+    """``int``, ``np.int64``, and list ``resamples`` all yield correct ids."""
+    bunches = list(load_partitions("era", resamples=resamples))
+    assert [b.resample_id for b in bunches] == expected_ids
+
+
+def test_resamples_list_with_masks(tmp_path):
+    """``resamples=[1]`` selects the second per-dataset mask."""
+    name = "ds_list_mask"
+    _write_csv(tmp_path, name)
+    mask0 = [True] * 14 + [False] * 6
+    mask1 = [True] * 10 + [False] * 10
+    _write_masks(tmp_path, name, [mask0, mask1])
+    (bunch,) = list(load_partitions(name, resamples=[1], data_home=tmp_path))
+    assert bunch.resample_id == 1
+    assert bunch.data_train.shape[0] == 10
+    assert bunch.data_test.shape[0] == 10
+
+
+@pytest.mark.parametrize(
+    "header_class_names, target, expected",
+    [
+        (
+            np.array(["low", "mid", "high"]),
+            np.array([0, 1, 2]),
+            ["low", "mid", "high"],
+        ),
+        (
+            None,
+            np.array([2, 0, 1, 0, 2]),
+            ["0", "1", "2"],
+        ),
+    ],
+    ids=["header-present", "header-none"],
+)
+def test_resolve_target_names(header_class_names, target, expected):
+    """Return header names, else sorted unique targets as strings."""
+    result = _resolve_target_names(header_class_names, target)
+    assert list(result) == expected
+    assert result.dtype.kind == "U"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `load_dataset` and `load_partitions` for loading ordinal datasets from CSV files, plus `get_data_home` and `clear_data_home` to manage the data home directory. `load_dataset` auto-detects three CSV header styles (metadata, named, headerless) and returns a `Bunch` or an `(X, y)` tuple. `load_partitions` yields one `Bunch` per resample, taking train/test splits from per-dataset masks, shared keyed masks, or a stratified k-fold fallback. Both resolve a dataset from `data_home`, a direct path, or the bundled datasets.