### PR TITLE
REF: Extract reporting into an evaluation module

### DIFF
--- a/skordinal/experiments/__init__.py
+++ b/skordinal/experiments/__init__.py
@@ -1,6 +1,7 @@
 """Experiments orchestration module."""
 
 from ._benchmark import Benchmark
+from ._evaluation import save_summary, summarize, tabulate_results
 from ._experiment import Experiment
 from ._model_config import ModelConfig
 from ._recipes import load_recipe, validate_recipe
@@ -13,5 +14,8 @@ __all__ = [
     "ModelConfig",
     "Results",
     "load_recipe",
+    "save_summary",
+    "summarize",
+    "tabulate_results",
     "validate_recipe",
 ]

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from skordinal.datasets import load_partitions
 
+from ._evaluation import save_summary
 from ._experiment import Experiment
 from ._model_config import ModelConfig
 from ._recipes import load_recipe
@@ -272,12 +273,12 @@ class Benchmark:
                     self._results.save(result)
 
     def summarize(self) -> None:
-        """Write the aggregated train and test summaries via the Results object."""
+        """Write the train and test summaries to the results folder."""
         if self.verbose:
             print("\nSaving summary...")
 
         for split in ("train", "test"):
             try:
-                self._results.save_summary(split=split)
+                save_summary(self.results_path, split=split)
             except ValueError:
                 pass

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -1,0 +1,229 @@
+"""Read-back aggregation over saved experiment results."""
+
+import math
+from pathlib import Path
+
+import pandas as pd
+
+
+def _check_split(split, *, allow_both):
+    """Raise ValueError when split is not a recognised value."""
+    valid = {"test", "train", "both"} if allow_both else {"test", "train"}
+    if split not in valid:
+        raise ValueError(f"split must be one of {sorted(valid)!r}, got {split!r}.")
+
+
+def _iter_pairs(results_path):
+    """Yield ``(classifier, dataset, csv_path)`` for each results pair."""
+    root = Path(results_path)
+    for clf_dir in sorted(root.iterdir()):
+        if not clf_dir.is_dir():
+            continue
+        for ds_dir in sorted(clf_dir.iterdir()):
+            if not ds_dir.is_dir():
+                continue
+            csv_path = ds_dir / "report.csv"
+            if csv_path.is_file():
+                yield clf_dir.name, ds_dir.name, csv_path
+
+
+def summarize(results_path, *, labels=None, split="test"):
+    """Aggregate per-pair report CSVs into a multi-index summary DataFrame.
+
+    Parameters
+    ----------
+    results_path : str or Path
+        Root folder of the experiment results. The function descends into
+        ``<results_path>/<classifier>/<dataset>/report.csv`` for each pair.
+
+    labels : iterable of str or None, default=None
+        When provided, only pairs whose classifier name is contained in
+        ``labels`` are included.  Must be an iterable of strings, not a
+        bare string.
+
+    split : {"test", "train", "both"}, default="test"
+        Which metric columns to include.
+
+        - ``"test"``: columns ending with ``_test``.
+        - ``"train"``: columns ending with ``_train``.
+        - ``"both"``: all columns ending with ``_test`` or ``_train``.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with a ``(classifier, dataset)`` MultiIndex and
+        MultiIndex columns at two levels: outer is the column name (e.g.
+        ``"mae_test"``), inner is ``"mean"`` or ``"std"``.
+        The ``("n_completed", "")`` column counts partitions per pair.
+        Returns an empty ``DataFrame`` when no pairs are found.
+
+    Raises
+    ------
+    ValueError
+        If ``split`` is not ``"test"``, ``"train"``, or ``"both"``.
+
+    TypeError
+        If ``labels`` is a bare string instead of an iterable of strings.
+
+    Examples
+    --------
+    >>> from skordinal.experiments import summarize
+    >>> df = summarize("/path/to/my-run", split="both")  # doctest: +SKIP
+    """
+    _check_split(split, allow_both=True)
+
+    if isinstance(labels, str):
+        raise TypeError(
+            "labels must be an iterable of classifier name strings, not a bare string; "
+            f"pass [{labels!r}] to filter by a single classifier."
+        )
+
+    label_set = set(labels) if labels is not None else None
+    rows = []
+
+    for clf, ds, csv_path in _iter_pairs(results_path):
+        # Skip pairs not in the requested label filter
+        if label_set is not None and clf not in label_set:
+            continue
+
+        df = pd.read_csv(csv_path, index_col=0)
+
+        # Select columns for the requested split
+        if split == "test":
+            metric_cols = [c for c in df.columns if c.endswith("_test")]
+        elif split == "train":
+            metric_cols = [c for c in df.columns if c.endswith("_train")]
+        else:
+            metric_cols = [c for c in df.columns if c.endswith(("_test", "_train"))]
+
+        # Compute mean and std for each metric column
+        row = {"classifier": clf, "dataset": ds}
+        for col in metric_cols:
+            series = df[col].dropna()
+            n = len(series)
+            row[(col, "mean")] = float(series.mean()) if n > 0 else float("nan")
+            row[(col, "std")] = (
+                float(series.std(ddof=1))
+                if n > 1
+                else (0.0 if n == 1 else float("nan"))
+            )
+        row[("n_completed", "")] = len(df)
+        rows.append(row)
+
+    if not rows:
+        return pd.DataFrame()
+
+    # Build MultiIndex DataFrame from accumulated rows
+    summary = pd.DataFrame(rows).set_index(["classifier", "dataset"])
+    summary.columns = pd.MultiIndex.from_tuples(list(summary.columns))
+    return summary
+
+
+def tabulate_results(results_path, *, metric="mean_absolute_error", split="test"):
+    """Pivot experiment results into a classifiers-by-datasets table.
+
+    Parameters
+    ----------
+    results_path : str or Path
+        Root folder of the experiment results.
+
+    metric : str, default="mean_absolute_error"
+        Base metric name.  The column ``{metric}_{split}`` is looked up in
+        each per-pair CSV.
+
+    split : {"test", "train"}, default="test"
+        Which evaluation split to read.
+
+    Returns
+    -------
+    pd.DataFrame
+        Pivot DataFrame with classifiers as rows and datasets as columns.
+        Each cell is a ``"mean +/- std"`` string formatted to 4 decimal
+        places, or ``"n/a"`` when the column is absent or all-NaN.
+        Returns an empty ``DataFrame`` when no pairs are found.
+
+    Raises
+    ------
+    ValueError
+        If ``split`` is not ``"test"`` or ``"train"``.
+
+    Examples
+    --------
+    >>> from skordinal.experiments import tabulate_results
+    >>> table = tabulate_results(  # doctest: +SKIP
+    ...     "/path/to/my-run",
+    ...     metric="accuracy_score",
+    ...     split="test",
+    ... )
+    """
+    _check_split(split, allow_both=False)
+
+    col = f"{metric}_{split}"
+    rows = []
+
+    for clf, ds, csv_path in _iter_pairs(results_path):
+        df = pd.read_csv(csv_path, index_col=0)
+        # Format as "mean +/- std", or "n/a" when metric is absent or all-NaN
+        if col not in df.columns or df[col].isna().all():
+            cell = "n/a"
+        else:
+            series = df[col].dropna()
+            mean = float(series.mean())
+            std = float(series.std(ddof=1)) if len(series) > 1 else 0.0
+            if not math.isfinite(mean):
+                cell = "n/a"
+            else:
+                std = std if math.isfinite(std) else 0.0
+                cell = f"{mean:.4f} +/- {std:.4f}"
+        rows.append({"classifier": clf, "dataset": ds, "value": cell})
+
+    if not rows:
+        return pd.DataFrame()
+
+    # Pivot into a classifiers x datasets table
+    return (
+        pd.DataFrame(rows)
+        .pivot(index="classifier", columns="dataset", values="value")
+        .fillna("n/a")
+        .rename_axis(index="classifier", columns="dataset")
+    )
+
+
+def save_summary(results_path, *, split="test"):
+    """Write a flattened summary CSV for one split under the results folder.
+
+    Parameters
+    ----------
+    results_path : str or Path
+        Root folder of the experiment results.  The CSV is written as
+        ``{split}_summary.csv`` directly under this directory.
+
+    split : {"test", "train", "both"}, default="test"
+        Which metric columns to include.  Forwarded to ``summarize``.
+
+    Returns
+    -------
+    Path
+        Path of the CSV file that was written.
+
+    Raises
+    ------
+    ValueError
+        If ``split`` is not a recognised value (via ``summarize`` →
+        ``_check_split``) or if there are no results in ``results_path``.
+
+    Examples
+    --------
+    >>> from skordinal.experiments import save_summary
+    >>> path = save_summary("/path/to/my-run", split="test")  # doctest: +SKIP
+    """
+    df = summarize(results_path, split=split)
+    if df.empty:
+        raise ValueError("No results found to summarise.")
+    flat = df.copy()
+    flat.columns = [
+        f"{outer}_{inner}" if inner else outer for outer, inner in flat.columns
+    ]
+    out_path = Path(results_path) / f"{split}_summary.csv"
+    flat.to_csv(out_path)
+    return out_path

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import json
-import math
-from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -13,13 +11,6 @@ import joblib
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
-
-
-def _check_split(split: str, *, allow_both: bool) -> None:
-    """Raise ValueError when *split* is not a recognised value."""
-    valid = {"test", "train", "both"} if allow_both else {"test", "train"}
-    if split not in valid:
-        raise ValueError(f"split must be one of {sorted(valid)!r}, got {split!r}.")
 
 
 @dataclass(frozen=True)
@@ -100,7 +91,7 @@ class Results:
 
     Notes
     -----
-    On-disk layout under :attr:`_experiment_folder`::
+    On-disk layout under ``_experiment_folder``::
 
         train_summary.csv
         test_summary.csv
@@ -115,7 +106,7 @@ class Results:
                     <resample_id>.joblib
 
     The root-level ``train_summary.csv`` and ``test_summary.csv`` files are
-    written by :meth:`save_summary` and are absent until it is called.
+    written by ``save_summary`` and are absent until it is called.
 
     """
 
@@ -215,12 +206,12 @@ class Results:
         experiment_folder : str or Path
             Path to an already-populated experiment folder. The folder does not
             need to exist at construction time; it is only accessed when a
-            method such as :meth:`exists` is called.
+            method such as ``exists`` is called.
 
         Returns
         -------
         Results
-            A :class:`Results` instance pointing at ``experiment_folder``.
+            A ``Results`` instance pointing at ``experiment_folder``.
 
         Examples
         --------
@@ -271,213 +262,3 @@ class Results:
             return False
         df = pd.read_csv(csv_path, index_col=0)
         return resample_id in df.index.astype(str)
-
-    def summarize(
-        self,
-        *,
-        labels: Iterable[str] | None = None,
-        split: str = "test",
-    ) -> pd.DataFrame:
-        """Aggregate per-pair CSVs into a multi-index summary DataFrame.
-
-        Parameters
-        ----------
-        labels : iterable of str or None, default=None
-            When provided, only pairs whose classifier name is contained in
-            ``labels`` are included.
-
-        split : {"test", "train", "both"}, default="test"
-            Which metric columns to include.
-
-            - ``"test"``: columns ending with ``_test``.
-            - ``"train"``: columns ending with ``_train``.
-            - ``"both"``: all columns ending with ``_test`` or ``_train``.
-
-        Returns
-        -------
-        pd.DataFrame
-            DataFrame with a ``(classifier, dataset)`` MultiIndex and
-            MultiIndex columns at two levels: outer is the column name (e.g.
-            ``"mae_test"``), inner is ``"mean"`` or ``"std"``.
-            The ``("n_completed", "")`` column counts partitions per pair.
-            Returns an empty :class:`~pandas.DataFrame` when no pairs are found.
-
-        Raises
-        ------
-        ValueError
-            If ``split`` is not ``"test"``, ``"train"``, or ``"both"``.
-        TypeError
-            If ``labels`` is a bare string instead of an iterable of strings.
-
-        Examples
-        --------
-        >>> from skordinal.experiments import Results
-        >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
-        >>> df = results.summarize(split="both")  # doctest: +SKIP
-
-        """
-        _check_split(split, allow_both=True)
-
-        if isinstance(labels, str):
-            raise TypeError(
-                "labels must be an iterable of classifier name strings, not a bare string; "
-                f"pass [{labels!r}] to filter by a single classifier."
-            )
-
-        label_set: set[str] | None = set(labels) if labels is not None else None
-        rows: list[dict] = []
-
-        for clf, ds, csv_path in self._iter_pairs():
-            # Skip pairs not in the requested label filter
-            if label_set is not None and clf not in label_set:
-                continue
-
-            df = pd.read_csv(csv_path, index_col=0)
-
-            # Select columns for the requested split
-            if split == "test":
-                metric_cols = [c for c in df.columns if c.endswith("_test")]
-            elif split == "train":
-                metric_cols = [c for c in df.columns if c.endswith("_train")]
-            else:
-                metric_cols = [c for c in df.columns if c.endswith(("_test", "_train"))]
-
-            # Compute mean and std for each metric column
-            row: dict = {"classifier": clf, "dataset": ds}
-            for col in metric_cols:
-                series = df[col].dropna()
-                n = len(series)
-                row[(col, "mean")] = float(series.mean()) if n > 0 else float("nan")
-                row[(col, "std")] = (
-                    float(series.std(ddof=1))
-                    if n > 1
-                    else (0.0 if n == 1 else float("nan"))
-                )
-            row[("n_completed", "")] = len(df)
-            rows.append(row)
-
-        if not rows:
-            return pd.DataFrame()
-
-        # Build MultiIndex DataFrame from accumulated rows
-        summary = pd.DataFrame(rows).set_index(["classifier", "dataset"])
-        summary.columns = pd.MultiIndex.from_tuples(list(summary.columns))
-        return summary
-
-    def tabulate(
-        self,
-        *,
-        metric: str = "mean_absolute_error",
-        split: str = "test",
-    ) -> pd.DataFrame:
-        """Pivot experiment results into a classifiers-by-datasets table.
-
-        Parameters
-        ----------
-        metric : str, default="mean_absolute_error"
-            Base metric name. The column ``{metric}_{split}`` is looked up in
-            each per-pair CSV.
-
-        split : {"test", "train"}, default="test"
-            Which evaluation split to read.
-
-        Returns
-        -------
-        pd.DataFrame
-            Pivot DataFrame with classifiers as rows and datasets as columns.
-            Each cell is a ``"mean +/- std"`` string formatted to 4 decimal
-            places, or ``"n/a"`` when the column is absent or all-NaN.
-            Returns an empty :class:`~pandas.DataFrame` when no pairs are found.
-
-        Raises
-        ------
-        ValueError
-            If ``split`` is not ``"test"`` or ``"train"``.
-
-        Examples
-        --------
-        >>> from skordinal.experiments import Results
-        >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
-        >>> table = results.tabulate(metric="ccr", split="test")  # doctest: +SKIP
-
-        """
-        _check_split(split, allow_both=False)
-
-        col = f"{metric}_{split}"
-        rows: list[dict] = []
-
-        for clf, ds, csv_path in self._iter_pairs():
-            df = pd.read_csv(csv_path, index_col=0)
-            # Format as "mean +/- std", or "n/a" when the metric is absent or all-NaN
-            if col not in df.columns or df[col].isna().all():
-                cell = "n/a"
-            else:
-                series = df[col].dropna()
-                mean = float(series.mean())
-                std = float(series.std(ddof=1)) if len(series) > 1 else 0.0
-                if not math.isfinite(mean):
-                    cell = "n/a"
-                else:
-                    std = std if math.isfinite(std) else 0.0
-                    cell = f"{mean:.4f} +/- {std:.4f}"
-            rows.append({"classifier": clf, "dataset": ds, "value": cell})
-
-        if not rows:
-            return pd.DataFrame()
-
-        # Pivot into a classifiers x datasets table
-        return (
-            pd.DataFrame(rows)
-            .pivot(index="classifier", columns="dataset", values="value")
-            .fillna("n/a")
-            .rename_axis(index="classifier", columns="dataset")
-        )
-
-    def save_summary(self, *, split: str = "test") -> Path:
-        """Write a summary CSV for the requested split to the experiment folder.
-
-        Parameters
-        ----------
-        split : {"test", "train", "both"}, default="test"
-            Which metric columns to include. Passed directly to
-            :meth:`summarize`.
-
-        Returns
-        -------
-        Path
-            Path of the CSV file that was written.
-
-        Raises
-        ------
-        ValueError
-            If ``split`` is not a recognised value or there are no results.
-
-        Examples
-        --------
-        >>> from skordinal.experiments import Results
-        >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
-        >>> path = results.save_summary(split="test")  # doctest: +SKIP
-
-        """
-        df = self.summarize(split=split)
-        if df.empty:
-            raise ValueError("No results found to summarise.")
-        flat = df.copy()
-        flat.columns = [
-            f"{outer}_{inner}" if inner else outer for outer, inner in flat.columns
-        ]
-        out_path = self._experiment_folder / f"{split}_summary.csv"
-        flat.to_csv(out_path)
-        return out_path
-
-    def _iter_pairs(self) -> Iterator[tuple[str, str, Path]]:
-        """Yield ``(classifier_name, dataset_name, csv_path)`` for each pair."""
-        for clf_dir in sorted(self._experiment_folder.iterdir()):
-            if not clf_dir.is_dir():
-                continue
-            for ds_dir in sorted(clf_dir.iterdir()):
-                if not ds_dir.is_dir():
-                    continue
-                csv_path = ds_dir / "report.csv"
-                if csv_path.is_file():
-                    yield clf_dir.name, ds_dir.name, csv_path

--- a/skordinal/experiments/tests/test_evaluation.py
+++ b/skordinal/experiments/tests/test_evaluation.py
@@ -1,0 +1,357 @@
+"""Tests for the _evaluation module (read-back/reporting functions)."""
+
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import skordinal.experiments as exp_pkg
+from skordinal.experiments import Results, save_summary, summarize, tabulate_results
+from skordinal.experiments._evaluation import _check_split, _iter_pairs
+
+
+def _make_pair_csv(base: Path, classifier: str, dataset: str, rows: list) -> Path:
+    """Write a minimal report.csv under base/classifier/dataset/."""
+    pair_dir = base / classifier / dataset
+    pair_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(rows)
+    csv_path = pair_dir / "report.csv"
+    df.to_csv(csv_path)
+    return csv_path
+
+
+@pytest.fixture
+def two_pair_folder(tmp_path):
+    """Two classifiers x two datasets with 2 partitions each under tmp_path."""
+    for clf in ("A", "B"):
+        for ds in ("d1", "d2"):
+            _make_pair_csv(
+                tmp_path,
+                clf,
+                ds,
+                [
+                    {"mae_train": 0.2, "mae_test": 0.3},
+                    {"mae_train": 0.4, "mae_test": 0.5},
+                ],
+            )
+    return tmp_path
+
+
+def test_summarize_importable_from_package():
+    """``summarize`` is importable from ``skordinal.experiments``."""
+    from skordinal.experiments import summarize as fn  # noqa: F401
+
+    assert callable(fn)
+
+
+def test_tabulate_results_importable_from_package():
+    """``tabulate_results`` is importable from ``skordinal.experiments``."""
+    from skordinal.experiments import tabulate_results as fn  # noqa: F401
+
+    assert callable(fn)
+
+
+def test_save_summary_importable_from_package():
+    """``save_summary`` is importable from ``skordinal.experiments``."""
+    from skordinal.experiments import save_summary as fn  # noqa: F401
+
+    assert callable(fn)
+
+
+def test_summarize_importable_from_evaluation_module():
+    """summarize is importable from skordinal.experiments._evaluation."""
+    from skordinal.experiments._evaluation import summarize as fn  # noqa: F401
+
+    assert callable(fn)
+
+
+def test_tabulate_results_importable_from_evaluation_module():
+    """tabulate_results is importable from the _evaluation module."""
+    from skordinal.experiments._evaluation import tabulate_results as fn  # noqa: F401
+
+    assert callable(fn)
+
+
+def test_save_summary_importable_from_evaluation_module():
+    """save_summary is importable from skordinal.experiments._evaluation."""
+    from skordinal.experiments._evaluation import save_summary as fn  # noqa: F401
+
+    assert callable(fn)
+
+
+def test_three_publics_in_dunder_all():
+    """summarize, tabulate_results, and save_summary appear in __all__."""
+    assert "summarize" in exp_pkg.__all__
+    assert "tabulate_results" in exp_pkg.__all__
+    assert "save_summary" in exp_pkg.__all__
+
+
+def test_evaluate_not_in_package():
+    """evaluate must not be importable from skordinal.experiments."""
+    assert not hasattr(exp_pkg, "evaluate")
+
+
+def test_results_has_no_summarize():
+    """Results must not have a summarize attribute after the extraction."""
+    assert not hasattr(Results, "summarize")
+
+
+def test_results_has_no_tabulate():
+    """Results must not have a tabulate attribute after the extraction."""
+    assert not hasattr(Results, "tabulate")
+
+
+def test_results_has_no_save_summary():
+    """Results must not have a save_summary attribute after the extraction."""
+    assert not hasattr(Results, "save_summary")
+
+
+def test_summarize_shape_split_test(two_pair_folder):
+    """summarize split=test returns a (4, 3) MultiIndex DataFrame."""
+    df = summarize(two_pair_folder, split="test")
+    assert isinstance(df.index, pd.MultiIndex)
+    assert isinstance(df.columns, pd.MultiIndex)
+    assert df.shape == (4, 3)
+
+
+def test_summarize_split_train_columns(two_pair_folder):
+    """summarize split=train selects only _train-suffixed columns."""
+    df = summarize(two_pair_folder, split="train")
+    metric_cols = [c for c in df.columns if c[0] != "n_completed"]
+    assert all(c[0].endswith("_train") for c in metric_cols)
+
+
+def test_summarize_split_both_includes_test_and_train(two_pair_folder):
+    """summarize split=both includes both _test and _train columns."""
+    df = summarize(two_pair_folder, split="both")
+    metric_names = [c[0] for c in df.columns if c[0] != "n_completed"]
+    assert any(c.endswith("_test") for c in metric_names)
+    assert any(c.endswith("_train") for c in metric_names)
+
+
+def test_summarize_mean_std_arithmetic(tmp_path):
+    """Mean and std are computed correctly for 2-resample pairs."""
+    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.2}, {"mae_test": 0.4}])
+    df = summarize(tmp_path, split="test")
+    assert df.loc[("clf", "ds"), ("mae_test", "mean")] == pytest.approx(0.3)
+    assert df.loc[("clf", "ds"), ("mae_test", "std")] == pytest.approx(0.1414, rel=1e-3)
+    assert df.loc[("clf", "ds"), ("n_completed", "")] == 2
+
+
+def test_summarize_labels_filter(two_pair_folder):
+    """``summarize(labels=["A"])`` restricts rows to classifier A."""
+    df = summarize(two_pair_folder, labels=["A"])
+    assert all(clf == "A" for clf, _ in df.index)
+
+
+def test_tabulate_results_pivot_structure(two_pair_folder):
+    """tabulate_results returns a classifiers x datasets pivot DataFrame."""
+    df = tabulate_results(two_pair_folder, metric="mae", split="test")
+    assert isinstance(df, pd.DataFrame)
+    assert set(df.index) == {"A", "B"}
+    assert set(df.columns) == {"d1", "d2"}
+
+
+def test_tabulate_results_missing_metric_returns_na(two_pair_folder):
+    """tabulate_results returns all n/a when the metric column is absent."""
+    df = tabulate_results(two_pair_folder, metric="nonexistent", split="test")
+    assert (df == "n/a").all().all()
+
+
+def test_summarize_empty_folder(tmp_path):
+    """summarize returns an empty DataFrame when the folder has no results."""
+    assert summarize(tmp_path).empty
+
+
+def test_tabulate_results_empty_folder(tmp_path):
+    """tabulate_results returns an empty DataFrame when no results exist."""
+    assert tabulate_results(tmp_path).empty
+
+
+def test_save_summary_writes_csv(two_pair_folder):
+    """``save_summary`` writes ``test_summary.csv`` and returns its path."""
+    path = save_summary(two_pair_folder, split="test")
+    assert path.is_file()
+    assert path.name == "test_summary.csv"
+    df = pd.read_csv(path)
+    assert df.shape[0] == 4
+
+
+def test_save_summary_returns_path_object(two_pair_folder):
+    """``save_summary`` return value is a ``Path`` to the written file."""
+    path = save_summary(two_pair_folder, split="test")
+    assert isinstance(path, Path)
+
+
+def test_summarize_labels_string_raises(two_pair_folder):
+    """Bare string for labels raises TypeError mentioning iterable."""
+    with pytest.raises(TypeError, match="iterable"):
+        summarize(two_pair_folder, labels="A")
+
+
+def test_summarize_invalid_split_raises(two_pair_folder):
+    """Invalid split value raises ValueError mentioning split must be."""
+    with pytest.raises(ValueError, match="split must be"):
+        summarize(two_pair_folder, split="bad")
+
+
+def test_tabulate_results_split_both_raises(two_pair_folder):
+    """split=both is rejected by tabulate_results with ValueError."""
+    with pytest.raises(ValueError, match="split must be"):
+        tabulate_results(two_pair_folder, split="both")
+
+
+def test_save_summary_empty_folder_raises(tmp_path):
+    """save_summary raises ValueError when the folder has no results."""
+    with pytest.raises(ValueError, match="No results"):
+        save_summary(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "split,expected_suffix",
+    [
+        ("test", "_test"),
+        ("train", "_train"),
+    ],
+)
+def test_summarize_split_column_suffix(two_pair_folder, split, expected_suffix):
+    """summarize selects only metric columns matching the suffix for split."""
+    df = summarize(two_pair_folder, split=split)
+    metric_cols = [c[0] for c in df.columns if c[0] != "n_completed"]
+    assert all(c.endswith(expected_suffix) for c in metric_cols)
+
+
+def test_summarize_split_both_is_union(two_pair_folder):
+    """summarize split=both yields the union of test and train columns."""
+    df_test = summarize(two_pair_folder, split="test")
+    df_train = summarize(two_pair_folder, split="train")
+    df_both = summarize(two_pair_folder, split="both")
+
+    test_metric_cols = {c[0] for c in df_test.columns if c[0] != "n_completed"}
+    train_metric_cols = {c[0] for c in df_train.columns if c[0] != "n_completed"}
+    both_metric_cols = {c[0] for c in df_both.columns if c[0] != "n_completed"}
+
+    assert both_metric_cols == test_metric_cols | train_metric_cols
+    # test and train column sets are disjoint
+    assert not test_metric_cols & train_metric_cols
+
+
+def test_iter_pairs_skips_dir_without_report_csv(tmp_path):
+    """_iter_pairs does not yield a dataset dir that lacks a report.csv."""
+    # Valid pair
+    _make_pair_csv(tmp_path, "clf", "ds_valid", [{"mae_test": 0.1}])
+    # Dir without report.csv
+    stray = tmp_path / "clf" / "ds_stray"
+    stray.mkdir(parents=True)
+
+    pairs = list(_iter_pairs(tmp_path))
+    ds_names = {ds for _, ds, _ in pairs}
+    assert "ds_valid" in ds_names
+    assert "ds_stray" not in ds_names
+
+
+def test_iter_pairs_skips_files_at_clf_level(tmp_path):
+    """``_iter_pairs`` skips non-directory entries at the classifier level."""
+    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.1}])
+    # Place a stray file at the root level (not inside any clf dir)
+    (tmp_path / "stray_file.txt").write_text("noise")
+
+    pairs = list(_iter_pairs(tmp_path))
+    # Only the one valid pair must appear
+    assert len(pairs) == 1
+    assert pairs[0][0] == "clf"
+
+
+def test_iter_pairs_skips_files_at_dataset_level(tmp_path):
+    """_iter_pairs skips non-directory entries inside a classifier dir."""
+    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.1}])
+    # Place a stray file inside the clf dir (at the dataset level)
+    (tmp_path / "clf" / "stray.txt").write_text("noise")
+
+    pairs = list(_iter_pairs(tmp_path))
+    assert len(pairs) == 1
+    assert pairs[0][1] == "ds"
+
+
+def test_iter_pairs_nonexistent_folder_raises_file_not_found(tmp_path):
+    """_iter_pairs raises FileNotFoundError when root folder does not exist."""
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(FileNotFoundError):
+        list(_iter_pairs(missing))
+
+
+def test_tabulate_results_single_resample_std_zero(tmp_path):
+    """A single-resample pair produces std == 0.0000 in the formatted cell."""
+    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.25}])
+    df = tabulate_results(tmp_path, metric="mae", split="test")
+    cell = df.loc["clf", "ds"]
+    assert "0.2500 +/- 0.0000" == cell
+
+
+def test_tabulate_results_all_nan_column_returns_na(tmp_path):
+    """An all-NaN metric column produces ``"n/a"`` in the pivot cell."""
+    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": float("nan")}])
+    df = tabulate_results(tmp_path, metric="mae", split="test")
+    assert df.loc["clf", "ds"] == "n/a"
+
+
+def test_tabulate_results_infinite_mean_returns_na(tmp_path):
+    """A metric column containing inf values produces n/a in the cell."""
+    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": float("inf")}])
+    df = tabulate_results(tmp_path, metric="mae", split="test")
+    assert df.loc["clf", "ds"] == "n/a"
+
+
+@pytest.mark.parametrize(
+    "rows,expected_std",
+    [
+        # n==0: column present but all-NaN; after dropna, n==0 → std is nan
+        ([{"mae_test": float("nan")}], float("nan")),
+        # n==1: single finite value → std falls back to 0.0
+        ([{"mae_test": 0.3}], 0.0),
+        # n>1: two finite values → ddof=1 std
+        ([{"mae_test": 0.2}, {"mae_test": 0.4}], pytest.approx(0.1414, rel=1e-3)),
+    ],
+    ids=["n-zero", "n-one", "n-gt-one"],
+)
+def test_summarize_std_behaviour_by_n(tmp_path, rows, expected_std):
+    """``summarize`` std is nan for n==0, 0.0 for n==1, and ddof=1 for n>1."""
+    _make_pair_csv(tmp_path, "clf", "ds", rows)
+    df = summarize(tmp_path, split="test")
+    std_val = df.loc[("clf", "ds"), ("mae_test", "std")]
+    if isinstance(expected_std, float) and math.isnan(expected_std):
+        assert math.isnan(std_val)
+    else:
+        assert std_val == expected_std
+
+
+def test_summarize_all_nan_metric_column_mean_is_nan(tmp_path):
+    """An all-NaN metric column yields a NaN mean in the summary."""
+    _make_pair_csv(
+        tmp_path, "clf", "ds", [{"mae_test": float("nan")}, {"mae_test": float("nan")}]
+    )
+    df = summarize(tmp_path, split="test")
+    mean_val = df.loc[("clf", "ds"), ("mae_test", "mean")]
+    assert math.isnan(mean_val)
+
+
+def test_check_split_valid_values_do_not_raise():
+    """``_check_split`` does not raise for valid split values."""
+    _check_split("test", allow_both=True)
+    _check_split("train", allow_both=True)
+    _check_split("both", allow_both=True)
+    _check_split("test", allow_both=False)
+    _check_split("train", allow_both=False)
+
+
+def test_check_split_both_rejected_when_allow_both_false():
+    """_check_split raises ValueError for both when allow_both=False."""
+    with pytest.raises(ValueError, match="split must be"):
+        _check_split("both", allow_both=False)
+
+
+def test_check_split_unknown_value_raises():
+    """_check_split raises ValueError for an unrecognised split value."""
+    with pytest.raises(ValueError, match="split must be"):
+        _check_split("unknown", allow_both=True)

--- a/skordinal/experiments/tests/test_evaluation.py
+++ b/skordinal/experiments/tests/test_evaluation.py
@@ -1,4 +1,4 @@
-"""Tests for the _evaluation module (read-back/reporting functions)."""
+"""Tests for the _evaluation read-back/reporting functions."""
 
 import math
 from pathlib import Path
@@ -6,12 +6,10 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-import skordinal.experiments as exp_pkg
-from skordinal.experiments import Results, save_summary, summarize, tabulate_results
-from skordinal.experiments._evaluation import _check_split, _iter_pairs
+from skordinal.experiments import save_summary, summarize, tabulate_results
 
 
-def _make_pair_csv(base: Path, classifier: str, dataset: str, rows: list) -> Path:
+def _make_pair_csv(base, classifier, dataset, rows):
     """Write a minimal report.csv under base/classifier/dataset/."""
     pair_dir = base / classifier / dataset
     pair_dir.mkdir(parents=True, exist_ok=True)
@@ -23,7 +21,7 @@ def _make_pair_csv(base: Path, classifier: str, dataset: str, rows: list) -> Pat
 
 @pytest.fixture
 def two_pair_folder(tmp_path):
-    """Two classifiers x two datasets with 2 partitions each under tmp_path."""
+    """Two classifiers by two datasets, each with two resamples."""
     for clf in ("A", "B"):
         for ds in ("d1", "d2"):
             _make_pair_csv(
@@ -31,327 +29,218 @@ def two_pair_folder(tmp_path):
                 clf,
                 ds,
                 [
-                    {"mae_train": 0.2, "mae_test": 0.3},
-                    {"mae_train": 0.4, "mae_test": 0.5},
+                    {
+                        "ccr_train": 0.8,
+                        "mae_train": 0.2,
+                        "ccr_test": 0.7,
+                        "mae_test": 0.3,
+                    },
+                    {
+                        "ccr_train": 0.6,
+                        "mae_train": 0.4,
+                        "ccr_test": 0.5,
+                        "mae_test": 0.5,
+                    },
                 ],
             )
     return tmp_path
 
 
-def test_summarize_importable_from_package():
-    """``summarize`` is importable from ``skordinal.experiments``."""
-    from skordinal.experiments import summarize as fn  # noqa: F401
-
-    assert callable(fn)
-
-
-def test_tabulate_results_importable_from_package():
-    """``tabulate_results`` is importable from ``skordinal.experiments``."""
-    from skordinal.experiments import tabulate_results as fn  # noqa: F401
-
-    assert callable(fn)
-
-
-def test_save_summary_importable_from_package():
-    """``save_summary`` is importable from ``skordinal.experiments``."""
-    from skordinal.experiments import save_summary as fn  # noqa: F401
-
-    assert callable(fn)
-
-
-def test_summarize_importable_from_evaluation_module():
-    """summarize is importable from skordinal.experiments._evaluation."""
-    from skordinal.experiments._evaluation import summarize as fn  # noqa: F401
-
-    assert callable(fn)
-
-
-def test_tabulate_results_importable_from_evaluation_module():
-    """tabulate_results is importable from the _evaluation module."""
-    from skordinal.experiments._evaluation import tabulate_results as fn  # noqa: F401
-
-    assert callable(fn)
-
-
-def test_save_summary_importable_from_evaluation_module():
-    """save_summary is importable from skordinal.experiments._evaluation."""
-    from skordinal.experiments._evaluation import save_summary as fn  # noqa: F401
-
-    assert callable(fn)
-
-
-def test_three_publics_in_dunder_all():
-    """summarize, tabulate_results, and save_summary appear in __all__."""
-    assert "summarize" in exp_pkg.__all__
-    assert "tabulate_results" in exp_pkg.__all__
-    assert "save_summary" in exp_pkg.__all__
-
-
-def test_evaluate_not_in_package():
-    """evaluate must not be importable from skordinal.experiments."""
-    assert not hasattr(exp_pkg, "evaluate")
-
-
-def test_results_has_no_summarize():
-    """Results must not have a summarize attribute after the extraction."""
-    assert not hasattr(Results, "summarize")
-
-
-def test_results_has_no_tabulate():
-    """Results must not have a tabulate attribute after the extraction."""
-    assert not hasattr(Results, "tabulate")
-
-
-def test_results_has_no_save_summary():
-    """Results must not have a save_summary attribute after the extraction."""
-    assert not hasattr(Results, "save_summary")
-
-
-def test_summarize_shape_split_test(two_pair_folder):
-    """summarize split=test returns a (4, 3) MultiIndex DataFrame."""
+def test_summarize_aggregates_metrics(two_pair_folder):
+    """summarize returns a MultiIndex frame with mean, std, and count."""
     df = summarize(two_pair_folder, split="test")
     assert isinstance(df.index, pd.MultiIndex)
     assert isinstance(df.columns, pd.MultiIndex)
-    assert df.shape == (4, 3)
+    # ccr_test and mae_test each contribute mean and std, plus n_completed
+    assert df.shape == (4, 5)
+    assert df.loc[("A", "d1"), ("mae_test", "mean")] == pytest.approx(0.4)
+    assert df.loc[("A", "d1"), ("mae_test", "std")] == pytest.approx(0.1414, abs=1e-3)
+    assert df.loc[("A", "d1"), ("n_completed", "")] == 2
 
 
-def test_summarize_split_train_columns(two_pair_folder):
-    """summarize split=train selects only _train-suffixed columns."""
-    df = summarize(two_pair_folder, split="train")
-    metric_cols = [c for c in df.columns if c[0] != "n_completed"]
-    assert all(c[0].endswith("_train") for c in metric_cols)
+@pytest.mark.parametrize(
+    "split,expected",
+    [
+        ("test", {"ccr_test", "mae_test"}),
+        ("train", {"ccr_train", "mae_train"}),
+        ("both", {"ccr_train", "mae_train", "ccr_test", "mae_test"}),
+    ],
+)
+def test_summarize_selects_columns_by_split(two_pair_folder, split, expected):
+    """summarize keeps only the metric columns for the requested split."""
+    df = summarize(two_pair_folder, split=split)
+    metrics = {c[0] for c in df.columns if c[0] != "n_completed"}
+    assert metrics == expected
 
 
-def test_summarize_split_both_includes_test_and_train(two_pair_folder):
-    """summarize split=both includes both _test and _train columns."""
-    df = summarize(two_pair_folder, split="both")
-    metric_names = [c[0] for c in df.columns if c[0] != "n_completed"]
-    assert any(c.endswith("_test") for c in metric_names)
-    assert any(c.endswith("_train") for c in metric_names)
+@pytest.mark.parametrize(
+    "labels,expected_clfs",
+    [
+        (["A"], {"A"}),
+        (["nonexistent"], set()),
+    ],
+    ids=["subset", "absent"],
+)
+def test_summarize_filters_by_labels(two_pair_folder, labels, expected_clfs):
+    """summarize with labels keeps only matching classifiers or empty."""
+    df = summarize(two_pair_folder, split="test", labels=labels)
+    if expected_clfs:
+        assert {clf for clf, _ in df.index} == expected_clfs
+    else:
+        assert df.empty
 
 
-def test_summarize_mean_std_arithmetic(tmp_path):
-    """Mean and std are computed correctly for 2-resample pairs."""
-    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.2}, {"mae_test": 0.4}])
+@pytest.mark.parametrize(
+    "rows,mean,std,n_completed",
+    [
+        ([{"mae_test": float("nan")}], float("nan"), float("nan"), 1),
+        ([{"mae_test": 0.3}], 0.3, 0.0, 1),
+        ([{"mae_test": 0.2}, {"mae_test": 0.4}], 0.3, 0.1414, 2),
+    ],
+    ids=["all-nan", "single-value", "two-values"],
+)
+def test_summarize_std_rule_by_n(tmp_path, rows, mean, std, n_completed):
+    """summarize std: nan/0.0/ddof=1 by n; n_completed counts all rows."""
+    _make_pair_csv(tmp_path, "clf", "ds", rows)
     df = summarize(tmp_path, split="test")
-    assert df.loc[("clf", "ds"), ("mae_test", "mean")] == pytest.approx(0.3)
-    assert df.loc[("clf", "ds"), ("mae_test", "std")] == pytest.approx(0.1414, rel=1e-3)
-    assert df.loc[("clf", "ds"), ("n_completed", "")] == 2
+    got_mean = df.loc[("clf", "ds"), ("mae_test", "mean")]
+    got_std = df.loc[("clf", "ds"), ("mae_test", "std")]
+    if math.isnan(mean):
+        assert math.isnan(got_mean)
+        assert math.isnan(got_std)
+    else:
+        assert got_mean == pytest.approx(mean)
+        assert got_std == pytest.approx(std, abs=1e-3)
+    # n_completed counts total rows written, including any with NaN values
+    assert df.loc[("clf", "ds"), ("n_completed", "")] == n_completed
 
 
-def test_summarize_labels_filter(two_pair_folder):
-    """``summarize(labels=["A"])`` restricts rows to classifier A."""
-    df = summarize(two_pair_folder, labels=["A"])
-    assert all(clf == "A" for clf, _ in df.index)
+def test_summarize_skips_non_pair_entries(tmp_path):
+    """summarize ignores stray files and dataset dirs without a report."""
+    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.1}])
+    (tmp_path / "stray.txt").write_text("noise")
+    (tmp_path / "clf" / "stray.txt").write_text("noise")
+    (tmp_path / "clf" / "empty_ds").mkdir()
+    df = summarize(tmp_path, split="test")
+    assert {(clf, ds) for clf, ds in df.index} == {("clf", "ds")}
 
 
-def test_tabulate_results_pivot_structure(two_pair_folder):
-    """tabulate_results returns a classifiers x datasets pivot DataFrame."""
-    df = tabulate_results(two_pair_folder, metric="mae", split="test")
-    assert isinstance(df, pd.DataFrame)
-    assert set(df.index) == {"A", "B"}
-    assert set(df.columns) == {"d1", "d2"}
-
-
-def test_tabulate_results_missing_metric_returns_na(two_pair_folder):
-    """tabulate_results returns all n/a when the metric column is absent."""
-    df = tabulate_results(two_pair_folder, metric="nonexistent", split="test")
-    assert (df == "n/a").all().all()
-
-
-def test_summarize_empty_folder(tmp_path):
-    """summarize returns an empty DataFrame when the folder has no results."""
+def test_summarize_empty_folder_returns_empty(tmp_path):
+    """summarize returns an empty frame when no pairs are present."""
     assert summarize(tmp_path).empty
 
 
-def test_tabulate_results_empty_folder(tmp_path):
-    """tabulate_results returns an empty DataFrame when no results exist."""
-    assert tabulate_results(tmp_path).empty
-
-
-def test_save_summary_writes_csv(two_pair_folder):
-    """``save_summary`` writes ``test_summary.csv`` and returns its path."""
-    path = save_summary(two_pair_folder, split="test")
-    assert path.is_file()
-    assert path.name == "test_summary.csv"
-    df = pd.read_csv(path)
-    assert df.shape[0] == 4
-
-
-def test_save_summary_returns_path_object(two_pair_folder):
-    """``save_summary`` return value is a ``Path`` to the written file."""
-    path = save_summary(two_pair_folder, split="test")
-    assert isinstance(path, Path)
-
-
-def test_summarize_labels_string_raises(two_pair_folder):
-    """Bare string for labels raises TypeError mentioning iterable."""
+def test_summarize_rejects_string_labels(two_pair_folder):
+    """summarize raises TypeError when labels is a bare string."""
     with pytest.raises(TypeError, match="iterable"):
         summarize(two_pair_folder, labels="A")
 
 
-def test_summarize_invalid_split_raises(two_pair_folder):
-    """Invalid split value raises ValueError mentioning split must be."""
+def test_summarize_rejects_unknown_split(two_pair_folder):
+    """summarize raises ValueError on an unrecognised split."""
     with pytest.raises(ValueError, match="split must be"):
         summarize(two_pair_folder, split="bad")
 
 
-def test_tabulate_results_split_both_raises(two_pair_folder):
-    """split=both is rejected by tabulate_results with ValueError."""
+@pytest.mark.parametrize(
+    "split,expected_cell",
+    [
+        ("test", "0.4000 +/- 0.1414"),
+        ("train", "0.3000 +/- 0.1414"),
+    ],
+)
+def test_tabulate_results_pivots_formatted_cells(two_pair_folder, split, expected_cell):
+    """tabulate_results pivots classifiers by datasets with mean +/- std."""
+    df = tabulate_results(two_pair_folder, metric="mae", split=split)
+    assert set(df.index) == {"A", "B"}
+    assert set(df.columns) == {"d1", "d2"}
+    assert df.loc["A", "d1"] == expected_cell
+
+
+@pytest.mark.parametrize(
+    "rows,metric",
+    [
+        ([{"mae_test": 0.3}], "nonexistent"),
+        ([{"mae_test": float("nan")}], "mae"),
+        ([{"mae_test": float("inf")}], "mae"),
+    ],
+    ids=["absent", "all-nan", "non-finite"],
+)
+def test_tabulate_results_renders_na(tmp_path, rows, metric):
+    """tabulate_results shows n/a for absent or non-finite metrics."""
+    _make_pair_csv(tmp_path, "clf", "ds", rows)
+    df = tabulate_results(tmp_path, metric=metric, split="test")
+    assert df.loc["clf", "ds"] == "n/a"
+
+
+def test_tabulate_results_single_resample_zero_std(tmp_path):
+    """tabulate_results reports zero std for a single resample."""
+    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.25}])
+    df = tabulate_results(tmp_path, metric="mae", split="test")
+    assert df.loc["clf", "ds"] == "0.2500 +/- 0.0000"
+
+
+def test_tabulate_results_fills_missing_pairs_with_na(tmp_path):
+    """tabulate_results fills a ragged classifier/dataset grid with n/a."""
+    _make_pair_csv(tmp_path, "A", "d1", [{"mae_test": 0.2}])
+    _make_pair_csv(tmp_path, "A", "d2", [{"mae_test": 0.4}])
+    _make_pair_csv(tmp_path, "B", "d1", [{"mae_test": 0.6}])
+    df = tabulate_results(tmp_path, metric="mae", split="test")
+    assert df.loc["A", "d2"] == "0.4000 +/- 0.0000"
+    assert df.loc["B", "d2"] == "n/a"
+
+
+def test_tabulate_results_rejects_both_split(two_pair_folder):
+    """tabulate_results rejects split=both with ValueError."""
     with pytest.raises(ValueError, match="split must be"):
         tabulate_results(two_pair_folder, split="both")
 
 
+def test_tabulate_results_empty_folder_returns_empty(tmp_path):
+    """tabulate_results returns an empty frame when no pairs are present."""
+    assert tabulate_results(tmp_path).empty
+
+
+@pytest.mark.parametrize(
+    "split,expected_metric_cols",
+    [
+        ("test", {"ccr_test_mean", "ccr_test_std", "mae_test_mean", "mae_test_std"}),
+        (
+            "train",
+            {"ccr_train_mean", "ccr_train_std", "mae_train_mean", "mae_train_std"},
+        ),
+        (
+            "both",
+            {
+                "ccr_train_mean",
+                "ccr_train_std",
+                "mae_train_mean",
+                "mae_train_std",
+                "ccr_test_mean",
+                "ccr_test_std",
+                "mae_test_mean",
+                "mae_test_std",
+            },
+        ),
+    ],
+)
+def test_save_summary_writes_csv_and_returns_path(
+    two_pair_folder, split, expected_metric_cols
+):
+    """save_summary writes ``<split>_summary.csv`` with flat metric columns."""
+    path = save_summary(two_pair_folder, split=split)
+    assert isinstance(path, Path)
+    assert path.name == f"{split}_summary.csv"
+    flat = pd.read_csv(path)
+    assert flat.shape[0] == 4
+    # flat columns are the reset MultiIndex levels plus the metric columns
+    assert (
+        set(flat.columns)
+        == {"classifier", "dataset", "n_completed"} | expected_metric_cols
+    )
+
+
 def test_save_summary_empty_folder_raises(tmp_path):
-    """save_summary raises ValueError when the folder has no results."""
+    """save_summary raises ValueError when there are no results."""
     with pytest.raises(ValueError, match="No results"):
         save_summary(tmp_path)
-
-
-@pytest.mark.parametrize(
-    "split,expected_suffix",
-    [
-        ("test", "_test"),
-        ("train", "_train"),
-    ],
-)
-def test_summarize_split_column_suffix(two_pair_folder, split, expected_suffix):
-    """summarize selects only metric columns matching the suffix for split."""
-    df = summarize(two_pair_folder, split=split)
-    metric_cols = [c[0] for c in df.columns if c[0] != "n_completed"]
-    assert all(c.endswith(expected_suffix) for c in metric_cols)
-
-
-def test_summarize_split_both_is_union(two_pair_folder):
-    """summarize split=both yields the union of test and train columns."""
-    df_test = summarize(two_pair_folder, split="test")
-    df_train = summarize(two_pair_folder, split="train")
-    df_both = summarize(two_pair_folder, split="both")
-
-    test_metric_cols = {c[0] for c in df_test.columns if c[0] != "n_completed"}
-    train_metric_cols = {c[0] for c in df_train.columns if c[0] != "n_completed"}
-    both_metric_cols = {c[0] for c in df_both.columns if c[0] != "n_completed"}
-
-    assert both_metric_cols == test_metric_cols | train_metric_cols
-    # test and train column sets are disjoint
-    assert not test_metric_cols & train_metric_cols
-
-
-def test_iter_pairs_skips_dir_without_report_csv(tmp_path):
-    """_iter_pairs does not yield a dataset dir that lacks a report.csv."""
-    # Valid pair
-    _make_pair_csv(tmp_path, "clf", "ds_valid", [{"mae_test": 0.1}])
-    # Dir without report.csv
-    stray = tmp_path / "clf" / "ds_stray"
-    stray.mkdir(parents=True)
-
-    pairs = list(_iter_pairs(tmp_path))
-    ds_names = {ds for _, ds, _ in pairs}
-    assert "ds_valid" in ds_names
-    assert "ds_stray" not in ds_names
-
-
-def test_iter_pairs_skips_files_at_clf_level(tmp_path):
-    """``_iter_pairs`` skips non-directory entries at the classifier level."""
-    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.1}])
-    # Place a stray file at the root level (not inside any clf dir)
-    (tmp_path / "stray_file.txt").write_text("noise")
-
-    pairs = list(_iter_pairs(tmp_path))
-    # Only the one valid pair must appear
-    assert len(pairs) == 1
-    assert pairs[0][0] == "clf"
-
-
-def test_iter_pairs_skips_files_at_dataset_level(tmp_path):
-    """_iter_pairs skips non-directory entries inside a classifier dir."""
-    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.1}])
-    # Place a stray file inside the clf dir (at the dataset level)
-    (tmp_path / "clf" / "stray.txt").write_text("noise")
-
-    pairs = list(_iter_pairs(tmp_path))
-    assert len(pairs) == 1
-    assert pairs[0][1] == "ds"
-
-
-def test_iter_pairs_nonexistent_folder_raises_file_not_found(tmp_path):
-    """_iter_pairs raises FileNotFoundError when root folder does not exist."""
-    missing = tmp_path / "does_not_exist"
-    with pytest.raises(FileNotFoundError):
-        list(_iter_pairs(missing))
-
-
-def test_tabulate_results_single_resample_std_zero(tmp_path):
-    """A single-resample pair produces std == 0.0000 in the formatted cell."""
-    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.25}])
-    df = tabulate_results(tmp_path, metric="mae", split="test")
-    cell = df.loc["clf", "ds"]
-    assert "0.2500 +/- 0.0000" == cell
-
-
-def test_tabulate_results_all_nan_column_returns_na(tmp_path):
-    """An all-NaN metric column produces ``"n/a"`` in the pivot cell."""
-    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": float("nan")}])
-    df = tabulate_results(tmp_path, metric="mae", split="test")
-    assert df.loc["clf", "ds"] == "n/a"
-
-
-def test_tabulate_results_infinite_mean_returns_na(tmp_path):
-    """A metric column containing inf values produces n/a in the cell."""
-    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": float("inf")}])
-    df = tabulate_results(tmp_path, metric="mae", split="test")
-    assert df.loc["clf", "ds"] == "n/a"
-
-
-@pytest.mark.parametrize(
-    "rows,expected_std",
-    [
-        # n==0: column present but all-NaN; after dropna, n==0 → std is nan
-        ([{"mae_test": float("nan")}], float("nan")),
-        # n==1: single finite value → std falls back to 0.0
-        ([{"mae_test": 0.3}], 0.0),
-        # n>1: two finite values → ddof=1 std
-        ([{"mae_test": 0.2}, {"mae_test": 0.4}], pytest.approx(0.1414, rel=1e-3)),
-    ],
-    ids=["n-zero", "n-one", "n-gt-one"],
-)
-def test_summarize_std_behaviour_by_n(tmp_path, rows, expected_std):
-    """``summarize`` std is nan for n==0, 0.0 for n==1, and ddof=1 for n>1."""
-    _make_pair_csv(tmp_path, "clf", "ds", rows)
-    df = summarize(tmp_path, split="test")
-    std_val = df.loc[("clf", "ds"), ("mae_test", "std")]
-    if isinstance(expected_std, float) and math.isnan(expected_std):
-        assert math.isnan(std_val)
-    else:
-        assert std_val == expected_std
-
-
-def test_summarize_all_nan_metric_column_mean_is_nan(tmp_path):
-    """An all-NaN metric column yields a NaN mean in the summary."""
-    _make_pair_csv(
-        tmp_path, "clf", "ds", [{"mae_test": float("nan")}, {"mae_test": float("nan")}]
-    )
-    df = summarize(tmp_path, split="test")
-    mean_val = df.loc[("clf", "ds"), ("mae_test", "mean")]
-    assert math.isnan(mean_val)
-
-
-def test_check_split_valid_values_do_not_raise():
-    """``_check_split`` does not raise for valid split values."""
-    _check_split("test", allow_both=True)
-    _check_split("train", allow_both=True)
-    _check_split("both", allow_both=True)
-    _check_split("test", allow_both=False)
-    _check_split("train", allow_both=False)
-
-
-def test_check_split_both_rejected_when_allow_both_false():
-    """_check_split raises ValueError for both when allow_both=False."""
-    with pytest.raises(ValueError, match="split must be"):
-        _check_split("both", allow_both=False)
-
-
-def test_check_split_unknown_value_raises():
-    """_check_split raises ValueError for an unrecognised split value."""
-    with pytest.raises(ValueError, match="split must be"):
-        _check_split("unknown", allow_both=True)

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -1,13 +1,11 @@
 """Tests for the Results class."""
 
 import json
-from pathlib import Path
 
 import joblib
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
-import pytest
 from sklearn.svm import SVC
 
 from skordinal.experiments import ExperimentResult, Results
@@ -44,7 +42,7 @@ def _make_result(
     )
 
 
-def _make_pair_csv(base: Path, classifier: str, dataset: str, rows: list[dict]) -> Path:
+def _make_pair_csv(base, classifier, dataset, rows):
     """Write a minimal report.csv under base/classifier/dataset/."""
     pair_dir = base / classifier / dataset
     pair_dir.mkdir(parents=True, exist_ok=True)
@@ -52,23 +50,6 @@ def _make_pair_csv(base: Path, classifier: str, dataset: str, rows: list[dict]) 
     csv_path = pair_dir / "report.csv"
     df.to_csv(csv_path)
     return csv_path
-
-
-@pytest.fixture
-def two_pair_results(tmp_path):
-    """Two classifiers x two datasets with 2 partitions each."""
-    for clf in ("A", "B"):
-        for ds in ("d1", "d2"):
-            _make_pair_csv(
-                tmp_path,
-                clf,
-                ds,
-                [
-                    {"mae_train": 0.2, "mae_test": 0.3},
-                    {"mae_train": 0.4, "mae_test": 0.5},
-                ],
-            )
-    return Results(tmp_path)
 
 
 def test_save(tmp_path):
@@ -291,86 +272,3 @@ def test_exists(tmp_path):
     )
     assert r.exists("SVC", "toy", "0") is True
     assert r.exists("SVC", "toy", "1") is False
-
-
-def test_summarize(two_pair_results, tmp_path):
-    """summarize() returns a MultiIndex DataFrame; split filtering works; mean/std values are correct."""
-    # split="test" returns MultiIndex DataFrame with correct shape
-    df_test = two_pair_results.summarize(split="test")
-    assert isinstance(df_test.index, pd.MultiIndex)
-    assert isinstance(df_test.columns, pd.MultiIndex)
-    assert df_test.shape == (4, 3)
-
-    # split="train" includes only _train columns
-    df_train = two_pair_results.summarize(split="train")
-    metric_cols = [c for c in df_train.columns if c[0] != "n_completed"]
-    assert all(c[0].endswith("_train") for c in metric_cols)
-
-    # split="both" includes both _test and _train columns
-    df_both = two_pair_results.summarize(split="both")
-    metric_cols_both = [c[0] for c in df_both.columns if c[0] != "n_completed"]
-    assert any(c.endswith("_test") for c in metric_cols_both)
-    assert any(c.endswith("_train") for c in metric_cols_both)
-
-    # mean and std are computed correctly from 2 partitions
-    _make_pair_csv(
-        tmp_path / "mean_check", "clf", "ds", [{"mae_test": 0.2}, {"mae_test": 0.4}]
-    )
-    df_vals = Results(tmp_path / "mean_check").summarize(split="test")
-    assert df_vals.loc[("clf", "ds"), ("mae_test", "mean")] == pytest.approx(0.3)
-    assert df_vals.loc[("clf", "ds"), ("mae_test", "std")] == pytest.approx(
-        0.1414, rel=1e-3
-    )
-    assert df_vals.loc[("clf", "ds"), ("n_completed", "")] == 2
-
-
-def test_summarize_labels_filter(two_pair_results):
-    """summarize(labels=[...]) restricts results to the given classifiers."""
-    df = two_pair_results.summarize(labels=["A"])
-    assert all(clf == "A" for clf, _ in df.index)
-
-
-def test_summarize_labels_string_raises(two_pair_results):
-    """Passing a bare string to labels raises TypeError."""
-    with pytest.raises(TypeError, match="iterable"):
-        two_pair_results.summarize(labels="A")
-
-
-def test_summarize_invalid_split(two_pair_results):
-    with pytest.raises(ValueError, match="split must be"):
-        two_pair_results.summarize(split="bad")
-
-
-def test_tabulate(two_pair_results):
-    """tabulate() returns a pivot DataFrame; missing metric yields n/a; invalid split raises."""
-    df = two_pair_results.tabulate(metric="mae", split="test")
-    assert isinstance(df, pd.DataFrame)
-    assert set(df.index) == {"A", "B"}
-    assert set(df.columns) == {"d1", "d2"}
-
-    df_missing = two_pair_results.tabulate(metric="nonexistent", split="test")
-    assert (df_missing == "n/a").all().all()
-
-    with pytest.raises(ValueError, match="split must be"):
-        two_pair_results.tabulate(split="both")
-
-
-def test_summarize_tabulate_empty_folder(tmp_path):
-    """Both summarize() and tabulate() return an empty DataFrame when the folder has no results."""
-    r = Results(tmp_path)
-    assert r.summarize().empty
-    assert r.tabulate().empty
-
-
-def test_save_summary_writes_csv(two_pair_results):
-    """save_summary() writes {split}_summary.csv and returns its path."""
-    path = two_pair_results.save_summary(split="test")
-    assert path.is_file()
-    assert path.name == "test_summary.csv"
-    df = pd.read_csv(path)
-    assert df.shape[0] == 4
-
-
-def test_save_summary_empty_raises(tmp_path):
-    with pytest.raises(ValueError, match="No results"):
-        Results(tmp_path).save_summary()


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Reporting moves out of `Results` into a new `skordinal/experiments/_evaluation.py` as module-level functions: `summarize`, `tabulate_results` (renamed from `Results.tabulate`), and `save_summary`. `Results` now handles persistence only, and the reporting functions take a results-folder path rather than a `Results` instance. Behaviour is unchanged: split selection, label filtering, aggregation, and output formatting are preserved. All three functions are importable from `skordinal.experiments`.