### PR TITLE
REF: Route Benchmark partitions through load_partitions

### DIFF
--- a/config.py
+++ b/config.py
@@ -71,10 +71,11 @@ def main(general_conf: dict[str, Any], configurations: dict[str, Any]) -> None:
 
     benchmark = Benchmark(
         configurations,
-        data_path=general_conf["basedir"],
+        data_home=general_conf["basedir"],
         datasets=general_conf["datasets"],
         eval_metrics=general_conf["metrics"],
         results_path=general_conf["output_folder"],
+        resamples=general_conf.get("resamples", 30),
         tuning_metric=general_conf.get("cv_metric", "neg_mean_absolute_error"),
         cv=general_conf.get("hyperparam_cv_nfolds", 3),
         n_jobs=general_conf.get("jobs", 1),

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -6,107 +6,19 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
-import numpy as np
-import pandas as pd
+from skordinal.datasets import load_partitions
 
 from ._experiment import Experiment
 from ._results import Results
 
 
-def _read_file(filename: Path) -> tuple[np.ndarray, np.ndarray]:
-    """Read a CSV partition file into ``(inputs, outputs)`` arrays."""
-    # Detect the separator automatically.
-    f = pd.read_csv(filename, header=None, engine="python")
-
-    inputs = f.values[:, 0:(-1)]
-    outputs = f.values[:, (-1)]
-
-    return inputs, outputs
-
-
-def _check_dataset_list(
-    data_path: str | Path, datasets: list[str]
-) -> tuple[str | Path, list[str]]:
-    """Resolve a dataset list, expanding ``["all"]`` and validating entries.
-
-    Expands a home-shorthand ``data_path`` and raises ``ValueError`` if the
-    list contains non-string entries.
-    """
-    base_path = Path(data_path)
-
-    # Check if home path is shortened
-    if str(base_path).startswith("~"):
-        base_path = Path.home() / str(base_path)[1:]
-
-    dataset_list = datasets
-
-    # Check if 'all' is the only value, and if it is, expand it
-    if len(dataset_list) == 1 and dataset_list[0] == "all":
-        dataset_list = [item.name for item in base_path.iterdir() if item.is_dir()]
-
-    elif not all(isinstance(item, str) for item in dataset_list):
-        raise ValueError("Dataset list can only contain strings")
-
-    return str(base_path), dataset_list
-
-
-def _load_dataset(dataset_path: Path) -> list[tuple[str, dict[str, Any]]]:
-    """Load a dataset folder into a sorted list of ``(index, partition)`` tuples.
-
-    Each partition dict disjoins train/test inputs and outputs. Raises
-    ``ValueError`` if the folder is missing and ``RuntimeError`` if a partition
-    has no train file.
-    """
-
-    def get_partition_index(filename: str) -> str:
-        # Extract the index between the last "_" and ".csv".
-        return filename.rsplit("_", 1)[-1].replace(".csv", "")
-
-    try:
-        partition_list: dict[str, dict[str, Any]] = {
-            get_partition_index(filename.name): {}
-            for filename in dataset_path.iterdir()
-            if filename.name.startswith("train_")
-        }
-
-        # Load train and test arrays for each partition.
-        for filename in dataset_path.iterdir():
-            if filename.name.startswith("train_"):
-                idx = get_partition_index(filename.name)
-                train_inputs, train_outputs = _read_file(filename)
-                partition_list[idx]["train_inputs"] = train_inputs
-                partition_list[idx]["train_outputs"] = train_outputs
-
-            elif filename.name.startswith("test_"):
-                idx = get_partition_index(filename.name)
-                test_inputs, test_outputs = _read_file(filename)
-                partition_list[idx]["test_inputs"] = test_inputs
-                partition_list[idx]["test_outputs"] = test_outputs
-
-    except OSError:
-        raise ValueError(f"No such file or directory: '{dataset_path}'")
-
-    except KeyError:
-        raise RuntimeError(
-            f"Found partition without train files: partition {filename.name}"
-        )
-
-    # Sort partitions into a list of (index, partition) tuples.
-    sorted_list: list[tuple[str, dict[str, Any]]] = sorted(
-        partition_list.items(),
-        key=lambda t: int(t[0]) if t[0].lstrip("-").isdigit() else t[0],
-    )
-
-    return sorted_list
-
-
 class Benchmark:
-    """Run a benchmark of M configurations across N datasets and their partitions.
+    """Run a benchmark of M configurations across N datasets and their resamples.
 
     Each configuration pairs a classifier method with one or more hyper-parameter
-    values. Calling :meth:`run` performs cross-validation for every partition of
-    each dataset-configuration pair, fits the selected model, predicts the test
-    labels, and stores all metrics in a :class:`Results` object. :meth:`summarize`
+    values. Calling ``run`` performs cross-validation for every resample of each
+    dataset-configuration pair, fits the selected model, predicts the test
+    labels, and stores all metrics in a ``Results`` object. ``summarize``
     then writes the aggregated train and test summaries.
 
     Parameters
@@ -118,20 +30,26 @@ class Benchmark:
         and ``"parameters"`` is a dictionary of hyper-parameter grids (lists of
         values to search over) or fixed values.
 
-    data_path : str or Path
-        Base directory that contains one sub-folder per dataset.
+    data_home : str, Path, or None, default=None
+        Optional base directory used to locate dataset files. When ``None``,
+        dataset names are resolved against a direct path or the bundled
+        collection via the dataset-loading layer.
 
     datasets : list of str
-        Names of the dataset sub-folders to run. Pass ``["all"]`` to expand
-        automatically to every directory found under ``data_path``.
+        Names of the datasets to load, resolved via the dataset-loading layer.
+        Each name is passed directly to ``load_partitions``.
 
     eval_metrics : list of str
-        Metric names to compute for every partition (e.g.
+        Metric names to compute for every resample (e.g.
         ``["mean_absolute_error", "average_mean_absolute_error"]``).
         Names must be recognised by ``skordinal.metrics.get_ordinal_scorer``.
 
     results_path : str or Path
         Directory where result files are written.
+
+    resamples : int, default=30
+        Number of resamples (train/test splits) to load per dataset. Forwarded
+        to ``load_partitions``.
 
     tuning_metric : str, default="neg_mean_absolute_error"
         Metric used as the cross-validation scoring criterion when selecting the
@@ -146,7 +64,7 @@ class Benchmark:
         Number of parallel jobs forwarded to ``GridSearchCV``.
 
     input_preprocessing : {"std", "norm"} or None, default=None
-        Optional feature preprocessing applied to every partition before
+        Optional feature preprocessing applied to every resample before
         fitting: ``"norm"`` applies min-max normalisation and ``"std"`` applies
         z-score standardisation. Both scalers are fitted on the training split
         only, then applied to both train and test splits. ``None`` means no
@@ -155,7 +73,8 @@ class Benchmark:
     random_state : int or None, default=None
         Seed used for two sources of randomness: the base estimator and the
         cross-validation splitter (``StratifiedKFold``) used during
-        hyper-parameter search. When ``None``, both use their own default
+        hyper-parameter search. Also forwarded to ``load_partitions`` when a
+        fallback split is generated. When ``None``, both use their own default
         random behaviour.
 
     verbose : bool, default=True
@@ -171,10 +90,11 @@ class Benchmark:
     >>> from skordinal.experiments import Benchmark  # doctest: +SKIP
     >>> benchmark = Benchmark(  # doctest: +SKIP
     ...     configurations={"SVM": {"classifier": "svc", "parameters": {"C": [1]}}},
-    ...     data_path="/data/ordinal",
-    ...     datasets=["balance-scale"],
+    ...     data_home="/data/ordinal",
+    ...     datasets=["balance_scale"],
     ...     eval_metrics=["mean_absolute_error"],
     ...     results_path="/tmp/results",
+    ...     resamples=30,
     ... )
     >>> benchmark.run()  # doctest: +SKIP
     >>> benchmark.summarize()  # doctest: +SKIP
@@ -185,10 +105,11 @@ class Benchmark:
         self,
         configurations: dict[str, Any],
         *,
-        data_path: str | Path,
+        data_home: str | Path | None = None,
         datasets: list[str],
         eval_metrics: list[str],
         results_path: str | Path,
+        resamples: int = 30,
         tuning_metric: str = "neg_mean_absolute_error",
         cv: int = 3,
         n_jobs: int = 1,
@@ -220,10 +141,11 @@ class Benchmark:
             input_preprocessing = _normalized
 
         self.configurations = deepcopy(configurations)
-        self.data_path: str | Path = data_path
+        self.data_home: str | Path | None = data_home
         self.datasets: list[str] = list(datasets)
         self.eval_metrics: list[str] = list(eval_metrics)
         self.results_path: str | Path = results_path
+        self.resamples: int = resamples
         self.tuning_metric = tuning_metric
         self.cv = cv
         self.n_jobs = n_jobs
@@ -232,48 +154,38 @@ class Benchmark:
         self.verbose = verbose
 
     def run(self) -> None:
-        """Run the benchmark over every dataset, configuration and partition.
+        """Run the benchmark over every dataset, configuration and resample.
 
-        Loads all datasets, which can be fragmented in partitions. Builds a model
-        per partition, using cross-validation to find the optimal values among the
-        hyper-parameters to compare from.
+        Loads all datasets via the dataset-loading layer, one resample at a
+        time. Builds a model per resample, using cross-validation to find the
+        optimal values among the hyper-parameters to compare from.
 
         Uses the built model to get train and test metrics, storing all the
         information into a Results object.
 
         Raises
         ------
-        ValueError
-            If the dataset list is inconsistent, or a dataset path does not
-            exist.
-
-        RuntimeError
-            If a partition is found without its train file.
+        FileNotFoundError
+            If a dataset name cannot be resolved by the dataset-loading layer
+            (no matching path and not present in the bundled collection).
 
         """
         self._results = Results(Path(self.results_path))
-
-        self.data_path, self.datasets = _check_dataset_list(
-            self.data_path, self.datasets
-        )
 
         if self.verbose:
             print("\n###############################")
             print("\tRunning Benchmark")
             print("###############################")
 
-        # Iterate over datasets.
+        # Iterate over datasets
         for x in self.datasets:
             dataset_name = x.strip()
-            dataset_path = Path(self.data_path) / dataset_name
-
-            dataset = _load_dataset(dataset_path)
 
             if self.verbose:
                 print("\nRunning", dataset_name, "dataset")
                 print("--------------------------")
 
-            # Iterate over configurations.
+            # Iterate over configurations
             for conf_name, configuration in self.configurations.items():
                 if self.verbose:
                     print("Running", conf_name, "...")
@@ -288,19 +200,24 @@ class Benchmark:
                     random_state=self.random_state,
                 )
 
-                # Iterate over partitions.
-                for part_idx, partition in dataset:
+                # Iterate over resamples via the dataset-loading layer
+                for b in load_partitions(
+                    dataset_name,
+                    data_home=self.data_home,
+                    resamples=self.resamples,
+                    random_state=self.random_state,
+                ):
                     if self.verbose:
-                        print("  Running Partition", part_idx)
+                        print("  Running resample", b.resample_id)
 
                     result = experiment.run(
-                        partition["train_inputs"],
-                        partition["train_outputs"],
-                        partition.get("test_inputs"),
-                        partition.get("test_outputs"),
+                        b.data_train,
+                        b.target_train,
+                        b.data_test,
+                        b.target_test,
                         dataset_name=dataset_name,
                         classifier_name=conf_name,
-                        resample_id=part_idx,
+                        resample_id=b.resample_id,
                     )
                     self._results.save(result)
 

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -28,11 +28,10 @@ class Experiment:
 
     Wraps one configuration (a classifier name and its hyper-parameter grid)
     together with the cross-validation and preprocessing settings shared across
-    partitions. Calling :meth:`run` applies optional preprocessing, selects and
-    fits the best estimator via
-    :func:`~skordinal.model_selection.load_classifier`, predicts on the train
+    partitions. Calling ``run`` applies optional preprocessing, selects and
+    fits the best estimator via ``load_classifier``, predicts on the train
     and (when present) test splits, computes all evaluation metrics and timing
-    keys, and returns an :class:`ExperimentResult`. Nothing is written to disk.
+    keys, and returns an ``ExperimentResult``. Nothing is written to disk.
 
     Parameters
     ----------
@@ -84,7 +83,7 @@ class Experiment:
     ...     X_train, y_train, X_test, y_test,
     ...     dataset_name="balance-scale",
     ...     classifier_name="SVM",
-    ...     resample_id="0",
+    ...     resample_id=0,
     ... )
 
     """
@@ -132,14 +131,14 @@ class Experiment:
         *,
         dataset_name: str,
         classifier_name: str,
-        resample_id: str,
+        resample_id: int,
     ) -> ExperimentResult:
         """Run the configuration on a single train/test partition.
 
         Applies optional preprocessing, selects and fits the best estimator,
         predicts on train and (when present) test splits, computes all
         evaluation metrics and timing keys, and returns an
-        :class:`ExperimentResult`. It does **not** persist anything to disk; the
+        ``ExperimentResult``. It does not persist anything to disk; the
         caller is responsible for saving the result.
 
         Parameters
@@ -158,15 +157,14 @@ class Experiment:
 
         dataset_name : str
             Name of the dataset, forwarded to the returned
-            :class:`ExperimentResult`.
+            ``ExperimentResult``.
 
         classifier_name : str
             Configuration label, used as ``classifier_name`` in the returned
-            :class:`ExperimentResult`.
+            ``ExperimentResult``.
 
-        resample_id : str
-            Partition index string, forwarded to the returned
-            :class:`ExperimentResult`.
+        resample_id : int
+            Partition index, forwarded to the returned ``ExperimentResult``.
 
         Returns
         -------

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -34,7 +34,7 @@ class ExperimentResult:
     classifier_name : str
         Name of the classifier configuration.
 
-    resample_id : str
+    resample_id : int
         Partition identifier.
 
     train_predicted_y : ndarray of shape (n_train_samples,)
@@ -72,7 +72,7 @@ class ExperimentResult:
 
     dataset_name: str
     classifier_name: str
-    resample_id: str
+    resample_id: int
     train_predicted_y: np.ndarray
     test_predicted_y: np.ndarray | None
     y_proba: np.ndarray | None

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -1,221 +1,86 @@
 """Tests for the benchmark runner module."""
 
-from pathlib import Path
+import json
 
 import numpy as np
 import pandas as pd
 import pytest
 
 from skordinal.experiments import Benchmark
-from skordinal.experiments._benchmark import _load_dataset
 
-_MINIMAL_CONF = {"cfg": {"classifier": "SVC", "parameters": {}}}
+_SVC_CONF: dict = {"SVM": {"classifier": "SVC", "parameters": {"C": [1]}}}
+_MINIMAL_CONF: dict = {"cfg": {"classifier": "SVC", "parameters": {}}}
+_BUNDLED_DS = "balance_scale"
+
+_INVALID_CONSTRUCTOR_CASES = [
+    pytest.param(
+        {},
+        [_BUNDLED_DS],
+        ["mean_absolute_error"],
+        "non-empty",
+        id="empty-configurations",
+    ),
+    pytest.param(
+        _MINIMAL_CONF,
+        [],
+        ["mean_absolute_error"],
+        "non-empty",
+        id="empty-datasets",
+    ),
+    pytest.param(
+        _MINIMAL_CONF,
+        [_BUNDLED_DS],
+        [],
+        "non-empty",
+        id="empty-eval-metrics",
+    ),
+]
 
 
-def create_csv(path, filename):
-    """Create a csv file with sample data."""
-    sample_data = "1,2,3,0\n4,5,6,1"
-    (path / filename).write_text(sample_data)
-
-
-def _write_partition_csv(directory, filename, n_per_class=10):
-    rng = np.random.default_rng(0)
-    n_rows = n_per_class * 3
-    features = rng.integers(1, 6, size=(n_rows, 4))
-    labels = np.repeat([0, 1, 2], n_per_class).reshape(-1, 1)
-    data = np.hstack([features, labels])
-    np.savetxt(directory / filename, data, delimiter=",", fmt="%d")
-
-
-def _from_general_conf(general_conf: dict, configurations: dict, **kwargs) -> Benchmark:
-    """Construct Benchmark from an old-style ``general_conf`` dict.
-
-    Keeps test call-sites readable without duplicating the key mapping.
-    """
-    return Benchmark(
-        configurations,
-        data_path=general_conf["basedir"],
-        datasets=general_conf["datasets"],
-        eval_metrics=general_conf["metrics"],
-        results_path=general_conf["output_folder"],
-        tuning_metric=general_conf.get("cv_metric", "neg_mean_absolute_error"),
-        cv=general_conf.get("hyperparam_cv_nfolds", 3),
-        n_jobs=general_conf.get("jobs", 1),
-        input_preprocessing=general_conf.get("input_preprocessing"),
-        **kwargs,
+@pytest.fixture
+def csv_ds_dir(tmp_path):
+    """Write a small 3-class CSV plus a 2-entry masks file under tmp_path."""
+    rng = np.random.default_rng(7)
+    n = 60
+    X = rng.standard_normal((n, 4))
+    y = np.repeat([0, 1, 2], n // 3)
+    rows = np.hstack([X, y.reshape(-1, 1)])
+    np.savetxt(tmp_path / "smallds.csv", rows, delimiter=",", fmt="%.6f")
+    mask0 = [True] * (n // 2) + [False] * (n // 2)
+    mask1 = [False] * (n // 2) + [True] * (n // 2)
+    (tmp_path / "smallds.masks.json").write_text(
+        json.dumps([mask0, mask1]), encoding="utf-8"
     )
+    return tmp_path
 
 
-@pytest.fixture
-def partition_dataset(tmp_path):
-    dataset_dir = tmp_path / "data" / "balance"
-    dataset_dir.mkdir(parents=True)
-    for i in range(2):
-        _write_partition_csv(dataset_dir, f"train_balance_{i}.csv")
-        _write_partition_csv(dataset_dir, f"test_balance_{i}.csv")
-    return tmp_path / "data"
-
-
-@pytest.fixture
-def experiment_conf(tmp_path, partition_dataset):
-    return {
-        "basedir": partition_dataset,
-        "datasets": ["balance"],
-        "input_preprocessing": "std",
-        "hyperparam_cv_nfolds": 3,
-        "jobs": 1,
-        "output_folder": str(tmp_path / "runs"),
-        "metrics": [
-            "accuracy_score",
-            "mean_absolute_error",
-            "average_mean_absolute_error",
-            "mean_zero_one_error",
-        ],
-        "cv_metric": "mean_absolute_error",
-    }
-
-
-@pytest.fixture
-def svm_conf():
-    return {
-        "SVM": {
-            "classifier": "SVC",
-            "parameters": {"C": [0.1, 1.0], "gamma": [0.1]},
-        },
-    }
-
-
-def test_run_and_summarize(tmp_path, experiment_conf, svm_conf):
-    """run and summarize produce the expected on-disk layout."""
-    benchmark = _from_general_conf(experiment_conf, svm_conf, verbose=False)
-    benchmark.run()
-    benchmark.summarize()
-
-    runs_dir = Path(experiment_conf["output_folder"])
-    assert runs_dir.exists()
-
-    svm_dir = runs_dir / "SVM" / "balance"
-    assert svm_dir.exists()
-
-    df = pd.read_csv(svm_dir / "report.csv", index_col=0)
-    assert df.shape == (2, 12)
-    assert all(df[c].dtype == np.float64 for c in df.columns)
-
-    assert len(list((svm_dir / "models").iterdir())) == 2
-    assert len(list((svm_dir / "predictions").iterdir())) == 4
-
-    train_summary = pd.read_csv(runs_dir / "train_summary.csv")
-    assert train_summary.shape == (1, 15)
-    assert all(
-        train_summary[c].dtype == np.float64 for c in train_summary.columns[2:-1]
-    )
-
-    test_summary = pd.read_csv(runs_dir / "test_summary.csv")
-    assert test_summary.shape == (1, 15)
-    assert all(test_summary[c].dtype == np.float64 for c in test_summary.columns[2:-1])
-
-
-def test_load_complete_dataset(tmp_path):
-    """Load a dataset of 5 partitions, each with a train and a test file."""
-    dataset_path = tmp_path / "complete"
-    dataset_path.mkdir()
-
-    for i in range(5):
-        create_csv(dataset_path, f"train_complete.{i}")
-        create_csv(dataset_path, f"test_complete.{i}")
-
-    partition_list = _load_dataset(dataset_path)
-
-    # Every partition holds train and test inputs and outputs (4 entries).
-    assert len(partition_list) == len(list(dataset_path.iterdir())) / 2
-    assert all(len(partition[1]) == 4 for partition in partition_list)
-
-
-def test_load_partitionless_dataset(tmp_path):
-    """Load a dataset of a single train and test file."""
-    dataset_path = tmp_path / "partitionless"
-    dataset_path.mkdir()
-
-    create_csv(dataset_path, "train_partitionless.csv")
-    create_csv(dataset_path, "test_partitionless.csv")
-
-    partition_list = _load_dataset(dataset_path)
-
-    assert len(partition_list) == 1
-    assert all(len(partition[1]) == 4 for partition in partition_list)
-
-
-def test_load_nontestfile_dataset(tmp_path):
-    """Load a dataset of five train files with no test files."""
-    dataset_path = tmp_path / "nontestfile"
-    dataset_path.mkdir()
-
-    for i in range(5):
-        create_csv(dataset_path, f"train_nontestfile.{i}")
-
-    partition_list = _load_dataset(dataset_path)
-
-    assert len(partition_list) == len(list(dataset_path.iterdir()))
-    assert all(len(partition[1]) == 2 for partition in partition_list)
-
-
-def test_load_nontrainfile_dataset(tmp_path):
-    """A partition lacking its train file raises RuntimeError."""
-    dataset_path = tmp_path / "nontrainfile"
-    dataset_path.mkdir()
-
-    for i in range(2):
-        create_csv(dataset_path, f"test_nontrainfile.{i}")
-
-    with pytest.raises(RuntimeError):
-        _load_dataset(dataset_path)
-
-
-def test_empty_configurations_raises(tmp_path):
-    """An empty configurations dict raises ValueError."""
-    with pytest.raises(ValueError, match="'configurations' must be a non-empty dict"):
+@pytest.mark.parametrize(
+    "configurations, datasets, eval_metrics, match",
+    _INVALID_CONSTRUCTOR_CASES,
+)
+def test_benchmark_constructor_validation(
+    tmp_path, configurations, datasets, eval_metrics, match
+):
+    """Constructor raises ValueError for each category of invalid argument."""
+    with pytest.raises(ValueError, match=match):
         Benchmark(
-            {},
-            data_path=".",
-            datasets=["x"],
-            eval_metrics=["mean_absolute_error"],
-            results_path=str(tmp_path),
+            configurations,
+            datasets=datasets,
+            eval_metrics=eval_metrics,
+            results_path=tmp_path,
         )
 
 
-def test_none_configurations_raises(tmp_path):
-    """None configurations is rejected by the non-empty check (ValueError)."""
-    with pytest.raises(ValueError, match="'configurations' must be a non-empty dict"):
-        Benchmark(
-            None,  # type: ignore[arg-type]
-            data_path=".",
-            datasets=["x"],
-            eval_metrics=["mean_absolute_error"],
-            results_path=str(tmp_path),
-        )
-
-
-def test_empty_datasets_raises(tmp_path):
-    """An empty datasets list raises ValueError."""
-    with pytest.raises(ValueError, match="'datasets' must be a non-empty list"):
+@pytest.mark.parametrize("bad_value", ["minmax", ""])
+def test_input_preprocessing_invalid_raises(tmp_path, bad_value):
+    """Unrecognised input_preprocessing values raise ValueError."""
+    with pytest.raises(ValueError, match="'input_preprocessing' must be one of"):
         Benchmark(
             _MINIMAL_CONF,
-            data_path=".",
-            datasets=[],
+            datasets=[_BUNDLED_DS],
             eval_metrics=["mean_absolute_error"],
-            results_path=str(tmp_path),
-        )
-
-
-def test_empty_eval_metrics_raises(tmp_path):
-    """An empty eval_metrics list raises ValueError."""
-    with pytest.raises(ValueError, match="'eval_metrics' must be a non-empty list"):
-        Benchmark(
-            _MINIMAL_CONF,
-            data_path=".",
-            datasets=["x"],
-            eval_metrics=[],
-            results_path=str(tmp_path),
+            results_path=tmp_path,
+            input_preprocessing=bad_value,
         )
 
 
@@ -229,56 +94,258 @@ def test_empty_eval_metrics_raises(tmp_path):
         ("NORM", "norm"),
     ],
 )
-def test_input_preprocessing_accepted_and_normalized(tmp_path, raw, expected):
+def test_input_preprocessing_accepted_and_normalised(tmp_path, raw, expected):
     """Valid input_preprocessing values are accepted and lower-stripped."""
-    benchmark = Benchmark(
+    b = Benchmark(
         _MINIMAL_CONF,
-        data_path=".",
-        datasets=["x"],
+        datasets=[_BUNDLED_DS],
         eval_metrics=["mean_absolute_error"],
-        results_path=str(tmp_path),
+        results_path=tmp_path,
         input_preprocessing=raw,
     )
-    assert benchmark.input_preprocessing == expected
+    assert b.input_preprocessing == expected
 
 
-@pytest.mark.parametrize("bad_value", ["minmax", ""])
-def test_input_preprocessing_invalid_raises(tmp_path, bad_value):
-    """Unrecognised input_preprocessing values raise ValueError."""
-    with pytest.raises(ValueError, match="'input_preprocessing' must be one of"):
-        Benchmark(
-            _MINIMAL_CONF,
-            data_path=".",
-            datasets=["x"],
-            eval_metrics=["mean_absolute_error"],
-            results_path=str(tmp_path),
-            input_preprocessing=bad_value,
-        )
-
-
-@pytest.mark.parametrize("kwargs, expected", [({}, None), ({"random_state": 42}, 42)])
-def test_random_state_stored(tmp_path, kwargs, expected):
-    """random_state defaults to None and is stored as given on the instance."""
-    benchmark = Benchmark(
-        _MINIMAL_CONF,
-        data_path=".",
-        datasets=["x"],
-        eval_metrics=["mean_absolute_error"],
-        results_path=str(tmp_path),
-        **kwargs,
-    )
-    assert benchmark.random_state == expected
-
-
-def test_configurations_is_deep_copied(tmp_path):
+def test_configurations_deep_copied(tmp_path):
     """Mutating the original configurations dict does not affect the stored copy."""
     original = {"cfg": {"classifier": "SVC", "parameters": {"C": [1]}}}
-    benchmark = Benchmark(
+    b = Benchmark(
         original,
-        data_path=".",
-        datasets=["x"],
+        datasets=[_BUNDLED_DS],
         eval_metrics=["mean_absolute_error"],
-        results_path=str(tmp_path),
+        results_path=tmp_path,
     )
     original["cfg"]["parameters"]["C"].append(10)
-    assert benchmark.configurations["cfg"]["parameters"]["C"] == [1]
+    assert b.configurations["cfg"]["parameters"]["C"] == [1]
+
+
+def test_data_home_str_stays_str(tmp_path):
+    """A str data_home is stored verbatim, not converted to Path."""
+    b = Benchmark(
+        _MINIMAL_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path,
+        data_home=str(tmp_path),
+    )
+    assert isinstance(b.data_home, str)
+    assert b.data_home == str(tmp_path)
+
+
+def test_data_home_none_stays_none(tmp_path):
+    """data_home=None is stored as None."""
+    b = Benchmark(
+        _MINIMAL_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path,
+    )
+    assert b.data_home is None
+
+
+def test_resamples_stored_verbatim(tmp_path):
+    """resamples is stored as-is (int, not coerced)."""
+    b = Benchmark(
+        _MINIMAL_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path,
+        resamples=7,
+    )
+    assert b.resamples == 7
+
+
+def test_protocol_attrs_stored(tmp_path):
+    """cv, tuning_metric, eval_metrics, random_state, n_jobs, verbose are stored."""
+    b = Benchmark(
+        _MINIMAL_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error", "accuracy_score"],
+        results_path=tmp_path,
+        resamples=3,
+        cv=4,
+        tuning_metric="accuracy_score",
+        n_jobs=2,
+        random_state=99,
+        verbose=False,
+    )
+    assert b.cv == 4
+    assert b.tuning_metric == "accuracy_score"
+    assert b.eval_metrics == ["mean_absolute_error", "accuracy_score"]
+    assert b.n_jobs == 2
+    assert b.random_state == 99
+    assert b.verbose is False
+
+
+def test_run_and_summarize_bundled_dataset(tmp_path):
+    """run() + summarize() over a bundled dataset write the expected on-disk layout."""
+    results_dir = tmp_path / "runs"
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=results_dir,
+        resamples=3,
+        cv=2,
+        verbose=False,
+        random_state=0,
+    )
+    b.run()
+    b.summarize()
+
+    pair_dir = results_dir / "SVM" / _BUNDLED_DS
+    assert pair_dir.is_dir()
+
+    # report.csv uses resample_id as its index; one row per resample
+    df = pd.read_csv(pair_dir / "report.csv", index_col=0)
+    assert df.shape[0] == 3
+
+    assert (pair_dir / "params.json").is_file()
+
+    pred_dir = pair_dir / "predictions"
+    train_preds = sorted(pred_dir.glob("train_*.csv"))
+    test_preds = sorted(pred_dir.glob("test_*.csv"))
+    assert len(train_preds) == 3
+    assert len(test_preds) == 3
+
+    # resample_id stems on prediction filenames are ints (0, 1, 2)
+    ids_from_files = sorted(int(f.stem.split("_")[1]) for f in train_preds)
+    assert ids_from_files == [0, 1, 2]
+
+    # report.csv must contain one <metric>_train and one <metric>_test column
+    assert "mean_absolute_error_train" in df.columns
+    assert "mean_absolute_error_test" in df.columns
+
+    assert (results_dir / "train_summary.csv").is_file()
+    assert (results_dir / "test_summary.csv").is_file()
+
+    # test_summary.csv must be well-formed with the expected aggregated columns
+    summary = pd.read_csv(results_dir / "test_summary.csv")
+    assert "SVM" in summary["classifier"].values
+    assert "mean_absolute_error_test_mean" in summary.columns
+    assert "n_completed" in summary.columns
+
+
+def test_run_resamples_count_matches_requested(tmp_path):
+    """run() with resamples=N produces exactly N rows in report.csv."""
+    results_dir = tmp_path / "out"
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=results_dir,
+        resamples=4,
+        cv=2,
+        verbose=False,
+        random_state=1,
+    )
+    b.run()
+
+    df = pd.read_csv(results_dir / "SVM" / _BUNDLED_DS / "report.csv", index_col=0)
+    assert df.shape[0] == 4
+
+
+def test_run_mask_path_correct_partition_count(tmp_path, csv_ds_dir):
+    """run() with a masks file consumes exactly the mask-defined number of partitions."""
+    results_dir = tmp_path / "mask_runs"
+    b = Benchmark(
+        _SVC_CONF,
+        data_home=csv_ds_dir,
+        datasets=["smallds"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=results_dir,
+        resamples=2,
+        cv=2,
+        verbose=False,
+        random_state=0,
+    )
+    b.run()
+
+    df = pd.read_csv(results_dir / "SVM" / "smallds" / "report.csv", index_col=0)
+    assert df.shape[0] == 2
+
+
+def test_run_mask_path_train_test_sizes_match_masks(tmp_path, csv_ds_dir):
+    """Prediction file row counts match the mask-defined train/test sizes."""
+    results_dir = tmp_path / "mask_runs2"
+    b = Benchmark(
+        _SVC_CONF,
+        data_home=csv_ds_dir,
+        datasets=["smallds"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=results_dir,
+        resamples=2,
+        cv=2,
+        verbose=False,
+        random_state=0,
+    )
+    b.run()
+
+    pred_dir = results_dir / "SVM" / "smallds" / "predictions"
+    # Each mask splits n=60 half-and-half: 30 train / 30 test
+    train_0 = pd.read_csv(pred_dir / "train_0.csv")
+    test_0 = pd.read_csv(pred_dir / "test_0.csv")
+    assert len(train_0) == 30
+    assert len(test_0) == 30
+
+
+def test_run_resamples_below_two_raises(tmp_path):
+    """resamples=1 on the CV-fallback path raises ValueError at run time."""
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path,
+        resamples=1,
+        cv=2,
+        verbose=False,
+    )
+    with pytest.raises(ValueError, match="resamples must be >= 2"):
+        b.run()
+
+
+def test_run_unresolvable_dataset_raises(tmp_path):
+    """run() propagates FileNotFoundError for an unknown dataset name."""
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=["this_dataset_does_not_exist_xyz"],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path,
+        resamples=3,
+        cv=2,
+        verbose=False,
+    )
+    with pytest.raises(FileNotFoundError):
+        b.run()
+
+
+def test_run_returns_none(tmp_path):
+    """run() returns None."""
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path / "out",
+        resamples=2,
+        cv=2,
+        verbose=False,
+        random_state=0,
+    )
+    assert b.run() is None
+
+
+def test_verbose_false_no_stdout(tmp_path, capsys):
+    """verbose=False produces no stdout output during run()."""
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path / "out",
+        resamples=2,
+        cv=2,
+        verbose=False,
+        random_state=0,
+    )
+    b.run()
+    captured = capsys.readouterr()
+    assert captured.out == ""

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -49,7 +49,7 @@ def _call_run(experiment, X_train, y_train, X_test, y_test):
         y_test,
         dataset_name="ds",
         classifier_name="cfg",
-        resample_id="0",
+        resample_id=0,
     )
 
 
@@ -122,12 +122,12 @@ def test_run_identity_passthrough(split_with_test):
         y_test,
         dataset_name="my_dataset",
         classifier_name="my_conf",
-        resample_id="42",
+        resample_id=42,
     )
 
     assert result.dataset_name == "my_dataset"
     assert result.classifier_name == "my_conf"
-    assert result.resample_id == "42"
+    assert result.resample_id == 42
 
 
 @pytest.mark.parametrize("has_test", [True, False])

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -14,7 +14,7 @@ from skordinal.experiments import ExperimentResult, Results
 
 
 def _make_result(
-    partition: str,
+    partition: int,
     dataset: str,
     configuration: str,
     best_params: dict,
@@ -77,7 +77,7 @@ def test_save(tmp_path):
     results = Results(tmp_path)
 
     result_0 = _make_result(
-        partition="0",
+        partition=0,
         dataset="toy",
         configuration="conf_1",
         best_params={"C": 0.1, "gamma": 1},
@@ -90,7 +90,7 @@ def test_save(tmp_path):
     results.save(result_0)
 
     result_1 = _make_result(
-        partition="1",
+        partition=1,
         dataset="toy",
         configuration="conf_1",
         best_params={"C": 1, "gamma": 1},
@@ -132,7 +132,7 @@ def test_save_with_true_labels(tmp_path):
     train_true = np.array([1, 2, 3, 1, 2])
     test_true = np.array([1, 2, 3])
     result = _make_result(
-        partition="0",
+        partition=0,
         dataset="toy",
         configuration="clf",
         best_params={},
@@ -159,7 +159,7 @@ def test_save_with_true_labels(tmp_path):
 def test_save_model_false(tmp_path):
     """save_model=False must not create a models/ folder."""
     result = _make_result(
-        partition="0",
+        partition=0,
         dataset="toy",
         configuration="conf_1",
         best_params={"C": 1},
@@ -181,7 +181,7 @@ def test_save_proba_not_written_to_disk(tmp_path):
     result = ExperimentResult(
         dataset_name="toy",
         classifier_name="conf_1",
-        resample_id="0",
+        resample_id=0,
         train_predicted_y=np.array([1, 2]),
         test_predicted_y=np.array([1, 2]),
         y_proba=y_proba,
@@ -201,7 +201,7 @@ def test_save_no_test_partition(tmp_path):
     result = ExperimentResult(
         dataset_name="toy",
         classifier_name="clf",
-        resample_id="0",
+        resample_id=0,
         train_predicted_y=np.array([1, 2, 3]),
         test_predicted_y=None,
         y_proba=None,
@@ -223,7 +223,7 @@ def test_save_multiple_partitions_and_params_upsert(tmp_path):
     for i in range(3):
         r.save(
             _make_result(
-                partition=str(i),
+                partition=i,
                 dataset="ds",
                 configuration="clf",
                 best_params={},
@@ -247,11 +247,11 @@ def test_save_multiple_partitions_and_params_upsert(tmp_path):
         test_predicted_y=np.array([1]),
     )
     r.save(
-        _make_result(partition="0", best_params={"C": 0.1}, **base_result),
+        _make_result(partition=0, best_params={"C": 0.1}, **base_result),
         save_model=False,
     )
     r.save(
-        _make_result(partition="0", best_params={"C": 1.0}, **base_result),
+        _make_result(partition=0, best_params={"C": 1.0}, **base_result),
         save_model=False,
     )
 
@@ -278,7 +278,7 @@ def test_exists(tmp_path):
 
     r.save(
         _make_result(
-            partition="0",
+            partition=0,
             dataset="toy",
             configuration="SVC",
             best_params={},


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`Benchmark` now sources train/test partitions from the dataset-loading layer through `load_partitions`, resolving each dataset by name. This removes the bespoke loader that scanned a folder of `train_*.csv`/`test_*.csv` files. The required `data_path` parameter becomes the optional `data_home`, a new `resamples` parameter sets the number of resamples, and the `datasets=["all"]` shortcut is removed. The recipe runner is updated to the new constructor.