### PR TITLE
ENH: Add ORBoost ordinal boosting classifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
             print(f'skordinal {skordinal.__version__} imported');
             import skordinal.classifiers._libsvmrank;
             import skordinal.classifiers._libsvorex;
+            import skordinal.classifiers._orensemble;
             print('C extensions loaded')"
       - uses: actions/upload-artifact@v7
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ^skordinal/classifiers/src/(libsvmrank|svorex)/
+exclude: ^skordinal/classifiers/src/(libsvmrank|orensemble|svorex)/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include skordinal/classifiers/src/libsvmrank *.h *.hpp
+recursive-include skordinal/classifiers/src/orensemble *.h
 recursive-include skordinal/classifiers/src/svorex *.h

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ ext-modules = [
             "skordinal/classifiers/src/orensemble/python",
             "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga",
             "skordinal/classifiers/src/orensemble/python/libsvm-2.81",
-        ], extra-compile-args = ["-std=gnu++98", "-Wno-unused-result", "-Wno-deprecated-declarations", "-Wno-write-strings", "-fvisibility=hidden"]}
+        ], extra-compile-args = ["-Wno-unused-result", "-Wno-deprecated-declarations", "-Wno-write-strings", "-fvisibility=hidden"]}
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,36 @@ ext-modules = [
             "skordinal/classifiers/src/svorex/smo_model_python.c",
             "skordinal/classifiers/src/svorex/smo_loadproblem_python.c",
             "skordinal/classifiers/src/svorex/smo_routine_python.c",
-        ], extra-compile-args = ["-Wno-unused-result", "-ffp-contract=off"], libraries = ["m"]}
+        ], extra-compile-args = ["-Wno-unused-result", "-ffp-contract=off"], libraries = ["m"]},
+    {name = "skordinal.classifiers._orensemble", language = "c++", sources = [
+            "skordinal/classifiers/src/orensemble/python/orensemble-module.cpp",
+            "skordinal/classifiers/src/orensemble/python/orensemble-model-python.cpp",
+            "skordinal/classifiers/src/orensemble/python/boostrank-train.cpp",
+            "skordinal/classifiers/src/orensemble/python/boostrank-predict.cpp",
+            "skordinal/classifiers/src/orensemble/python/train-functions.cpp",
+            "skordinal/classifiers/src/orensemble/orensemble/aggrank.cpp",
+            "skordinal/classifiers/src/orensemble/orensemble/orboost.cpp",
+            "skordinal/classifiers/src/orensemble/orensemble/rankboost.cpp",
+            "skordinal/classifiers/src/orensemble/orensemble/softperc.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/aggregating.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/feedforwardnn.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/kernel.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/learnmodel.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/nnlayer.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/object.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/perceptron.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/utility.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/svm.cpp",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/quickfun.c",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/random.c",
+            "skordinal/classifiers/src/orensemble/python/libsvm-2.81/svm.cpp",
+        ], include-dirs = [
+            "skordinal/classifiers/src/orensemble/orensemble",
+            "skordinal/classifiers/src/orensemble/python",
+            "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga",
+            "skordinal/classifiers/src/orensemble/python/libsvm-2.81",
+        ], extra-compile-args = ["-std=gnu++98", "-Wno-unused-result", "-Wno-deprecated-declarations", "-Wno-write-strings", "-fvisibility=hidden"]}
 ]
 
 [tool.pytest.ini_options]
@@ -149,4 +178,6 @@ git-only = [
     "skordinal/classifiers/src/svorex/Makefile",
     "skordinal/classifiers/src/svorex/README.svorex",
     "skordinal/classifiers/src/svorex/setup.py",
+    "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/LEMGA.dox",
+    "skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/Makefile",
 ]

--- a/skordinal/classifiers/__init__.py
+++ b/skordinal/classifiers/__init__.py
@@ -3,6 +3,7 @@
 from ._cost_sensitive_wrapper import CostSensitiveWrapper
 from ._nnop import NNOP
 from ._nnpom import NNPOM
+from ._orboost import ORBoost
 from ._ordinal_decomposition import OrdinalDecomposition
 from ._redsvm import REDSVM
 from ._regressor_wrapper import RegressorWrapper
@@ -12,6 +13,7 @@ __all__ = [
     "CostSensitiveWrapper",
     "NNOP",
     "NNPOM",
+    "ORBoost",
     "OrdinalDecomposition",
     "REDSVM",
     "RegressorWrapper",

--- a/skordinal/classifiers/_orboost.py
+++ b/skordinal/classifiers/_orboost.py
@@ -1,0 +1,200 @@
+"""Ordinal boosting classifier (ORBoost)."""
+
+from numbers import Integral
+
+import numpy as np
+from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.utils.validation import check_is_fitted
+
+from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.validation import check_ordinal_targets
+
+from . import _orensemble as _orensemble_lib  # type: ignore[attr-defined]
+
+# Backend "bag" codes: tens digit 3/4 = margins to the adjacent/all
+# thresholds; units digit 1 adds a 1e-32 weight stabiliser, 0 does not
+_BAG_CODES = {
+    ("lr", False): 30,
+    ("lr", True): 31,
+    ("full", False): 40,
+    ("full", True): 41,
+}
+
+# Backend weak-learner codes: 100 = stump, 200 = perceptron
+_BASE_CODES = {
+    "stump": 100,
+    "perceptron": 200,
+}
+
+
+class ORBoost(ClassifierMixin, BaseEstimator):
+    """ORBoost ordinal boosting classifier.
+
+    ORBoost [1]_ fits a thresholded ensemble of ``n_estimators`` weak
+    learners by minimising an exponential loss over ordinal ranks. Each
+    boosting round adds one weak learner and re-estimates the ordered
+    thresholds that convert the aggregated output into a rank.
+
+    Parameters
+    ----------
+    n_estimators : int, default=200
+        Number of boosting rounds. Must be >= 1.
+
+    loss_form : {"lr", "full"}, default="lr"
+        Loss formulation. ``"lr"`` penalises each sample's margins to
+        the two thresholds adjacent to its rank; ``"full"`` penalises
+        its margins to all thresholds.
+
+    base_learner : {"stump", "perceptron"}, default="stump"
+        Weak learner type. ``"stump"`` trains a decision stump;
+        ``"perceptron"`` trains a linear perceptron by random
+        coordinate descent.
+
+    weight_reg : bool, default=True
+        If ``True``, adds a small constant (``1e-32``) to both sides of
+        the weak-learner weight computation, preventing division by
+        zero and ``log(0)`` when one side of an ordinal split carries
+        no sample mass.
+
+    Attributes
+    ----------
+    classes_ : ndarray of shape (n_classes,)
+        Unique ordinal class labels seen during ``fit``, sorted in
+        ascending order.
+
+    n_features_in_ : int
+        Number of features seen during ``fit``.
+
+    feature_names_in_ : ndarray of shape (n_features_in_,), dtype object
+        Feature names seen during ``fit``. Defined only when ``X`` is a
+        ``pandas.DataFrame``.
+
+    model_ : dict
+        Model state returned by the C++ backend after fitting, with
+        keys ``'model'`` (learned parameters) and ``'params'``
+        (training configuration). Treat as read-only; modifying this
+        dict may corrupt subsequent calls to ``predict``.
+
+    See Also
+    --------
+    REDSVM : SVM-based ordinal classifier with a C++ backend.
+
+    Notes
+    -----
+    ``predict`` returns hard class labels; ORBoost exposes no
+    ``predict_proba`` or ``decision_function``.
+
+    ORBoost has no ``random_state`` parameter. Fitting with
+    ``base_learner="stump"`` is deterministic. The perceptron learner
+    draws from a process-global, unseeded random stream: the first fit
+    in a fresh process is reproducible, but later fits in the same
+    process may differ.
+
+    Predictions with ``base_learner="perceptron"`` are sensitive to
+    feature scale, so standardising features beforehand is
+    recommended; the stump learner is invariant to monotone
+    per-feature transformations.
+
+    The confidence-rated weak learners of [1]_ are not exposed.
+
+    References
+    ----------
+    .. [1] H.-T. Lin and L. Li, "Large-margin thresholded ensembles for
+       ordinal regression: theory and practice," in Proc. Algorithmic
+       Learning Theory (ALT), Lecture Notes in Computer Science,
+       vol. 4264, pp. 319-333, Springer, 2006.
+       https://doi.org/10.1007/11894841_26
+
+    Examples
+    --------
+    >>> from skordinal.datasets import make_ordinal_classification
+    >>> from skordinal.classifiers import ORBoost
+    >>> X, y = make_ordinal_classification(n_samples=100, random_state=0)
+    >>> clf = ORBoost(n_estimators=20).fit(X, y)
+    >>> clf.predict(X[:3])  # doctest: +SKIP
+    array([3, 4, 2])
+    """
+
+    _parameter_constraints: dict = {
+        "n_estimators": [Interval(Integral, 1, None, closed="left")],
+        "loss_form": [StrOptions({"lr", "full"})],
+        "base_learner": [StrOptions({"stump", "perceptron"})],
+        "weight_reg": ["boolean"],
+    }
+
+    def __init__(
+        self,
+        n_estimators=200,
+        loss_form="lr",
+        base_learner="stump",
+        weight_reg=True,
+    ):
+        self.n_estimators = n_estimators
+        self.loss_form = loss_form
+        self.base_learner = base_learner
+        self.weight_reg = weight_reg
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y):
+        """Fit ORBoost on training data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training patterns.
+
+        y : array-like of shape (n_samples,)
+            Ordinal target labels.
+
+        Returns
+        -------
+        self : ORBoost
+            Fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` contains fewer than 2 unique classes.
+        """
+        X, y = validate_data(self, X, y, dtype=np.float64)
+        self.classes_, y_enc = check_ordinal_targets(y)
+        K = len(self.classes_)
+
+        bag_code = _BAG_CODES[(self.loss_form, bool(self.weight_reg))]
+        base_code = _BASE_CODES[self.base_learner]
+
+        # Backend expects 1-indexed float labels and plain Python lists
+        self.model_ = _orensemble_lib.fit(
+            X.tolist(),
+            (y_enc + 1).astype(float).tolist(),
+            bag_code,
+            base_code,
+            K,
+            self.n_estimators,
+        )
+        return self
+
+    def predict(self, X):
+        """Predict ordinal class labels.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input samples.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted class labels drawn from ``self.classes_``.
+
+        Raises
+        ------
+        NotFittedError
+            If the model is not fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        y_pred = _orensemble_lib.predict(X.tolist(), self.model_)
+        # Map the backend's 1-indexed ranks back to labels in classes_
+        return self.classes_[np.array(y_pred, dtype=int) - 1]

--- a/skordinal/classifiers/src/orensemble/orensemble/aggrank.cpp
+++ b/skordinal/classifiers/src/orensemble/orensemble/aggrank.cpp
@@ -1,0 +1,285 @@
+/**
+   aggrank.cpp: an abstract class for general thresholded ensembles
+   (c) 2006-2007 Hsuan-Tien Lin
+**/
+#include <assert.h>
+#include <cmath>
+#include <map>
+#include <limits>
+
+#include "aggrank.h"
+
+namespace lemga {
+    /** basics **/
+    bool AggRank::serialize (std::ostream& os, ver_list& vl) const {
+	SERIALIZE_PARENT(Aggregating, os, vl, 1);    
+	assert(lm_wgt.size() == lm.size());
+	for (UINT i = 0; i < lm_wgt.size(); ++i)
+	    os << lm_wgt[i] << ' ';
+	if (!lm_wgt.empty()) os << '\n';
+	os << n_rank << '\n';
+	UINT t=0;
+	for (UINT i = 0; i <= lm.size(); i++){
+	    for (UINT k = 1; k < n_rank; k++)
+		os << thres[t++] << ' ';
+	    os << '\n';
+	}
+
+	if (t > 0) os << '\n';
+	return true;
+    }
+
+    bool AggRank::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+	if (d != id() && d != NIL_ID) return false;
+	UNSERIALIZE_PARENT(Aggregating, is, vl, 1, v);
+    
+	const UINT n = lm.size();
+	lm_wgt.resize(n);
+	for (UINT i = 0; i < n; ++i)
+	    if (!(is >> lm_wgt[i])) return false;
+
+	if (!set_aggregation_size(n)) return false;
+
+	UINT _n_rank;
+	if (!(is >> _n_rank))
+	    return false;
+	set_n_rank(_n_rank);
+	thres.resize((n+1) * (n_thres));
+	UINT t=0;
+	for (UINT i = 0; i <= n; i++)
+	    for (UINT k = 1; k < n_rank; k++)
+		if (!(is >> thres[t++])) return false;
+
+	return true;
+    }
+
+    Output AggRank::operator() (const Input& x, UINT iter) const {
+	//y[1] is the decision value, and y[0] is the prediction
+	assert(_n_out == 1);
+	Output y(2, 0);
+
+	if (iter > n_in_agg) iter = n_in_agg;
+    
+	for (UINT i = 0; i < iter; ++i) {
+	    Output out = (*lm[i])(x);
+
+	    y[1] += (out[0] * lm_wgt[i]);
+	}
+
+	UINT rank = 1;
+	UINT idx = iter * n_thres;
+	for(UINT k = 1; k < n_rank; k++)
+	    if (y[1] >= thres[idx++]) rank++;
+	y[0] = rank;
+    
+	return y;
+    }
+    
+    /** initialize routine **/
+    void AggRank::reset() {
+	//clear the trained results, but retain other settings
+	Aggregating::reset();
+	assert(n_rank >= 2);
+	lm_wgt.clear();
+	thres.resize(n_thres);
+	for (UINT k = 0; k < n_thres; ++k){
+	    switch(init_mode){
+	    case INIT_NAIVE:
+		thres[k] = 1.0 + k - 0.5 * n_rank;
+		break;
+	    case INIT_ZERO:
+		thres[k] = 0.0;
+		break;
+	    case INIT_RAND:
+		if (k > 0)
+		    thres[k] = thres[k-1] + randuc();
+		else
+		    thres[k] = randuc();
+		break;
+	    }
+	}
+
+	dec_value.resize(n_samples);
+	for (UINT j = 0; j < n_samples; ++j)
+	    dec_value[j] = 0;
+    }
+
+    pLearnModel AggRank::learn_weak(const vREAL& rhopos, const vREAL& rhoneg, 
+				    const REAL sum_rhodiff) {
+	// rhopos: the sample weights supporting the prediction to be positive
+	// rhoneg: the sample weights supporting the prediction to be negative
+	DataSet* btd = new DataSet();
+	DataWgt* btw = new DataWgt();    
+
+	for(UINT j = 0; j < n_samples; ++j) {
+	    if (rhopos[j] >= rhoneg[j])
+		btd->append(ptd->x(j), 
+			    Output(1, +1));
+	    else
+		btd->append(ptd->x(j), 
+			    Output(1, -1));
+	    btw->push_back(fabs(rhopos[j] - rhoneg[j]) / sum_rhodiff);
+	}
+
+	LearnModel *plm = lm_base->clone();
+    
+	plm->set_train_data(btd, btw);
+	plm->train();
+	return plm;
+    }
+
+    void AggRank::recompute_dec() {    
+	dec_value.resize(n_samples);
+
+	for (UINT j = 0; j < n_samples; ++j){
+	    dec_value[j] = 0.0;
+	    for (UINT i = 0; i < n_in_agg; ++i) {
+		Output out = (*lm[i])(ptd->x(j));	
+		dec_value[j] += (out[0] >= 0)? lm_wgt[i] : -lm_wgt[i];
+	    }
+	}
+    }
+
+    void AggRank::compute_thres(vREAL::iterator it) {
+	vREAL thres_now(n_rank+1);
+	thres_now[0] = -std::numeric_limits<REAL>::max();
+	thres_now[n_rank] = std::numeric_limits<REAL>::max();
+
+	switch(thres_mode){
+	case THRES_EXPLOSS:
+	    compute_thres_exploss(thres_now, false, false);
+	    break;
+	case THRES_EXPLOSS_ORDERED:
+	    compute_thres_exploss(thres_now, true, false);
+	    break;
+	case THRES_ABSLOSS:
+	    compute_thres_dploss(thres_now, true);
+	    break;
+	case THRES_CLALOSS:
+	    compute_thres_dploss(thres_now, false);
+	    break;
+	default:
+	    assert(thres_mode < THRES_CLALOSS);
+	}
+
+	for(UINT k = 1; k < n_rank; ++k)
+	    (*it++)=thres_now[k];
+    }
+
+    void AggRank::compute_thres_exploss(vREAL& th, bool ordered, bool full){
+	assert(th[n_rank] >= std::numeric_limits<REAL>::max());
+
+	vREAL wp(n_rank+1), wn(n_rank+1);
+
+	for(UINT j = 0; j < n_samples; ++j) {
+	    int o = (int)ptd->y(j)[0];
+	    if (full){
+		for(int k=1; k <= o-1; ++k)
+		    wp[k] += exp(-dec_value[j]);
+		for(int k=o; k <= (int)n_rank-1; ++k)
+		    wn[k] += exp(dec_value[j]);
+	    }
+	    else{
+		wp[o-1] += exp(-dec_value[j]);
+		wn[o] += exp(dec_value[j]);
+	    }
+	}
+    
+	for(UINT k = n_rank-1; k > 0; --k){
+	    th[k] = 0.5 * log(wn[k] / wp[k]);
+	    //clip th in the good region
+	    if (std::isnan(th[k]))
+		th[k] = th[k+1];	    
+	    if (std::isinf(th[k]))
+		th[k] = std::isinf(th[k]) * std::numeric_limits<REAL>::max();
+
+	    if (ordered && th[k] > th[k+1]){
+		UINT kk;
+		REAL wwn(wn[k]), wwp(wp[k]);
+	
+		for(kk = k+1; ; kk++){
+		    assert(kk <= n_rank-1); 
+		    // if th[n_rank] = INFTY, 
+		    // then the assertion should be true
+		    wwn += wn[kk];
+		    wwp += wp[kk];
+		    th[kk] = 0.5 * log(wwn / wwp);
+		    if (std::isnan(th[kk]))
+			th[kk] = th[kk+1];
+
+		    if (th[kk] <= th[kk+1])
+			break;
+		}
+		//update from k to kk
+		while(kk > k){
+		    kk--;
+		    th[kk] = th[kk+1];
+		}
+	    }
+	}
+    }
+
+    void AggRank::compute_thres_dploss(vREAL& th, bool do_abs){
+	std::map<REAL, std::vector<UINT> > declbl;
+	std::vector<vREAL> cost;
+	std::map<REAL, std::vector<UINT> >::iterator it;
+	vREAL threserr(n_rank+1);
+	for(UINT j = 0; j < n_samples; ++j)
+	    declbl[dec_value[j]].push_back((UINT)(ptd->y(j)[0]));
+
+	it = declbl.begin();
+	cost.resize(declbl.size());
+	cost[0].resize(n_rank * 2 + 1);
+	cost[0][0] = it->first;
+	for(UINT k = 1; k <= n_rank; ++k){
+	    REAL loss = 0;
+	    for(std::vector<UINT>::iterator in = it->second.begin(); 
+		in != it->second.end(); in++)
+		if (*in != k) loss += (do_abs ? fabs(REAL(*in) - REAL(k)) : 1);
+
+	    cost[0][k] = loss;
+	    cost[0][k+n_rank] = -1;
+	}
+
+	++it;
+	for(UINT n = 1; it != declbl.end(); it++, n++){
+	    REAL bestloss = std::numeric_limits<REAL>::infinity();
+	    REAL bestidx = -1;
+	    cost[n].resize(n_rank * 2 + 1);
+	    cost[n][0] = it->first;
+	    for(UINT k = 1; k <= n_rank; ++k){
+		if (cost[n-1][k] < bestloss){
+		    bestloss = cost[n-1][k];
+		    bestidx = k;
+		}
+		REAL loss = bestloss;
+		for(std::vector<UINT>::iterator in = it->second.begin(); 
+		    in != it->second.end(); in++)
+		    if (*in != k) 
+			loss += (do_abs ? fabs(REAL(*in) - REAL(k)) : 1);
+		cost[n][k] = loss;
+		cost[n][k+n_rank] = bestidx;
+	    }
+	}
+    
+	UINT bestidx = 1;
+	UINT nCost = cost.size();
+	for(UINT k = 1; k <= n_rank; ++k){
+	    if (cost[nCost-1][k] < cost[nCost-1][bestidx])
+		bestidx = k;
+	}
+	for(UINT j = bestidx; j < n_rank; ++j)
+	    th[j] = std::numeric_limits<REAL>::max();
+
+	for(UINT n = nCost-1; n > 0; n--){
+	    UINT nextidx = (UINT)(cost[n][bestidx + n_rank]);
+	    if (bestidx != nextidx){
+		for(UINT j = nextidx; j < bestidx; ++j)
+		    th[j] = (cost[n][0] + cost[n-1][0]) * 0.5;
+		bestidx = nextidx;	    
+	    }
+	}    
+	for(UINT j = 1; j < bestidx; ++j)
+	    th[j] = -std::numeric_limits<REAL>::max();
+    }
+} //namespace lemga

--- a/skordinal/classifiers/src/orensemble/orensemble/aggrank.h
+++ b/skordinal/classifiers/src/orensemble/orensemble/aggrank.h
@@ -1,0 +1,86 @@
+/**
+   aggrank.h: an abstract class for general thresholded ensembles
+   (c) 2006-2007 Hsuan-Tien Lin
+**/
+#ifndef __LEMGA_AGGREGATING_AGGRANK_H__
+#define __LEMGA_AGGREGATING_AGGRANK_H__
+
+#include <aggregating.h>
+
+
+namespace lemga {
+
+    typedef std::vector<REAL> vREAL;
+
+    class AggRank : public Aggregating {
+    public:
+	enum {THRES_EXPLOSS, THRES_EXPLOSS_ORDERED, 
+	      THRES_ABSLOSS, THRES_CLALOSS};
+	enum {INIT_ZERO, INIT_NAIVE, INIT_RAND};
+
+    protected:
+	UINT n_rank;
+
+#define n_thres (n_rank - 1)
+
+	vREAL lm_wgt;
+	vREAL thres; //of size (n_iter+1) * n_thres
+
+	vREAL dec_value;
+
+	UINT thres_mode;
+	UINT init_mode;
+
+    public:
+	explicit AggRank (UINT _n_rank = 2): 
+	    thres_mode(THRES_ABSLOSS), init_mode(INIT_ZERO) {
+	    set_n_rank(_n_rank); 
+	}
+	explicit AggRank (std::istream& is) { is >> *this; }
+
+	virtual AggRank* create () const = 0;
+	virtual AggRank* clone () const = 0;
+	virtual bool support_weighted_data () const { return false; }
+
+	REAL model_weight (UINT n) const { return lm_wgt[n]; }
+	REAL threshold (UINT iter, UINT k) const {
+	    assert(k > 0 && k <= n_thres && iter <= n_in_agg); 
+	    return thres[iter * n_thres + (k-1)]; 
+	}
+	UINT get_n_rank () const { return n_rank; }
+
+	void set_n_rank (UINT _n_rank) { 
+	    assert(_n_rank >= 1); n_rank = _n_rank; 
+	}
+	void set_init_mode (UINT _init_mode) { init_mode = _init_mode; }
+	void set_thres_mode (UINT _thres_mode) { thres_mode = _thres_mode; }
+    protected:
+	virtual bool serialize (std::ostream&, ver_list&) const;
+	virtual bool unserialize (std::istream&, ver_list&,
+				  const id_t& = NIL_ID);
+    public:
+	virtual Output operator() (const Input&, UINT) const;
+	virtual Output operator() (const Input& _in) const { 
+	    return operator()(_in, n_in_agg); 
+	}
+
+	virtual void reset();
+	virtual void train () = 0;
+	virtual void set_reg_param (REAL) = 0;
+    protected:
+	//should be in a level of boosting rather than aggregating
+	pLearnModel learn_weak(const vREAL& rhopos, 
+					const vREAL& rhoneg, 
+					const REAL sum_rhodiff);
+	void recompute_dec();
+	void compute_thres(vREAL::iterator it);
+	void compute_thres_exploss(vREAL& th, bool ordered, bool full);
+	void compute_thres_dploss(vREAL& th, bool do_abs);
+    };
+} // namespace lemga
+
+#ifdef  __AGGRANK_H__
+#warning "This header file may conflict with another `aggrank.h' file."
+#endif
+#define __AGGRANK_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/orensemble/orboost.cpp
+++ b/skordinal/classifiers/src/orensemble/orensemble/orboost.cpp
@@ -1,0 +1,140 @@
+/**
+   orboost.cpp: implement the ORBoost algorithm (Lin and Li 2006)
+   for ordinal regression
+   (c) 2006-2007 Hsuan-Tien Lin
+**/
+#include <assert.h>
+#include <cmath>
+#include <limits>
+
+#include "orboost.h"
+
+REGISTER_CREATOR(lemga::ORBoost);
+
+namespace lemga {
+  void ORBoost::train() {
+    //steepest coordinate decent on (h, w). Then iteratively update (thres, w) for sub_iter times
+
+    set_dimensions(*ptd);
+
+    std::cerr << "Entering ORBoost Training" << std::endl;
+
+
+    vREAL thres_now(n_rank+1);
+    vREAL rhopos(n_samples);
+    vREAL rhoneg(n_samples);
+    REAL sum_rhodiff, obj;
+
+    recompute_dec();
+
+    thres_now[0] = - std::numeric_limits<REAL>::infinity();
+    thres_now[n_rank] = std::numeric_limits<REAL>::infinity();
+
+    compute_thres_exploss(thres_now, ordered, form == FORM_FULL);
+    for(UINT k = 1; k <= n_thres; ++k){
+      thres[(n_in_agg*n_thres) + k-1] = thres_now[k];
+    }
+
+    update_with_dec(thres_now, rhopos, rhoneg, sum_rhodiff, obj);
+    // Issue https://github.com/ayrna/orca/issues/13
+    //std::cerr << "Iteration " << 0 << "/" << max_n_model << " : Obj = " << obj << std::endl;
+
+    thres.resize((max_n_model+1) * n_thres);
+    for (UINT i = 1; i <= max_n_model; ++i) {      
+      pLearnModel plm = learn_weak(rhopos, rhoneg, sum_rhodiff);	
+      REAL ww(0.0);
+      int infflag;
+
+      for(UINT z=0;z<sub_iter;z++){
+	REAL w = compute_w(plm, rhopos, rhoneg);
+	if (std::isnan(w))
+	  w = 0;
+	
+	infflag = std::isinf(w);
+
+	if (infflag)
+	  w = infflag * std::numeric_limits<REAL>::max();
+
+	for(UINT j = 0; j < n_samples; ++j) {
+	  REAL o = plm->get_output(j)[0];
+
+	  dec_value[j] += o * w;
+
+	}
+	ww += w;
+
+	compute_thres_exploss(thres_now, ordered, form == FORM_FULL);
+
+	update_with_dec(thres_now, rhopos, rhoneg, sum_rhodiff, obj);
+
+	if (infflag)
+	  break;
+      }
+
+      infflag = std::isinf(ww);
+
+      if (infflag)
+	ww = infflag * std::numeric_limits<REAL>::max();
+     
+      // Issue: https://github.com/ayrna/orca/issues/1i3 
+      //std::cerr << "Iteration " << i << "/" << max_n_model << " : Obj = " << obj << std::endl;
+      lm.push_back(plm); lm_wgt.push_back(ww);
+      n_in_agg++;
+      for(UINT k = 1; k <= n_thres; ++k)
+	thres[(n_in_agg*n_thres) + k-1] = thres_now[k];
+
+      if (infflag){
+	thres.resize((n_in_agg+1) * n_thres);
+	return;
+      }
+      plm->set_train_data(ptd);
+    }
+  }
+
+  REAL ORBoost::compute_w(pLearnModel plm, vREAL& rhopos, vREAL& rhoneg){
+    REAL wp(reg_param), wn(reg_param);
+    for(UINT j = 0; j < n_samples; ++j) {
+      REAL o = plm->get_output(j)[0];
+
+      if (o >= 0){
+	wn += rhopos[j] * o;
+	wp += rhoneg[j] * o;
+      }
+      else{
+	wp += rhopos[j] * (-o);
+	wn += rhoneg[j] * (-o);
+      }
+    }
+    /**
+       for o in [0, 1]
+          exp(w * o) <= (e^+w - 1)*  o + 1
+       for o in [-1, 0]
+          exp(w * o) <= (e^-w - 1)* -o + 1
+    **/
+
+    return 0.5 * log(wn / wp);
+  }
+
+  void ORBoost::update_with_dec(vREAL& thres_now, vREAL& rhopos, vREAL& rhoneg, REAL& sum_rhodiff, REAL& obj){
+    sum_rhodiff = 0.0;
+    obj = 0.0;
+
+    for(UINT j = 0; j < n_samples; ++j) {
+      UINT goal = (UINT)ptd->y(j)[0];
+      if (form == FORM_LR){
+	rhopos[j] = exp(- dec_value[j] + thres_now[goal-1]);
+	rhoneg[j] = exp(dec_value[j] - thres_now[goal]);
+      }
+      else{ //FORM_FULL
+	rhopos[j] = 0.0;
+	rhoneg[j] = 0.0;
+	for(UINT k = 1; k <= goal-1; ++k)
+	  rhopos[j] += exp(- dec_value[j] + thres_now[k]);
+	for(UINT k = goal; k < n_rank; ++k)
+	  rhoneg[j] += exp(dec_value[j] - thres_now[k]);
+      }
+      sum_rhodiff += fabs(rhopos[j] - rhoneg[j]);
+      obj += (rhopos[j] + rhoneg[j]);
+    }
+  }
+} //namespace lemga

--- a/skordinal/classifiers/src/orensemble/orensemble/orboost.cpp
+++ b/skordinal/classifiers/src/orensemble/orensemble/orboost.cpp
@@ -17,7 +17,7 @@ namespace lemga {
 
     set_dimensions(*ptd);
 
-    std::cerr << "Entering ORBoost Training" << std::endl;
+    //std::cerr << "Entering ORBoost Training" << std::endl;
 
 
     vREAL thres_now(n_rank+1);

--- a/skordinal/classifiers/src/orensemble/orensemble/orboost.h
+++ b/skordinal/classifiers/src/orensemble/orensemble/orboost.h
@@ -1,0 +1,50 @@
+/**
+   orboost.h: implement the ORBoost algorithm (Lin and Li 2006)
+   for ordinal regression
+   (c) 2006-2007 Hsuan-Tien Lin
+**/
+#ifndef __LEMGA_AGGRANK_ORBOOST_H__
+#define __LEMGA_AGGRANK_ORBOOST_H__
+
+#include "aggrank.h"
+
+namespace lemga {
+
+  class ORBoost : public AggRank {
+  public:
+    enum {FORM_LR, FORM_FULL};
+
+  protected:
+    UINT form;
+    bool ordered;
+    UINT sub_iter;
+    REAL reg_param;
+
+  public:
+    explicit ORBoost (UINT _n_rank = 2): AggRank(_n_rank), form(FORM_LR), ordered(true), sub_iter(1), reg_param(0.0) {}
+    explicit ORBoost (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual ORBoost* create () const { return new ORBoost(); }
+    virtual ORBoost* clone () const { return new ORBoost(*this); }
+
+    void set_form (UINT _form) { form = _form; }
+    void set_ordered (bool _ordered) { ordered = _ordered; }
+    void set_sub_iter (UINT _sub_iter) { sub_iter = _sub_iter; }
+    void set_reg_param (REAL _reg_param) { reg_param = _reg_param; }
+
+  public:
+    virtual void train ();
+
+  private:
+    void update_with_dec(vREAL& thres_now, vREAL& rholeft, vREAL& rhoright, REAL& sum_rhodiff, REAL& obj);
+    REAL compute_w(pLearnModel plm, vREAL& rholeft, vREAL& rhoright);
+  };
+
+} // namespace lemga
+
+#ifdef  __ORBOOST_H__
+#warning "This header file may conflict with another `orboost.h' file."
+#endif
+#define __ORBOOST_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/orensemble/rankboost.cpp
+++ b/skordinal/classifiers/src/orensemble/orensemble/rankboost.cpp
@@ -1,0 +1,149 @@
+/**
+   rankboost.cpp: efficiently implement the RankBoost 
+   algorithm (Freund et al. 2003) for ordinal regression
+   (c) 2006-2007 Hsuan-Tien Lin
+**/
+#include <assert.h>
+#include <cmath>
+#include <limits>
+
+#include "rankboost.h"
+
+REGISTER_CREATOR(lemga::RankBoost);
+
+namespace lemga {
+  void RankBoost::train() {
+    //rankboost, efficient implementation, early stop if inf
+
+    set_dimensions(*ptd);
+
+    std::cerr << "Entering RankBoost Training" << std::endl;
+    
+    recompute_dec();
+
+    vREAL rhopos(n_samples);
+    vREAL rhoneg(n_samples);    
+    REAL sum_rhodiff, obj;
+
+    update_with_dec(rhopos, rhoneg, sum_rhodiff, obj);
+
+    // https://github.com/ayrna/orca/issues/13
+    //std::cerr << "Iteration " << 0 << "/" << max_n_model << " : Obj = " << obj << std::endl;
+
+    thres.resize((max_n_model+1) * n_thres);
+
+    for (UINT i = 1; i <= max_n_model; ++i) {      
+      pLearnModel plm = learn_weak(rhopos, rhoneg, sum_rhodiff);
+      REAL w = compute_w(plm);
+      if (std::isnan(w))
+	w = 0; //this happens when plm is a constant classifier
+	
+      int infflag = std::isinf(w);
+
+      if (infflag)
+	w = infflag * std::numeric_limits<REAL>::max();
+
+      for(UINT j = 0; j < n_samples; ++j) {
+	REAL o = plm->get_output(j)[0];
+	dec_value[j] += o * w;
+      }
+      update_with_dec(rhopos, rhoneg, sum_rhodiff, obj);
+
+      // https://github.com/ayrna/orca/issues/13
+      // std::cerr << "Iteration " << i << "/" << max_n_model << " : Obj = " << obj << std::endl;
+      lm.push_back(plm); lm_wgt.push_back(w);
+      n_in_agg++;
+      compute_thres(thres.begin() + (n_in_agg*n_thres));
+
+      if (infflag){
+	thres.resize((n_in_agg+1) * n_thres);
+	return;
+      }
+      plm->set_train_data(ptd);
+    }
+  }
+
+  void RankBoost::update_with_dec(vREAL& rhopos, vREAL& rhoneg, REAL& sum_rhodiff, REAL& obj){
+    //rhopos[i]: weights that desire h_i positive = exp(-g_i) sum_(y_j < y_i) exp(g_j)
+    //rhoneg[i]: weights that desire h_i negative = exp(g_i) sum_(y_j > y_i) exp(-g_j)
+    //the later terms would be computed in lower[y_i] and upper[y_i] first
+    //obj = sum_{y_j < y_i} exp(g_j - g_i) = sum rhopos[i] = sum rhoneg[j]
+
+    vREAL lower(n_rank), upper(n_rank);
+    {
+      //final goal
+      //lower[k-1] = \sum_{y_j < k} exp(g_j)
+      //upper[k-1] = \sum_{y_j > k} exp(-g_j)
+    
+      //first compute 
+      //lower[k-1] = \sum_{y_j = k} exp(g_j)
+      //upper[k-1] = \sum_{y_j = k} exp(-g_j)
+      for(UINT j = 0; j < n_samples; ++j){
+	UINT goal = (UINT)(ptd->y(j)[0] - 1);
+	lower[goal] += exp(dec_value[j]);
+	upper[goal] += exp(-dec_value[j]);
+      }
+      REAL sum;
+
+      //a summation for lower
+      sum = 0.0;
+      for(UINT k = 0; k < n_rank; ++k){
+	REAL tmp = lower[k];
+	lower[k] = sum;
+	sum += tmp;
+      }
+      
+      //a summation for upper
+      sum = 0.0;
+      for(UINT k = n_rank; k > 0; --k){
+	REAL tmp = upper[k-1];
+	upper[k-1] = sum;
+	sum += tmp;
+      }
+    }
+
+    obj = 0.0;
+    sum_rhodiff = 0.0;
+    for(UINT j = 0; j < n_samples; ++j){
+      UINT goal = (UINT)(ptd->y(j)[0] - 1);
+      rhopos[j] = exp(-dec_value[j]) * lower[goal];
+      rhoneg[j] = exp(dec_value[j]) * upper[goal];
+      sum_rhodiff += fabs(rhopos[j] - rhoneg[j]);
+      obj += 0.5 * (rhopos[j] + rhoneg[j]);
+    }      
+  }
+
+  REAL RankBoost::compute_w(pLearnModel plm){
+    /** Method 3 of RankBoost:
+	for r in [-2, 2]
+	r = sum_{y_i < y_j} exp(-(dec_value[j]-dec_value[i])) * (oj - oi) * 0.5
+	sumd = sum_{y_i < y_j} exp(-(dec_value[j]-dec_value[i]))
+    **/
+    
+    REAL r(0.0);
+    vREAL exppos(n_rank), expneg(n_rank);
+    vREAL sumpos(n_rank), sumneg(n_rank);
+    REAL sumd(0.0);
+    
+    for(UINT j = 0; j < n_samples; ++j) {
+      REAL o = plm->get_output(j)[0];
+      UINT goal = (UINT)(ptd->y(j)[0] - 1);
+      
+      exppos[goal] += o * exp(dec_value[j]);
+      expneg[goal] += o * exp(-dec_value[j]);
+      
+      sumpos[goal] += exp(dec_value[j]);
+      sumneg[goal] += exp(-dec_value[j]);
+    }    
+    
+    for(UINT yi = 0; yi < n_rank; yi++){
+      for(UINT yj = yi+1; yj < n_rank; yj++){
+	//now y_i < y_j
+	r += expneg[yj] * sumpos[yi] - exppos[yi] * sumneg[yj];
+	sumd += sumpos[yi] * sumneg[yj];
+      }
+    }
+    r *= 0.5; //shrink from [-2, 2] to [-1, 1];
+    return 0.25 * log((sumd + r) / (sumd - r));    
+  }
+} //namespace lemga

--- a/skordinal/classifiers/src/orensemble/orensemble/rankboost.h
+++ b/skordinal/classifiers/src/orensemble/orensemble/rankboost.h
@@ -1,0 +1,41 @@
+/**
+   rankboost.h: efficiently implement the RankBoost 
+   algorithm (Freund et al. 2003) for ordinal regression
+   (c) 2006-2007 Hsuan-Tien Lin
+**/
+#ifndef __LEMGA_AGGRANK_RANKBOOST_H__
+#define __LEMGA_AGGRANK_RANKBOOST_H__
+
+#include "aggrank.h"
+
+namespace lemga {
+
+  class RankBoost : public AggRank {
+  protected:
+    REAL reg_param;
+
+  public:
+    explicit RankBoost (UINT _n_rank = 2): AggRank(_n_rank), reg_param(0.0) { }
+    explicit RankBoost (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual RankBoost* create () const { return new RankBoost(); }
+    virtual RankBoost* clone () const { return new RankBoost(*this); }
+
+    void set_reg_param(REAL _reg_param) { reg_param = _reg_param; }
+
+  public:
+    virtual void train ();
+
+  private:
+    void update_with_dec(vREAL& rhopos, vREAL& rhoneg, REAL& sum_rhodiff, REAL& obj);
+    REAL compute_w(pLearnModel plm);
+  };
+
+} // namespace lemga
+
+#ifdef  __ADARANK_H__
+#warning "This header file may conflict with another `adarank.h' file."
+#endif
+#define __ADARANK_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/orensemble/softperc.cpp
+++ b/skordinal/classifiers/src/orensemble/orensemble/softperc.cpp
@@ -1,0 +1,58 @@
+/**
+   softperc.cpp: a perceptron model with sigmoid outputs
+   (c) 2006-2007 Hsuan-Tien Lin
+   (some code copied from perceptron.cpp in LEMGA (c) Ling Li)
+**/
+#include <assert.h>
+#include <cmath>
+#include <numeric>
+#include "softperc.h"
+
+REGISTER_CREATOR(lemga::SoftPerc);
+
+#define INPUT_SUM(w,x)  \
+    std::inner_product(x.begin(), x.end(), w.begin(), w.back())
+
+namespace lemga {
+
+Output SoftPerc::operator() (const Input& x) const {
+    assert(x.size() == n_input());
+    REAL sum = INPUT_SUM(wgt, x);
+    return Output(1, tanh(scale * sum));
+}
+
+typedef std::vector<REAL> RVEC;
+typedef std::vector<RVEC> RMAT;
+
+#define DOTPROD(x,y) std::inner_product(x.begin(), x.end(), y.begin(), .0)
+// The version without bias
+#define DOTPROD_NB(x,y) std::inner_product(x.begin(),x.end()-1,y.begin(),.0)
+
+inline void normalize (RVEC& v, REAL thr = 0) {
+    REAL s = DOTPROD(v, v);
+    assert(s > 0);
+    if (s <= thr) return;
+    s = 1 / std::sqrt(s);
+    for (RVEC::iterator p = v.begin(); p != v.end(); ++p)
+        *p *= s;
+}
+
+void SoftPerc::train() {
+    Perceptron::train();
+    normalize(wgt);
+}
+
+bool SoftPerc::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(Perceptron, os, vl, 1);
+
+    return (os << scale << '\n');
+}
+
+bool SoftPerc::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(Perceptron, is, vl, 1, v);
+
+    return (is >> scale);
+}
+
+} // namespace lemga

--- a/skordinal/classifiers/src/orensemble/orensemble/softperc.cpp
+++ b/skordinal/classifiers/src/orensemble/orensemble/softperc.cpp
@@ -45,14 +45,14 @@ void SoftPerc::train() {
 bool SoftPerc::serialize (std::ostream& os, ver_list& vl) const {
     SERIALIZE_PARENT(Perceptron, os, vl, 1);
 
-    return (os << scale << '\n');
+    return (bool)(os << scale << '\n');
 }
 
 bool SoftPerc::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
     if (d != id() && d != NIL_ID) return false;
     UNSERIALIZE_PARENT(Perceptron, is, vl, 1, v);
 
-    return (is >> scale);
+    return (bool)(is >> scale);
 }
 
 } // namespace lemga

--- a/skordinal/classifiers/src/orensemble/orensemble/softperc.h
+++ b/skordinal/classifiers/src/orensemble/orensemble/softperc.h
@@ -1,0 +1,45 @@
+/**
+   softperc.h: a perceptron model with sigmoid outputs
+   (c) 2006-2007 Hsuan-Tien Lin
+**/
+#ifndef __LEMGA_SOFTPERC_H__
+#define __LEMGA_SOFTPERC_H__
+
+#include <vector>
+#include <perceptron.h>
+
+namespace lemga {
+
+/** SoftPerc outputs tanh(scale * (w^T x + b))
+ *  instead of sign(w^T x + b)
+ */
+class SoftPerc : public Perceptron {
+private:
+    REAL scale;
+
+public:
+    explicit SoftPerc (UINT n_in = 0) : Perceptron(n_in), scale(1.0) {}
+    explicit SoftPerc (std::istream& is) { is >> *this; }
+
+    void set_scale(REAL _scale) { assert(scale > 0); scale = _scale; };
+    virtual const id_t& id () const;
+    virtual SoftPerc* create () const { return new SoftPerc(); }
+    virtual SoftPerc* clone () const { return new SoftPerc(*this); }
+
+    virtual Output operator() (const Input&) const;
+
+    virtual void train();
+
+protected:
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+
+};
+
+} // namespace lemga
+
+#ifdef  __SOFTPERC_H__
+#warning "This header file may conflict with another `softperc.h' file."
+#endif
+#define __SOFTPERC_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/boostrank-predict.cpp
+++ b/skordinal/classifiers/src/orensemble/python/boostrank-predict.cpp
@@ -26,15 +26,16 @@ void setInvalidArgsErrorPred()
 lemga::DataSet *loadPredData(PyObject *features, const boostrankParams &params)
 {
     lemga::DataSet *pd = new lemga::DataSet();
-    ssize_t n_test = PyLong_AsLong(PyLong_FromSsize_t(PyList_Size(features)));
+    ssize_t n_test = PyList_Size(features);
 
     for (ssize_t i = 0; i < n_test; ++i)
     {
         lemga::Input x(params.n_in);
         lemga::Output y(params.n_out);
-        if (PyLong_AsUnsignedLong(PyLong_FromSsize_t(PyList_Size(PyList_GetItem(features, i)))) < params.n_in)
+        if ((UINT)PyList_Size(PyList_GetItem(features, i)) < params.n_in)
         {
             PyErr_SetString(PyExc_ValueError, "Instance has less features than expected");
+            delete pd;
             return NULL;
         }
         for (UINT j = 0; j < params.n_in; ++j)
@@ -65,16 +66,18 @@ PyObject *predict(PyObject *self, PyObject *args)
         return NULL;
     }
     /* load test data */
-    lemga::pDataSet ted = loadPredData(features, params);
+    lemga::DataSet *td = loadPredData(features, params);
+    if (NULL == td)
+    {
+        delete pbag;
+        return NULL;
+    }
+    lemga::pDataSet ted = td;
 
-    UINT n_rank = pbag->get_n_rank();
     std::vector<lemga::Output> out(ted->size());
 
     for (UINT i = 0; i < ted->size(); ++i)
-    {
         out[i] = (*pbag)(ted->x(i), params.n_iter);
-        UINT pred = (UINT)(out[i][0]);
-    }
 
     // std::cout << "Absolute Error: " << ae << std::endl;
     // std::cout << "Classification Error: " << ce << std::endl;
@@ -90,6 +93,7 @@ PyObject *predict(PyObject *self, PyObject *args)
         Py_DECREF(list_el);
     }
 
+    delete pbag;
     return predictedLabels;
 }
 
@@ -103,8 +107,17 @@ int parseArgumentsPred(PyObject *args, PyObject **features, lemga::AggRank **mod
 
         boostrankModelParams *modelParams = pythonToModelAndParams(pyModelParams);
 
+        if (NULL == modelParams->model || NULL == modelParams->params)
+        {
+            delete modelParams->model;
+            delete modelParams->params;
+            delete modelParams;
+            return 1;
+        }
         params = *modelParams->params;
         *model = modelParams->model;
+        delete modelParams->params;
+        delete modelParams;
         return 0;
     }
 

--- a/skordinal/classifiers/src/orensemble/python/boostrank-predict.cpp
+++ b/skordinal/classifiers/src/orensemble/python/boostrank-predict.cpp
@@ -1,0 +1,115 @@
+/**
+   boostrank-predict.cpp: main file for performing ordinal regression testing
+   with thresholded ensemble models
+   (c) 2006-2007 Hsuan-Tien Lin
+**/
+#include <fstream>
+#include <iostream>
+#include <set>
+
+#include "aggrank.h"
+#include "orboost.h"
+#include "rankboost.h"
+
+#include "object.h"
+
+#include "Python.h"
+#include "orensemble-model-python.h"
+
+int parseArgumentsPred(PyObject *args, PyObject **features, lemga::AggRank **model, boostrankParams &params);
+
+void setInvalidArgsErrorPred()
+{
+    PyErr_SetString(PyExc_ValueError, "Usage: model.predict(features)");
+}
+
+lemga::DataSet *loadPredData(PyObject *features, const boostrankParams &params)
+{
+    lemga::DataSet *pd = new lemga::DataSet();
+    ssize_t n_test = PyLong_AsLong(PyLong_FromSsize_t(PyList_Size(features)));
+
+    for (ssize_t i = 0; i < n_test; ++i)
+    {
+        lemga::Input x(params.n_in);
+        lemga::Output y(params.n_out);
+        if (PyLong_AsUnsignedLong(PyLong_FromSsize_t(PyList_Size(PyList_GetItem(features, i)))) < params.n_in)
+        {
+            PyErr_SetString(PyExc_ValueError, "Instance has less features than expected");
+            return NULL;
+        }
+        for (UINT j = 0; j < params.n_in; ++j)
+            x[j] = PyFloat_AsDouble(PyList_GetItem(PyList_GetItem(features, i), j));
+
+        y[0] = 0;
+        pd->append(x, y);
+    }
+
+    return pd;
+}
+
+PyObject *predict(PyObject *self, PyObject *args)
+{
+
+    PyObject *features = NULL;
+    boostrankParams params;
+    lemga::AggRank *pbag = NULL;
+    if (parseArgumentsPred(args, &features, &pbag, params))
+    {
+        setInvalidArgsErrorPred();
+        return NULL;
+    }
+
+    if ((NULL == features) || NULL == pbag)
+    {
+        PyErr_SetString(PyExc_MemoryError, "Couldn't allocate dataset or model");
+        return NULL;
+    }
+    /* load test data */
+    lemga::pDataSet ted = loadPredData(features, params);
+
+    UINT n_rank = pbag->get_n_rank();
+    std::vector<lemga::Output> out(ted->size());
+
+    for (UINT i = 0; i < ted->size(); ++i)
+    {
+        out[i] = (*pbag)(ted->x(i), params.n_iter);
+        UINT pred = (UINT)(out[i][0]);
+    }
+
+    // std::cout << "Absolute Error: " << ae << std::endl;
+    // std::cout << "Classification Error: " << ce << std::endl;
+    // std::cout << "Raw Ranking Loss: " << rl << std::endl;
+    // std::cout << "Thresholded Ranking Loss: " << tl << std::endl;
+
+    PyObject *predictedLabels = Py_BuildValue("[]"), *list_el = NULL;
+    for (UINT i = 0; i < out.size(); ++i)
+    {
+        list_el = Py_BuildValue("i", (int)out[i][0]);
+        PyList_Append(predictedLabels, list_el);
+
+        Py_DECREF(list_el);
+    }
+
+    return predictedLabels;
+}
+
+int parseArgumentsPred(PyObject *args, PyObject **features, lemga::AggRank **model, boostrankParams &params)
+{
+    PyObject *pyModelParams;
+    try
+    {
+        if (!PyArg_ParseTuple(args, "OO", features, &pyModelParams))
+            return 1;
+
+        boostrankModelParams *modelParams = pythonToModelAndParams(pyModelParams);
+
+        params = *modelParams->params;
+        *model = modelParams->model;
+        return 0;
+    }
+
+    catch (const std::exception &ex)
+    {
+        return 1;
+    }
+}

--- a/skordinal/classifiers/src/orensemble/python/boostrank-train.cpp
+++ b/skordinal/classifiers/src/orensemble/python/boostrank-train.cpp
@@ -1,0 +1,48 @@
+/**
+   boostrank-train.cpp: generates the `fit` function of the python module.
+   Based on the original boostrank-train.cpp (c) 2006-2007 Hsuan-Tien Lin
+**/
+#include "aggrank.h"
+
+#include "orboost.h"
+#include "orensemble-model-python.h"
+#include "orensemble-module.h"
+#include "rankboost.h"
+#include "train-functions.h"
+
+PyObject *fit(PyObject *self, PyObject *args)
+{
+    // Python parameters
+    PyObject *labels = NULL;
+    PyObject *features = NULL;
+    boostrankParams params;
+
+    if (parseArgumentsTrain(args, &features, &labels, params))
+    {
+        setInvalidArgsErrorTrain();
+        return NULL;
+    }
+
+    if ((NULL == labels) || (NULL == features))
+    {
+        PyErr_SetString(PyExc_MemoryError, "Couldn't allocate dataset");
+        return NULL;
+    }
+
+    /* load training data */
+    lemga::DataSet *trd = loadData(features, labels, params);
+
+    if (NULL == trd)
+    {
+        PyErr_SetString(PyExc_RuntimeError, "Error loading the dataset");
+        return NULL;
+    }
+
+    lemga::AggRank *pbag = setUpModel(params);
+
+    pbag->set_train_data(trd);
+    pbag->train();
+
+    PyObject *ret = modelAndParamsToPython(pbag, params);
+    return ret;
+}

--- a/skordinal/classifiers/src/orensemble/python/boostrank-train.cpp
+++ b/skordinal/classifiers/src/orensemble/python/boostrank-train.cpp
@@ -40,9 +40,16 @@ PyObject *fit(PyObject *self, PyObject *args)
 
     lemga::AggRank *pbag = setUpModel(params);
 
+    if (NULL == pbag)
+    {
+        delete trd;
+        return NULL;
+    }
+
     pbag->set_train_data(trd);
     pbag->train();
 
     PyObject *ret = modelAndParamsToPython(pbag, params);
+    delete pbag;
     return ret;
 }

--- a/skordinal/classifiers/src/orensemble/python/common.h
+++ b/skordinal/classifiers/src/orensemble/python/common.h
@@ -1,0 +1,20 @@
+#ifndef __ORENSEMBLE_COMMON_H__
+#define __ORENSEMBLE_COMMON_H__
+#include "aggrank.h"
+
+typedef struct boostrankParams
+{
+    UINT bag;
+    UINT base;
+    UINT n_rank;
+    UINT n_iter;
+    UINT n_in;
+    UINT n_out;
+} boostrankParams;
+
+typedef struct boostrankModelParams
+{
+    lemga::AggRank *model;
+    boostrankParams *params;
+} boostrankModelParams;
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/LEMGA.dox
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/LEMGA.dox
@@ -1,0 +1,39 @@
+/** @mainpage
+ *  @section intro Introduction
+ *  LEMGA stands for ``Learning Models and Generic Algorithms.''
+ *
+ *  It was rewritten from an old implementation and is still under
+ *  development and test.
+ *
+ *  [<A href="../index.html">Go back</A>]
+ */
+
+
+/** @namespace lemga
+ *  @brief Learning models and generic algorithms
+ *
+ *  The idea is to separate the learning model and optimization techniques.
+ *
+ *  Using vectorop.h for default vector operation
+ *  @todo documentation: basic idea, ...
+ */
+
+/** @namespace lemga::cost
+ *  @brief Cost functions and their derivatives.
+ *
+ *  Boosting can be applied to optimize different cost functions, as long
+ *  as the derivative exists, and line-search is deployed.
+ */
+
+/** @namespace lemga::kernel
+ *  @brief Kernels (inner product in some space)
+ *
+ *  Currently kernels also pass parameters to LIBSVM, which is used as
+ *  the underlying implementation of SVM.
+ */
+
+/** @namespace lemga::op
+ *  @brief Operators used in optimization
+ *
+ *  @todo documentation
+ */

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/Makefile
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/Makefile
@@ -1,0 +1,269 @@
+CC = g++
+CC_FINAL = -D NDEBUG -O3
+CC_DEBUG = -O1
+CC_LIB_FLAGS = -lm
+
+ifeq ($(shell uname -s),Darwin)
+	CC_FLAGS = -std=c++98 -Wall -Wshadow -Wcast-qual\
+		-Wpointer-arith -Wconversion -Wredundant-decls\
+		-Wwrite-strings -Woverloaded-virtual
+else
+	CC_FLAGS = -std=c++98 -static-libgcc -Wall -Wshadow -Wcast-qual\
+		-Wpointer-arith -Wconversion -Wredundant-decls\
+		-Wwrite-strings -Woverloaded-virtual
+endif
+CC_FINAL += -funroll-loops
+
+#ifeq ($(CC), g++)        # for GCC >= 3.2.x
+#CC_FLAGS = -std=c++98 -Wall -Wshadow -Wcast-qual\
+#	-Wpointer-arith -Wconversion -Wredundant-decls\
+#	-Wwrite-strings -Woverloaded-virtual
+#CC_FINAL += -funroll-loops
+##CC_FINAL += -march=pentium3 -mfpmath=sse -msse -mmmx
+##CC_FINAL += -march=pentium4 -mfpmath=sse -msse -msse2 -mmmx
+#endif
+
+#ifeq ($(CC), icc)        # for ICC 8.0
+#CC_FLAGS = -Wall -w1 -pch
+#CC_FINAL += -i_dynamic -ipo -unroll
+#CC_FINAL += -tpp6 -xK
+##CC_FINAL += -tpp7 -xW
+#endif
+
+lemga_do_not_exec:
+	echo Do not run "make" under this directory.
+
+shared_ptr_h = shared_ptr.h
+vectorop_h = vectorop.h
+optimize_h = $(vectorop_h) optimize.h
+
+object_h = object.h
+object_o = object.o
+object_src = object.cpp $(object_h)
+robject.o: $(object_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dobject.o: $(object_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+random_h = $(object_h) random.h
+random_o = $(object_o) random.o
+random_src = random.c $(random_h)
+rrandom.o: $(random_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+drandom.o: $(random_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+quickfun_h = $(object_h) quickfun.h
+quickfun_o = $(object_o) quickfun.o
+quickfun_src = quickfun.c $(quickfun_h)
+rquickfun.o: $(quickfun_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dquickfun.o: $(quickfun_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+utility_h = $(object_h) utility.h
+utility_o = utility.o
+utility_src = utility.cpp $(utility_h)
+rutility.o: $(utility_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dutility.o: $(utility_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+dataset_h = $(random_h) dataset.h
+cost_h = $(object_h) cost.h
+
+kernel_h = $(learnmodel_h) kernel.h
+// have to include svm.o since Kernel::pass_params is implemented there
+kernel_tmp_o = $(object_o) kernel.o
+kernel_o = $(svm_o) $(kernel_tmp_o)
+kernel_src = kernel.cpp $(kernel_h)
+rkernel.o: $(kernel_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dkernel.o: $(kernel_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+learnmodel_h = $(object_h) $(dataset_h) $(shared_ptr_h) learnmodel.h
+learnmodel_o = $(object_o) learnmodel.o
+learnmodel_src = learnmodel.cpp $(learnmodel_h)
+rlearnmodel.o: $(learnmodel_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dlearnmodel.o: $(learnmodel_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+datafeeder_h = $(learnmodel_h) datafeeder.h
+datafeeder_o = $(learnmodel_o) $(random_o) datafeeder.o
+datafeeder_src = datafeeder.cpp $(random_h) $(datafeeder_h)
+rdatafeeder.o: $(datafeeder_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+ddatafeeder.o: $(datafeeder_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+crossval_h = $(shared_ptr_h) $(learnmodel_h) crossval.h
+crossval_o = $(random_o) $(learnmodel_o) crossval.o
+crossval_src = crossval.cpp $(vectorop_h) $(random_h) $(crossval_h)
+rcrossval.o: $(crossval_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dcrossval.o: $(crossval_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+nnlayer_h = $(learnmodel_h) nnlayer.h
+nnlayer_o = $(random_o) $(quickfun_o) $(learnmodel_o) nnlayer.o
+nnlayer_src = nnlayer.cpp $(random_h) $(quickfun_h) $(nnlayer_h)
+rnnlayer.o: $(nnlayer_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dnnlayer.o: $(nnlayer_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+feedforwardnn_h = $(learnmodel_h) $(nnlayer_h) feedforwardnn.h
+feedforwardnn_o = $(learnmodel_o) $(nnlayer_o) feedforwardnn.o
+feedforwardnn_src = feedforwardnn.cpp $(feedforwardnn_h) $(optimize_h)
+rfeedforwardnn.o: $(feedforwardnn_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dfeedforwardnn.o: $(feedforwardnn_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+aggregating_h = $(learnmodel_h) $(shared_ptr_h) aggregating.h
+aggregating_o = $(learnmodel_o) aggregating.o
+aggregating_src = aggregating.cpp $(aggregating_h)
+raggregating.o: $(aggregating_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+daggregating.o: $(aggregating_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+bagging_h = $(aggregating_h) bagging.h
+bagging_o = $(aggregating_o) bagging.o
+bagging_src = bagging.cpp $(bagging_h)
+rbagging.o: $(bagging_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dbagging.o: $(bagging_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+boosting_h = $(aggregating_h) $(cost_h) boosting.h
+boosting_o = $(aggregating_o) boosting.o
+boosting_src = boosting.cpp $(vectorop_h) $(optimize_h) $(boosting_h)
+rboosting.o: $(boosting_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dboosting.o: $(boosting_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+adaboost_h = $(boosting_h) adaboost.h
+adaboost_o = $(boosting_o) adaboost.o
+adaboost_src = adaboost.cpp $(adaboost_h)
+radaboost.o: $(adaboost_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dadaboost.o: $(adaboost_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+stump_h = $(learnmodel_h) stump.h
+stump_o = $(learnmodel_o) stump.o
+stump_src = stump.cpp $(stump_h)
+rstump.o: $(stump_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dstump.o: $(stump_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+cascade_h = $(aggregating_h) cascade.h
+cascade_o = $(aggregating_o) cascade.o
+cascade_src = cascade.cpp $(cascade_h)
+rcascade.o: $(cascade_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dcascade.o: $(cascade_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+pulse_h = $(learnmodel_h) pulse.h
+pulse_o = $(learnmodel_o) pulse.o
+pulse_src = pulse.cpp $(pulse_h)
+rpulse.o: $(pulse_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dpulse.o: $(pulse_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+cgboost_h = $(boosting_h) cgboost.h
+cgboost_o = $(boosting_o) cgboost.o
+cgboost_src = cgboost.cpp $(cgboost_h) $(vectorop_h) $(optimize_h)
+rcgboost.o: $(cgboost_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dcgboost.o: $(cgboost_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+mgnboost_h = $(boosting_h) mgnboost.h
+mgnboost_o = $(boosting_o) mgnboost.o
+mgnboost_src = mgnboost.cpp $(optimize_h) $(mgnboost_h)
+rmgnboost.o: $(mgnboost_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dmgnboost.o: $(mgnboost_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+## external module: LIBSVM ##
+LIBSVM = ../../libsvm-2.81
+libsvm_h = ${LIBSVM}/svm.h
+libsvm_src = ${LIBSVM}/svm.cpp $(libsvm_h)
+rlibsvm.o: $(libsvm_src)
+	$(CC) -I${LIBSVM} $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dlibsvm.o: $(libsvm_src)
+	$(CC) -I${LIBSVM} $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+svm_h = $(learnmodel_h) $(kernel_h) svm.h
+svm_o = $(learnmodel_o) ${kernel_tmp_o} libsvm.o svm.o
+svm_src = svm.cpp $(libsvm_h) $(svm_h)
+rsvm.o: $(svm_src)
+	$(CC) -I${LIBSVM} $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dsvm.o: $(svm_src)
+	$(CC) -I${LIBSVM} $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+## external module: GLPK ##
+## You'll have to configure/make/install GLPK before use.
+GLPK = ../../../glpk-4.8
+glpk_h = $(GLPK)/include/glpk.h
+glpk_a = $(GLPK)/src/libglpk.a
+
+lpboost_h = $(boosting_h) lpboost.h
+lpboost_o = $(boosting_o) lpboost.o
+lpboost_lib = $(glpk_a)
+lpboost_src = lpboost.cpp $(lpboost_h) $(glpk_h)
+rlpboost.o: $(lpboost_src)
+	$(CC) -I${GLPK}/include $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dlpboost.o: $(lpboost_src)
+	$(CC) -I${GLPK}/include $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+perceptron_h = $(learnmodel_h) $(svm_h) perceptron.h
+perceptron_o = $(random_o) $(utility_o) $(svm_o) $(stump_o) perceptron.o
+perceptron_src = perceptron.cpp $(random_h) $(utility_h) $(stump_h) \
+	$(perceptron_h)
+rperceptron.o: $(perceptron_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dperceptron.o: $(perceptron_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+multiclass_ecoc_h = $(aggregating_h) multiclass_ecoc.h
+multiclass_ecoc_o = $(aggregating_o) multiclass_ecoc.o
+multiclass_ecoc_src = multiclass_ecoc.cpp $(multiclass_ecoc_h)
+rmulticlass_ecoc.o: $(multiclass_ecoc_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dmulticlass_ecoc.o: $(multiclass_ecoc_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+adaboost_ecoc_h = $(multiclass_ecoc_h) $(shared_ptr_h) adaboost_ecoc.h
+adaboost_ecoc_o = $(multiclass_ecoc_o) $(random_o) adaboost_ecoc.o
+adaboost_ecoc_src = adaboost_ecoc.cpp $(random_h) $(utility_h) \
+	$(vectorop_h) $(adaboost_ecoc_h)
+radaboost_ecoc.o: $(adaboost_ecoc_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dadaboost_ecoc.o: $(adaboost_ecoc_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+adaboost_erp_h = $(adaboost_ecoc_h) adaboost_erp.h
+adaboost_erp_o = $(adaboost_ecoc_o) adaboost_erp.o
+adaboost_erp_src = adaboost_erp.cpp $(adaboost_erp_h)
+radaboost_erp.o: $(adaboost_erp_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dadaboost_erp.o: $(adaboost_erp_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<
+
+ordinal_ble_h = $(learnmodel_h) $(multiclass_ecoc_h) ordinal_ble.h
+ordinal_ble_o = $(learnmodel_o) ordinal_ble.o
+ordinal_ble_src = ordinal_ble.cpp $(ordinal_ble_h)
+rordinal_ble.o: $(ordinal_ble_src)
+	$(CC) $(CC_FLAGS) $(CC_FINAL) -c -o $@ $<
+dordinal_ble.o: $(ordinal_ble_src)
+	$(CC) $(CC_FLAGS) $(CC_DEBUG) -c -o $@ $<

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/aggregating.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/aggregating.cpp
@@ -1,0 +1,130 @@
+/** @file
+ *  $Id: aggregating.cpp 2664 2006-03-07 19:50:51Z ling $
+ */
+
+#include <assert.h>
+#include "aggregating.h"
+
+namespace lemga {
+
+/** Delete learning models stored in @a lm. This is only used in
+ *  operator= and load().
+ *  @note @a lm_base is not deleted since load() will need it
+ *  @todo make it public under the name clear()? Or remove it
+ */
+void Aggregating::reset () {
+    LearnModel::reset();
+    lm.clear(); n_in_agg = 0;
+    assert(lm_base == 0 || valid_dimensions(*lm_base));
+}
+
+/** @note Brand new models are used in the new born object. Thus
+ *  any future change to the learning models @a a will not affect
+ *  this model.
+ */
+Aggregating::Aggregating (const Aggregating& a)
+    : LearnModel(a), lm_base(a.lm_base),
+      n_in_agg(a.n_in_agg), max_n_model(a.max_n_model)
+{
+    const UINT lms = a.lm.size();
+    assert(n_in_agg <= lms);
+    for (UINT i = 0; i < lms; ++i)
+        lm.push_back(a.lm[i]->clone());
+}
+
+/** @copydoc Aggregating(const Aggregating&) */
+const Aggregating& Aggregating::operator= (const Aggregating& a) {
+    if (&a == this) return *this;
+
+    LearnModel::operator=(a);
+    lm_base = a.lm_base;
+    n_in_agg = a.n_in_agg;
+    max_n_model = a.max_n_model;
+
+    const UINT lms = a.lm.size();
+    assert(n_in_agg <= lms);
+    lm.clear();
+    for (UINT i = 0; i < lms; ++i)
+        lm.push_back(a.lm[i]->clone());
+
+    return *this;
+}
+
+bool Aggregating::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(LearnModel, os, vl, 1);
+
+    if (!(os << lm.size() << ' ' << (lm_base != 0) << '\n'))
+        return false;
+    if (lm_base != 0)
+        if (!(os << *lm_base)) return false;
+    for (UINT i = 0; i < lm.size(); ++i)
+        if (!(os << *lm[i])) return false;
+
+    return true;
+}
+
+bool Aggregating::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(LearnModel, is, vl, 1, v);
+
+    if (v == 0) /* Take care of _n_in and _n_out */
+        if (!(is >> _n_in >> _n_out)) return false;
+
+    UINT t3, t4;
+    if (!(is >> t3 >> t4) || t4 > 1) return false;
+
+    if (!t4) lm_base = 0;
+    else {
+        if (v == 0) { /* ignore a one-line comment */
+            char c; is >> c;
+            assert(c == '#');
+            is.ignore(100, '\n');
+        }
+        LearnModel* p = (LearnModel*) Object::create(is);
+        lm_base = p;
+        if (p == 0 || !valid_dimensions(*p)) return false;
+    }
+
+    lm.clear();
+    for (UINT i = 0; i < t3; ++i) {
+        LearnModel* p = (LearnModel*) Object::create(is);
+        lm.push_back(p);
+        if (p == 0 || !exact_dimensions(*p)) return false;
+    }
+    n_in_agg = t3;
+
+    return true;
+}
+
+/** @brief Set the base learning model.
+ *  @todo Allowed to call when !empty()?
+ */
+void Aggregating::set_base_model (const LearnModel& blm) {
+    assert(valid_dimensions(blm));
+    lm_base = blm.clone();
+}
+
+/** @brief Specify the number of hypotheses used in aggregating.
+ *  @return @c false if @a n is larger than size().
+ *
+ *  Usually all the hypotheses are used in aggregating. However, a
+ *  smaller number @a n can also be specified so that only the first
+ *  @a n hypotheses are used.
+ */
+bool Aggregating::set_aggregation_size (UINT n) {
+    if (n <= size()) {
+        n_in_agg = n;
+        return true;
+    }
+    return false;
+}
+
+void Aggregating::set_train_data (const pDataSet& pd, const pDataWgt& pw) {
+    LearnModel::set_train_data(pd, pw);
+    // Note: leave the compatibility check of the base learner to training.
+    for (UINT i = 0; i < lm.size(); ++i)
+        if (lm[i] != 0)
+            lm[i]->set_train_data(ptd, ptw);
+}
+
+}

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/aggregating.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/aggregating.h
@@ -1,0 +1,86 @@
+// -*- C++ -*-
+#ifndef __LEMGA_AGGREGATING_H__
+#define __LEMGA_AGGREGATING_H__
+
+/** @file
+ *  @brief Declare @link lemga::Aggregating Aggregating@endlink class.
+ *
+ *  $Id: aggregating.h 2664 2006-03-07 19:50:51Z ling $
+ */
+
+#include <vector>
+#include "learnmodel.h"
+
+namespace lemga {
+
+/** @brief An abstract class for aggregating.
+ *
+ *  %Aggregating in learning stands for a series of techniques which
+ *  generate several hypotheses and combine them into a large and
+ *  usually better one. Bagging and AdaBoost are two famous examples
+ *  of such techniques. This class provides member functions to
+ *  store and retrieve hypotheses used in aggregating.
+ *
+ *  The class has a vector of hypotheses, and a base learning model,
+ *  which is the ``parent'' of all those hypotheses. For users of this
+ *  class, a possible calling order for training is
+ *  -# <code>Aggregating *ag = new Some_Aggregating_Method (6, 5);</code>\n
+ *     Create an instance of aggregating with 6 as input dimension
+ *     and 5 output dimension.
+ *  -# <code>ag->@link
+ *     set_base_model() set_base_model@endlink(a_neural_net);</code>\n
+ *     Specify the base learning model (in this example, a neural network).
+ *  -# Follow the
+ *     @ref learnmodel_training_order "normal calling order for training"
+ *     to complete the training.
+ *
+ *  We do not provide...?
+ *  @todo Documentation
+ */
+class Aggregating : public LearnModel {
+protected:
+    pcLearnModel lm_base;           ///< The base learning model
+    std::vector<pLearnModel> lm;    ///< Pointers to learning models
+    UINT n_in_agg;                  ///< \# of models in aggregating
+    UINT max_n_model;               ///< Maximal # of models allowed
+
+public:
+    Aggregating () : LearnModel(), n_in_agg(0), max_n_model(0) {}
+    Aggregating (const Aggregating&);
+    const Aggregating& operator= (const Aggregating&);
+
+    virtual Aggregating* create () const = 0;
+    virtual Aggregating* clone () const = 0;
+
+    //@{ @name Set/get the base model (weak learner)
+    void set_base_model (const LearnModel&);
+    const LearnModel& base_model () const { return *lm_base; }
+    //@}
+
+    void set_max_models (UINT max) { max_n_model = max; }
+
+    //@{ @name Hypotheses operation
+    /// Total number of hypotheses
+    UINT size () const { return lm.size(); }
+    bool empty () const { return lm.empty(); }
+    const LearnModel& model (UINT n) const { return *lm[n]; }
+    const LearnModel& operator[] (UINT n) const { return *lm[n]; }
+    //@}
+
+    virtual bool set_aggregation_size (UINT);
+    UINT aggregation_size () const { return n_in_agg; }
+    virtual void set_train_data (const pDataSet&, const pDataWgt& = 0);
+    virtual void reset ();
+
+protected:
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+};
+
+} // namespace lemga
+
+#ifdef  __AGGREGATING_H__
+#warning "This header file may conflict with another `aggregating.h' file."
+#endif
+#define __AGGREGATING_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/dataset.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/dataset.h
@@ -1,0 +1,176 @@
+// -*- C++ -*-
+#ifndef __LEMGA_DATASET_H__
+#define __LEMGA_DATASET_H__
+
+/** @file
+ *  @brief Class template @link lemga::dataset dataset@endlink for
+ *  wrapping a vector of input-output pairs.
+ *
+ *  $Id: dataset.h 2537 2006-01-08 08:40:36Z ling $
+ */
+
+#include <vector>
+#include <utility>
+#include "random.h"
+
+namespace lemga {
+
+/** @brief Class template for storing, retrieving, and manipulating a
+ *  vector of input-output style data.
+ *  @param Tx Type of input @a x.
+ *  @param Ty Type of output @a y.
+ *
+ *  What we want are:
+ *  1. a place to store data
+ *  2. be able to deal with missing feature?
+ *
+ *  Member functions:
+ *  - basic info.: size, dimension, ...
+ *  - load from / save to a file
+ *  - copy from / to another format (REAL **)
+ *  - ways to produce new data set (by sampling...)
+ *
+ *  @todo documentation
+ */
+template <typename Tx, typename Ty>
+class dataset {
+    /** @note An alternative way to store the input-output pairs is
+     *  to put them into separate variables, i.e., one vector for @a x
+     *  and one for @a y. However, usually the input @a x and output
+     *  @a y in a same pair will be used together. Thus it is better
+     *  for systems with cache to put together corresponding @a x and
+     *  @a y.
+     */
+    std::vector< std::pair<Tx,Ty> > d;
+
+public:
+    typedef Tx x_type;
+    typedef Ty y_type;
+
+    dataset () : d() {}
+
+    //@{ @name Basic
+    UINT size () const { return d.size(); }
+    bool empty () const { return d.empty(); }
+    void clear () { d.clear(); }
+    const Tx& x (UINT i) const { return d[i].first; }
+    const Ty& y (UINT i) const { return d[i].second; }
+    //@}
+
+    //@{ @name Convert from other data types
+    template <typename IIX, typename IIY>
+    dataset (IIX xb, IIX xe, IIY yb, IIY ye) { import(xb, xe, yb, ye); }
+
+    /** @brief Import data from other types.
+     *  @param IIX stands for Input Iterator for @a x.
+     *  @param IIY stands for Input Iterator for @a y.
+     *
+     *  import() copies input @a x from range [@a xb, @a xe) and
+     *  output @a y from range [@a yb, @a ye). Old data stored in
+     *  the set will be erased.
+     *
+     *  To import data from two vectors @a vx and @a vy, use
+     *  @code import(vx.begin(), vx.end(), vy.begin(), vy.end()); @endcode
+     *  To import @a n samples from two pointers px and py, use
+     *  @code import(px, px+n, py, py+n); @endcode
+     */
+    template <typename IIX, typename IIY>
+    void import (IIX xb, IIX xe, IIY yb, IIY ye) {
+        d.clear();
+        d.reserve(xe - xb);
+        for (; xb != xe && yb != ye; ++xb, ++yb)
+            append(*xb, *yb);
+    }
+    //@}
+
+    //@{ @name Data manipulation
+    /** @brief Generate a randomly sampled copy of the data set.
+     *  @param n Number of random samples requested.
+     *  @return A pointer to the new born data set.
+     *
+     *  Samples are chosen with uniform probability.
+     */
+    dataset* random_sample (UINT n) const {
+        const UINT dn = d.size();
+        assert(n == 0 || dn > 0);
+
+        dataset* rd = new dataset();
+        rd->d.reserve(n);
+        while (n--) {
+            const UINT sel = UINT(randu() * dn);
+            assert(sel < dn);
+            rd->d.push_back(d[sel]);
+        }
+        return rd;
+    }
+
+    /** @copydoc random_sample()
+     *  @param W Sample weight type, which usually is @c vector<REAL>.
+     *  @a W should support @c operator[].
+     *  @param wgt Sample weight.
+     */
+    template <typename W>
+    dataset* random_sample (const W& wgt, UINT n) const {
+        const UINT dn = d.size();
+        assert(n == 0 || dn > 0);
+
+        std::vector<PROBAB> cdf(dn+1);
+        cdf[0] = 0;
+        for (UINT i = 0; i < dn; ++i)
+            cdf[i+1] = cdf[i] + wgt[i];
+        assert(cdf[dn]-1 > -EPSILON && cdf[dn]-1 < EPSILON);
+
+        dataset* rd = new dataset();
+        rd->d.reserve(n);
+        while (n--) {
+            const PROBAB r = randu();
+
+            UINT b = 0, e = dn, m;
+            while (b+1 < e) {
+                m = (b + e) / 2;
+                if (r < cdf[m]) e = m;
+                else b = m;
+            }
+
+            rd->d.push_back(d[b]);
+        }
+        return rd;
+    }
+    //@}
+
+    /** @brief Combine two data sets.
+     *  @note Code
+     *  @code copy(ds.d.begin(), ds.d.end(), back_inserter(d)); @endcode
+     *  does almost the same thing, but will fail when @a ds is just
+     *  *this. That is, @code ds += ds; @endcode doesn't work.
+     *  @todo We need more functions to add/remove samples.
+     */
+    dataset& operator+= (const dataset& ds) {
+        const UINT n = ds.d.size();
+        d.reserve(d.size() + n);
+        for (UINT i = 0; i < n; ++i)
+            d.push_back(ds.d[i]);
+        return *this;
+    }
+
+    void append (const Tx& _x, const Ty& _y) {
+        d.resize(d.size()+1);           // 1 constructor + 1 copy
+        d.back().first = _x;            // 1 copy
+        d.back().second = _y;
+        //d.push_back(make_pair(_x, _y));   // 2 copy
+    }
+
+    void replace (UINT i, const Tx& _x, const Ty& _y) {
+        assert (i < d.size());
+        d[i].first = _x;
+        d[i].second = _y;
+    }
+};
+
+} // namespace lemga
+
+#ifdef  __DATASET_H__
+#warning "This header file may conflict with another `dataset.h' file."
+#endif
+#define __DATASET_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/feedforwardnn.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/feedforwardnn.cpp
@@ -1,0 +1,286 @@
+/** @file
+ *  $Id: feedforwardnn.cpp 2664 2006-03-07 19:50:51Z ling $
+ */
+
+#include <assert.h>
+#include "feedforwardnn.h"
+#include "optimize.h"
+
+REGISTER_CREATOR(lemga::FeedForwardNN);
+
+namespace lemga {
+
+void FeedForwardNN::free_space () {
+    for (UINT i = 1; i <= n_layer; ++i) {
+        assert(layer[i] != NULL);
+        delete layer[i];
+    }
+    layer.resize(1);
+    n_layer = 0;
+}
+
+FeedForwardNN::FeedForwardNN ()
+    : LearnModel(0,0), n_layer(0),
+      online_learn(false), train_method(GRADIENT_DESCENT),
+      learn_rate(0.01), min_cst(0), max_run(500)
+{
+    layer.push_back(NULL);
+    /** @todo Online learning is not implemented */
+}
+
+FeedForwardNN::FeedForwardNN (const FeedForwardNN& nn)
+    : LearnModel(nn), n_layer(nn.n_layer), _y(nn._y), _dy(nn._dy),
+      online_learn(nn.online_learn), train_method(nn.train_method),
+      learn_rate(nn.learn_rate), min_cst(nn.min_cst), max_run(nn.max_run)
+{
+    assert(n_layer+1 == nn.layer.size());
+    layer.push_back(NULL);
+    for (UINT i = 1; i <= n_layer; ++i)
+        layer.push_back(nn.layer[i]->clone());
+}
+
+FeedForwardNN::~FeedForwardNN () {
+    free_space();
+}
+
+const FeedForwardNN& FeedForwardNN::operator= (const FeedForwardNN& nn) {
+    if (&nn == this) return *this;
+    LearnModel::operator=(nn);
+
+    free_space();
+    n_layer = nn.n_layer;
+    _y = nn._y;
+    _dy = nn._dy;
+    online_learn = nn.online_learn;
+    train_method = nn.train_method;
+    learn_rate = nn.learn_rate;
+    min_cst = nn.min_cst;
+    max_run = nn.max_run;
+
+    assert(n_layer+1 == nn.layer.size());
+    for (UINT i = 1; i <= n_layer; ++i)
+        layer.push_back(nn.layer[i]->clone());
+
+    return *this;
+}
+
+bool FeedForwardNN::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(LearnModel, os, vl, 1);
+
+    if (!(os << n_layer << '\n')) return false;
+    if (!(os << online_learn << ' ' << learn_rate << ' '
+          << min_cst << ' ' << max_run << '\n')) return false;
+
+    for (UINT i = 1; i <= n_layer; ++i)
+        if (!(os << *layer[i])) return false;
+    return true;
+}
+
+bool
+FeedForwardNN::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(LearnModel, is, vl, 1, v);
+
+    UINT tmp_layer;
+    if (!(is >> tmp_layer) || tmp_layer == 0) return false;
+
+    std::vector<UINT> lsize;
+    if (v == 0) {
+        lsize.resize(tmp_layer+1);
+        for (UINT i = 0; i <= tmp_layer; ++i)
+            if (!(is >> lsize[i]) || lsize[i] == 0) return false;
+    }
+
+    int online;
+    if (!(is >> online >> learn_rate >> min_cst >> max_run))
+        return false;
+    if (online > 1 || learn_rate <= 0 || min_cst < 0 || max_run < 1)
+        return false;
+    online_learn = (online != 0);
+
+    // free the old model !!!
+    const UINT n_in_got = _n_in, n_out_got = _n_out;
+    free_space();
+    _y.clear();
+    _dy.clear();
+
+    for (UINT i = 0; i < tmp_layer; ++i) {
+        NNLayer* pl = (NNLayer*) Object::create(is);
+        if (pl == 0) return false;
+
+        if (v == 0) {
+            if (pl->n_input() != lsize[i] || pl->n_output() != lsize[i+1])
+                return false;
+        }
+        else {
+            static UINT last_output;
+            if (i > 0 && pl->n_input() != last_output) return false;
+            last_output = pl->n_output();
+        }
+
+        add_top(*pl); delete pl;
+    }
+    if (v > 0)
+        if (n_in_got != _n_in || n_out_got != _n_out) return false;
+
+    return true;
+}
+
+void FeedForwardNN::add_top (const NNLayer& nl) {
+    assert(n_layer+1 == layer.size());
+    assert(n_output() == nl.n_input() || n_layer == 0);
+    if (n_layer == 0) {
+        assert(_y.empty() && _dy.empty());
+        _n_in = nl.n_input();
+        _y.push_back(Output(_n_in));
+        _dy.push_back(Output(_n_in));
+    }
+
+    n_layer++;
+    _n_out = nl.n_output();
+    layer.push_back(nl.clone());
+    _y.push_back(Output(nl.n_output()));
+    _dy.push_back(Output(nl.n_output()));
+}
+
+void FeedForwardNN::initialize () {
+    for (UINT i = 1; i <= n_layer; ++i)
+        layer[i]->initialize();
+}
+
+void FeedForwardNN::train () {
+    assert(n_layer > 0);
+    assert(ptd != NULL && ptw != NULL);
+
+    switch (train_method) {
+    case GRADIENT_DESCENT:
+        iterative_optimize(_gradient_descent<FeedForwardNN,WEIGHT,REAL>
+                           (this, learn_rate));
+        break;
+    case LINE_SEARCH:
+        iterative_optimize(_line_search<FeedForwardNN,WEIGHT,REAL,REAL>
+                           (this, learn_rate));
+        break;
+    case CONJUGATE_GRADIENT:
+        iterative_optimize
+            (_conjugate_gradient<FeedForwardNN,WEIGHT,REAL,REAL>
+             (this, learn_rate));
+        break;
+    case WEIGHT_DECAY:
+        iterative_optimize(_gd_weightdecay<FeedForwardNN,WEIGHT,REAL>
+                           (this, learn_rate, 0.01));
+        break;
+    case ADAPTIVE_LEARNING_RATE:
+        iterative_optimize(_gd_adaptive<FeedForwardNN,WEIGHT,REAL,REAL>
+                           (this, learn_rate, 1.15, 0.5));
+        break;
+    default:
+        assert(0);
+    }
+}
+
+void FeedForwardNN::log_cost (UINT epoch, REAL cst) {
+    if (logf != NULL)
+        fprintf(logf, "%lu %g %g\n", epoch, learn_rate, cst);
+
+    if (epoch % 20 == 1)
+        printf("epoch %lu, cost = %g\n", epoch, cst);
+}
+
+Output FeedForwardNN::operator() (const Input& x) const {
+    assert(n_layer > 0);
+    assert(x.size() == n_input());
+
+    forward(x);
+    return _y[n_layer];
+}
+
+FeedForwardNN::WEIGHT FeedForwardNN::weight () const {
+    WEIGHT wgt;
+    for (UINT i = 1; i <= n_layer; ++i)
+        wgt.push_back(layer[i]->weight());
+    return wgt;
+}
+
+void FeedForwardNN::set_weight (const WEIGHT& wgt) {
+    assert(wgt.size() == n_layer);
+    for (UINT i = 1; i <= n_layer; ++i)
+        layer[i]->set_weight(wgt[i-1]);
+}
+
+Output FeedForwardNN::_cost_deriv (const Output& F, const Output& y) const {
+    assert(F.size() == n_output() && y.size() == n_output());
+
+    Output d(_n_out);
+    for (UINT i = 0; i < _n_out; ++i)
+        d[i] = F[i] - y[i];
+    return d;
+}
+
+REAL FeedForwardNN::cost (UINT idx) const {
+    return _cost(get_output(idx), ptd->y(idx));
+}
+
+REAL FeedForwardNN::cost () const {
+    assert(ptd != NULL && ptw != NULL);
+    const UINT n = ptd->size();
+    REAL cst = 0;
+    for (UINT i = 0; i < n; ++i)
+        cst += cost(i) * (*ptw)[i];
+    return cst;
+}
+
+FeedForwardNN::WEIGHT FeedForwardNN::gradient (UINT idx) const {
+    assert(ptd != NULL);
+    assert(n_layer > 0);
+
+    clear_gradient();
+
+    forward(_y[0] = ptd->x(idx));
+    _dy[n_layer] = _cost_deriv(_y[n_layer], ptd->y(idx));
+    for (UINT i = n_layer; i; --i)
+        layer[i]->back_propagate(_y[i-1], _dy[i], _dy[i-1]);
+
+    WEIGHT grad;
+    for (UINT i = 1; i <= n_layer; ++i)
+        grad.push_back(layer[i]->gradient());
+    return grad;
+}
+
+FeedForwardNN::WEIGHT FeedForwardNN::gradient () const {
+    assert(ptd != NULL && ptw != NULL);
+    assert(n_layer > 0);
+
+    clear_gradient();
+
+    const UINT n = ptd->size();
+    for (UINT idx = 0; idx < n; idx++) {
+        forward(_y[0] = ptd->x(idx));
+
+        _dy[n_layer] = _cost_deriv(_y[n_layer], ptd->y(idx));
+        assert(_dy[n_layer].size() == _n_out);
+        const REAL w = (*ptw)[idx] * n;
+        for (UINT j = 0; j < _n_out; ++j)
+            _dy[n_layer][j] *= w;
+
+        for (UINT i = n_layer; i; --i)
+            layer[i]->back_propagate(_y[i-1], _dy[i], _dy[i-1]);
+    }
+
+    WEIGHT grad;
+    for (UINT i = 1; i <= n_layer; ++i)
+        grad.push_back(layer[i]->gradient());
+    return grad;
+}
+
+void FeedForwardNN::clear_gradient () const {
+    for (UINT i = 1; i <= n_layer; ++i)
+        layer[i]->clear_gradient();
+}
+
+bool FeedForwardNN::stop_opt (UINT step, REAL cst) {
+    log_cost(step, cst);
+    return (step >= max_run || cst < min_cst);
+}
+
+} // namespace lemga

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/feedforwardnn.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/feedforwardnn.h
@@ -1,0 +1,108 @@
+// -*- C++ -*-
+#ifndef __LEMGA_FEEDFORWARDNN_H__
+#define __LEMGA_FEEDFORWARDNN_H__
+
+/** @file
+ *  @brief Feed-forward neural network.
+ *
+ *  $Id: feedforwardnn.h 2664 2006-03-07 19:50:51Z ling $
+ */
+
+#include <vector>
+#include "learnmodel.h"
+#include "nnlayer.h"
+
+namespace lemga {
+
+/** @todo documentation */
+class FeedForwardNN : public LearnModel {
+    void free_space ();
+    void forward (const Input& x) const {
+        assert(n_layer > 0 && x.size() == n_input());
+        layer[1]->feed_forward(x, _y[1]);
+        for (UINT i = 2; i <= n_layer; ++i)
+            layer[i]->feed_forward(_y[i-1], _y[i]);
+    }
+
+public:
+    typedef std::vector<NNLayer::WVEC> WEIGHT;
+    enum TRAIN_METHOD {
+        GRADIENT_DESCENT,
+        LINE_SEARCH,
+        CONJUGATE_GRADIENT,
+        WEIGHT_DECAY,
+        ADAPTIVE_LEARNING_RATE
+    };
+
+protected:
+    UINT n_layer;                   ///< # of layers == layer.size()-1.
+    std::vector<NNLayer*> layer;    ///< layer pointers (layer[0] == 0).
+    mutable std::vector<Output> _y; ///< buffer for outputs.
+    mutable std::vector<Output> _dy;///< buffer for derivatives.
+
+    bool online_learn;
+    TRAIN_METHOD train_method;
+    REAL learn_rate, min_cst;
+    UINT max_run;
+
+public:
+    FeedForwardNN ();
+    FeedForwardNN (const FeedForwardNN&);
+    explicit FeedForwardNN (std::istream& is) { is >> *this; }
+    virtual ~FeedForwardNN ();
+    const FeedForwardNN& operator= (const FeedForwardNN&);
+
+    virtual const id_t& id () const;
+    virtual FeedForwardNN* create () const { return new FeedForwardNN(); }
+    virtual FeedForwardNN* clone () const {
+        return new FeedForwardNN(*this); }
+
+    UINT size () const { return n_layer; }
+    const NNLayer& operator[] (UINT n) const { return *layer[n+1]; }
+    void add_top (const NNLayer&);
+    void add_bottom (const NNLayer&);
+
+    void set_batch_mode (bool b = true) { online_learn = !b; }
+    void set_train_method (TRAIN_METHOD m) { train_method = m; }
+    /** @param lr learning rate.
+     *  @param mincst minimal cost (error) need to be achieved during
+     *         training.
+     *  @param maxrun maximal # of epochs the training should take.
+     */
+    void set_parameter (REAL lr, REAL mincst, UINT maxrun) {
+        learn_rate = lr; min_cst = mincst; max_run = maxrun; }
+
+    virtual bool support_weighted_data () const { return true; }
+    virtual void initialize ();
+    virtual void train ();
+    virtual Output operator() (const Input&) const;
+
+protected:
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+
+    virtual REAL _cost (const Output& F, const Output& y) const {
+        return r_error(F, y); }
+    virtual Output _cost_deriv (const Output& F, const Output& y) const;
+    virtual void log_cost (UINT epoch, REAL err);
+
+public:
+    WEIGHT weight () const;
+    void set_weight (const WEIGHT&);
+
+    REAL cost (UINT idx) const;
+    REAL cost () const;
+    WEIGHT gradient (UINT idx) const;
+    WEIGHT gradient () const;
+    void clear_gradient () const;
+
+    bool stop_opt (UINT step, REAL cst);
+};
+
+} // namespace lemga
+
+#ifdef  __FEEDFORWARDNN_H__
+#warning "This header file may conflict with another `feedforwardnn.h' file."
+#endif
+#define __FEEDFORWARDNN_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/kernel.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/kernel.cpp
@@ -1,0 +1,67 @@
+/** @file
+ *  Register kernel creators.
+ *  $Id: kernel.cpp 2551 2006-01-17 04:31:27Z ling $
+ */
+
+#include "kernel.h"
+
+REGISTER_CREATOR2(lemga::kernel::Linear,     k_lin);
+REGISTER_CREATOR2(lemga::kernel::Polynomial, k_pol);
+REGISTER_CREATOR2(lemga::kernel::Stump,      k_stu);
+REGISTER_CREATOR2(lemga::kernel::Perceptron, k_per);
+REGISTER_CREATOR2(lemga::kernel::RBF,        k_rbf);
+REGISTER_CREATOR2(lemga::kernel::Sigmoid,    k_sig);
+
+namespace lemga {
+namespace kernel {
+
+bool Kernel::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(Object, os, vl, 1);
+    return os;
+}
+
+bool Kernel::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(Object, is, vl, 1, v);
+    assert(v > 0);
+    return true;
+}
+
+bool Polynomial::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(Kernel, os, vl, 1);
+    return (os << degree << ' ' << gamma << ' ' << coef0 << '\n');
+}
+
+bool
+Polynomial::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(Kernel, is, vl, 1, v);
+    assert(v > 0);
+    return (is >> degree >> gamma >> coef0) && (gamma > 0);
+}
+
+bool RBF::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(Kernel, os, vl, 1);
+    return (os << gamma << '\n');
+}
+
+bool RBF::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(Kernel, is, vl, 1, v);
+    assert(v > 0);
+    return (is >> gamma) && (gamma > 0);
+}
+
+bool Sigmoid::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(Kernel, os, vl, 1);
+    return (os << gamma << ' ' << coef0 << '\n');
+}
+
+bool Sigmoid::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(Kernel, is, vl, 1, v);
+    assert(v > 0);
+    return (is >> gamma >> coef0) && (gamma > 0);
+}
+
+}} // namespace lemga::kernel

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/kernel.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/kernel.cpp
@@ -17,7 +17,7 @@ namespace kernel {
 
 bool Kernel::serialize (std::ostream& os, ver_list& vl) const {
     SERIALIZE_PARENT(Object, os, vl, 1);
-    return os;
+    return (bool) os;
 }
 
 bool Kernel::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
@@ -29,7 +29,7 @@ bool Kernel::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
 
 bool Polynomial::serialize (std::ostream& os, ver_list& vl) const {
     SERIALIZE_PARENT(Kernel, os, vl, 1);
-    return (os << degree << ' ' << gamma << ' ' << coef0 << '\n');
+    return (bool)(os << degree << ' ' << gamma << ' ' << coef0 << '\n');
 }
 
 bool
@@ -42,7 +42,7 @@ Polynomial::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
 
 bool RBF::serialize (std::ostream& os, ver_list& vl) const {
     SERIALIZE_PARENT(Kernel, os, vl, 1);
-    return (os << gamma << '\n');
+    return (bool)(os << gamma << '\n');
 }
 
 bool RBF::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
@@ -54,7 +54,7 @@ bool RBF::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
 
 bool Sigmoid::serialize (std::ostream& os, ver_list& vl) const {
     SERIALIZE_PARENT(Kernel, os, vl, 1);
-    return (os << gamma << ' ' << coef0 << '\n');
+    return (bool)(os << gamma << ' ' << coef0 << '\n');
 }
 
 bool Sigmoid::unserialize (std::istream& is, ver_list& vl, const id_t& d) {

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/kernel.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/kernel.h
@@ -1,0 +1,204 @@
+// -*- C++ -*-
+#ifndef __LEMGA_KERNEL_H__
+#define __LEMGA_KERNEL_H__
+
+/** @file
+ *  @brief Kernels for SVM etc.
+ *
+ *  $Id: kernel.h 2611 2006-02-02 21:53:30Z ling $
+ */
+
+#include <cmath>
+#include <numeric>
+#include "learnmodel.h"
+
+#define DOTPROD(x,y) std::inner_product(x.begin(), x.end(), y.begin(), .0)
+
+namespace lemga {
+
+// only for LIBSVM, see Kernel::set_params.
+struct SVM_detail;
+
+namespace kernel {
+
+inline REAL norm_1 (const Input& u, const Input& v) {
+    REAL sum(0);
+    Input::const_iterator x = u.begin(), y = v.begin();
+    for (; x != u.end(); ++x, ++y)
+        sum += std::fabs(*x - *y);
+    return sum;
+}
+
+inline REAL norm_2 (const Input& u, const Input& v) {
+    REAL sum(0);
+    Input::const_iterator x = u.begin(), y = v.begin();
+    for (; x != u.end(); ++x, ++y) {
+        REAL d = *x - *y;
+        sum += d * d;
+    }
+    return sum;
+}
+
+/// The operator() gives the inner-product in the transformed space.
+class Kernel : public Object {
+public:
+    virtual Kernel* create () const = 0;
+    virtual Kernel* clone () const = 0;
+
+    /// The inner-product of two input vectors.
+    virtual REAL operator() (const Input&, const Input&) const = 0;
+    /// Store a dataset in order to compute the kernel matrix.
+    virtual void set_data (const pDataSet& pd) { ptd = pd; }
+    /// The inner-product of two stored inputs with index @a i and @a j.
+    virtual REAL matrix (UINT i, UINT j) const
+    { return operator()(ptd->x(i), ptd->x(j)); }
+
+    /// In order to keep the SVM interface simple and avoid
+    /// member functions specific to kernels (e.g., set_gamma()),
+    /// we use Kernel to pass kernel parameters to SVM_detail.
+    virtual void set_params (SVM_detail*) const = 0;
+
+protected:
+    pDataSet ptd;
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+};
+
+/// %Linear kernel @f$\left<u,v\right>@f$.
+struct Linear : public Kernel {
+    Linear () {}
+    explicit Linear (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual Linear* create () const { return new Linear(); }
+    virtual Linear* clone () const { return new Linear(*this); }
+
+    virtual REAL operator() (const Input& a, const Input& b) const {
+        return DOTPROD(a, b);
+    }
+    virtual void set_params (SVM_detail*) const;
+};
+
+/// %Polynomial kernel @f$(\gamma*\left<u,v\right>+c_0)^d@f$.
+struct Polynomial : public Kernel {
+    UINT degree;
+    REAL gamma, coef0;
+
+    Polynomial (UINT d = 3, REAL g = 0.5, REAL c0 = 0)
+        : degree(d), gamma(g), coef0(c0) {};
+    explicit Polynomial (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual Polynomial* create () const { return new Polynomial(); }
+    virtual Polynomial* clone () const { return new Polynomial(*this); }
+
+    virtual REAL operator() (const Input& a, const Input& b) const {
+        return std::pow(gamma * DOTPROD(a, b) + coef0, (double) degree);
+    }
+    virtual void set_params (SVM_detail*) const;
+
+protected:
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+};
+
+/// %Stump kernel @f$-\left|u-v\right|_1@f$.
+struct Stump : public Kernel {
+    Stump () {}
+    explicit Stump (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual Stump* create () const { return new Stump(); }
+    virtual Stump* clone () const { return new Stump(*this); }
+
+    virtual REAL operator() (const Input& a, const Input& b) const {
+        return -norm_1(a, b);
+    }
+    virtual void set_params (SVM_detail*) const;
+};
+
+/// %Perceptron kernel @f$-\left|u-v\right|_2@f$.
+struct Perceptron : public Kernel {
+protected:
+    std::vector<REAL> x_norm2; ///< cached inner-product of data input
+
+public:
+    Perceptron () {}
+    explicit Perceptron (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual Perceptron* create () const { return new Perceptron(); }
+    virtual Perceptron* clone () const { return new Perceptron(*this); }
+
+    virtual REAL operator() (const Input& a, const Input& b) const {
+        return -std::sqrt(norm_2(a, b));
+    }
+
+    virtual void set_data (const pDataSet& pd) {
+        Kernel::set_data(pd);
+        const UINT n = ptd->size();
+        x_norm2.resize(n);
+        for (UINT i = 0; i < n; ++i)
+            x_norm2[i] = DOTPROD(ptd->x(i), ptd->x(i));
+    }
+    virtual REAL matrix (UINT i, UINT j) const {
+        REAL n2 = x_norm2[i] + x_norm2[j] - 2*DOTPROD(ptd->x(i), ptd->x(j));
+        return (n2 > 0)? -std::sqrt(n2) : 0;   // avoid -0.0
+    }
+
+    virtual void set_params (SVM_detail*) const;
+};
+
+/// %RBF (Gausssian) kernel @f$e^{-\gamma\left|u-v\right|_2^2}@f$.
+struct RBF : public Perceptron {
+    REAL gamma;
+    explicit RBF (REAL g = 0.5) : gamma(g) {}
+    explicit RBF (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual RBF* create () const { return new RBF(); }
+    virtual RBF* clone () const { return new RBF(*this); }
+
+    virtual REAL operator() (const Input& a, const Input& b) const {
+        return std::exp(-gamma * norm_2(a, b));
+    }
+
+    virtual REAL matrix (UINT i, UINT j) const {
+        REAL n2 = x_norm2[i] + x_norm2[j] - 2*DOTPROD(ptd->x(i), ptd->x(j));
+        return std::exp(-gamma * n2);
+    }
+
+    virtual void set_params (SVM_detail*) const;
+
+protected:
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+};
+
+/// %Sigmoid kernel @f$\tanh(\gamma\left<u,v\right>+c_0)@f$.
+struct Sigmoid : public Kernel {
+    REAL gamma, coef0;
+    Sigmoid (REAL g = 0.5, REAL c0 = 0) : gamma(g), coef0(c0) {};
+    explicit Sigmoid (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual Sigmoid* create () const { return new Sigmoid(); }
+    virtual Sigmoid* clone () const { return new Sigmoid(*this); }
+
+    virtual REAL operator() (const Input& a, const Input& b) const {
+        return std::tanh(gamma * DOTPROD(a, b) + coef0);
+    }
+    virtual void set_params (SVM_detail*) const;
+
+protected:
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+};
+
+}} // namespace lemga::kernel
+
+#ifdef  __KERNEL_H__
+#warning "This header file may conflict with another `kernel.h' file."
+#endif
+#define __KERNEL_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/learnmodel.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/learnmodel.cpp
@@ -1,0 +1,225 @@
+/** @file
+ *  $Id: learnmodel.cpp 2664 2006-03-07 19:50:51Z ling $
+ */
+
+#include <assert.h>
+#include <cmath>
+#include <sstream>
+#include <stdio.h>
+#include "learnmodel.h"
+
+namespace lemga {
+
+/** A local helper for load_data */
+static DataSet*
+load_data (DataSet* pd, std::istream& is, UINT n, UINT in, UINT out) {
+    for (UINT i = 0; i < n; ++i) {
+        Input x(in);
+        Output y(out);
+        for (UINT j = 0; j < in; ++j)
+            if (!(is >> x[j])) return pd;
+        for (UINT j = 0; j < out; ++j)
+            if (!(is >> y[j])) return pd;
+
+        pd->append(x, y);
+    }
+    return pd;
+}
+
+/** Each sample consists of first the input and then the output.
+ *  Numbers are separated by spaces.
+ *  @param is the input stream
+ *  @param n gives the number of samples
+ *  @param in is the dimension of input
+ *  @param out is the dimension of output
+ *  @todo documentation: why separate function
+ */
+DataSet* load_data (std::istream& is, UINT n, UINT in, UINT out) {
+    DataSet* pd = new DataSet();
+    return load_data(pd, is, n, in, out);
+}
+
+/** An easier-to-use version, where the output dimension is fixed
+ *  at 1, and the input dimension is auto-detected. This version
+ *  requires that each row of stream @a is should be a sample.
+ */
+DataSet* load_data (std::istream& is, UINT n) {
+    assert(n > 0);
+    /* read the first line and infer the input dimension */
+    Input x;
+    do {
+        char line[1024*10];
+        is.getline(line, 1024*10);
+        std::istringstream iss(line);
+        REAL xi;
+        while (iss >> xi)
+            x.push_back(xi);
+    } while (x.empty() && !is.eof());
+    if (x.empty()) return 0;
+
+    Output y(1, x.back());
+    x.pop_back();
+
+    DataSet* pd = new DataSet();
+    pd->append(x, y);
+    return load_data(pd, is, n-1, x.size(), 1);
+}
+
+/** @param n_in is the dimension of input.
+ *  @param n_out is the dimension of output. */
+LearnModel::LearnModel (UINT n_in, UINT n_out)
+    : Object(), _n_in(n_in), _n_out(n_out), n_samples(0), logf(NULL)
+{ /* empty */ }
+
+bool LearnModel::serialize (std::ostream& os,
+                            ver_list& vl) const {
+    SERIALIZE_PARENT(Object, os, vl, 1);
+    return (os << _n_in << ' ' << _n_out << '\n');
+}
+
+bool LearnModel::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    assert(d == NIL_ID);
+    UNSERIALIZE_PARENT(Object, is, vl, 1, v);
+    _n_in = 0; _n_out = 0;
+    ptd = 0; ptw = 0; n_samples = 0;
+    if (v == 0) return true;
+    return (is >> _n_in >> _n_out);
+}
+
+/** @param out is the output from the learned hypothesis.
+ *  @param y is the real output.
+ *  @return Regression error between @a out and @a y.
+ *  A commonly used measure is the squared error.
+ */
+REAL LearnModel::r_error (const Output& out, const Output& y) const {
+    assert(out.size() == n_output());
+    assert(y.size() == n_output());
+
+    REAL err = 0;
+    for (UINT i = 0; i < _n_out; ++i) {
+        REAL dif = out[i] - y[i];
+        err += dif * dif;
+    }
+    return err / 2;
+}
+
+/** @param out is the output from the learned hypothesis.
+ *  @param y is the real output.
+ *  @return Classification error between @a out and @a y.
+ *  The error measure is not necessary symmetric. A commonly used
+ *  measure is @a out != @a y.
+ */
+REAL LearnModel::c_error (const Output& out, const Output& y) const {
+    assert(n_output() == 1);
+    assert(std::fabs(std::fabs(y[0]) - 1) < INFINITESIMAL);
+    return (out[0]*y[0] <= 0);
+}
+
+REAL LearnModel::train_r_error () const {
+    assert(ptw != 0);
+    REAL err = 0;
+    for (UINT i = 0; i < n_samples; ++i)
+        err += (*ptw)[i] * r_error(get_output(i), ptd->y(i));
+    return err;
+}
+
+REAL LearnModel::train_c_error () const {
+    assert(ptw != 0);
+    REAL err = 0;
+    for (UINT i = 0; i < n_samples; ++i)
+        err += (*ptw)[i] * c_error(get_output(i), ptd->y(i));
+    return err;
+}
+
+REAL LearnModel::test_r_error (const pDataSet& pd) const {
+    UINT n = pd->size();
+    REAL err = 0;
+    for (UINT i = 0; i < n; ++i)
+        err += r_error((*this)(pd->x(i)), pd->y(i));
+    return err / n;
+}
+
+REAL LearnModel::test_c_error (const pDataSet& pd) const {
+    UINT n = pd->size();
+    REAL err = 0;
+    for (UINT i = 0; i < n; ++i)
+        err += c_error((*this)(pd->x(i)), pd->y(i));
+    return err / n;
+}
+
+/** If the learning model/algorithm can only do training using uniform
+ *  sample weight, i.e., support_weighted_data() returns @c false, a
+ *  ``boostrapped'' copy of the original data set will be generated and
+ *  used in the following training. The boostrapping is done by randomly
+ *  pick samples (with replacement) w.r.t. the given weight @a pw.
+ *
+ *  In order to make the life easier, when support_weighted_data() returns
+ *  @c true, a null @a pw will be replaced by a uniformly distributed
+ *  probability vector. So we have the following invariant
+ *  @invariant support_weighted_data() == (@a ptw != 0)
+ *
+ *  @param pd gives the data set.
+ *  @param pw gives the sample weight, whose default value is 0.
+ *  @sa support_weighted_data(), train()
+ */
+void LearnModel::set_train_data (const pDataSet& pd, const pDataWgt& pw) {
+    n_samples = pd->size();
+    assert(n_samples > 0);
+    assert(!pw || n_samples == pw->size());
+    if (support_weighted_data()) {
+        ptd = pd;
+        ptw = (pw != 0)? pw : new DataWgt(n_samples, 1.0 / n_samples);
+    } else {
+        ptd = (!pw)? pd : pd->random_sample(*pw, n_samples);
+        ptw = 0;
+    }
+    assert(support_weighted_data() == (ptw != 0));
+#ifndef NDEBUG
+    // assert: ptw is a probability vector
+    if (ptw != 0) {
+        REAL wsum = 0;
+        for (UINT i = 0; i < n_samples; i++) {
+            assert((*ptw)[i] >= 0);
+            wsum += (*ptw)[i];
+        }
+        assert(wsum-1 > -EPSILON && wsum-1 < EPSILON);
+    }
+#endif
+    if (!exact_dimensions(*pd)) {
+        std::cerr << id() << "::set_train_data: Error: "
+            "Wrong input/output dimensions.\n";
+        exit(-1);
+    }
+}
+
+void LearnModel::reset () {
+    _n_in = _n_out = 0;
+}
+
+REAL LearnModel::margin_of (const Input&, const Output&) const {
+    OBJ_FUNC_UNDEFINED("margin_of");
+}
+
+REAL LearnModel::min_margin () const {
+    REAL min_m = INFINITY;
+    for (UINT i = 0; i < n_samples; ++i) {
+        // assume all examples count (in computing the minimum)
+        assert((*ptw)[i] > INFINITESIMAL);
+        REAL m = margin(i);
+        if (min_m > m) min_m = m;
+    }
+    return min_m;
+}
+
+bool LearnModel::valid_dimensions (UINT nin, UINT nout) const {
+    return (nin == 0 || _n_in == 0 || nin == _n_in) &&
+        (nout == 0 || _n_out == 0 || nout == _n_out);
+}
+
+void LearnModel::set_dimensions (UINT nin, UINT nout) {
+    assert(valid_dimensions(nin, nout));
+    if (nin > 0) _n_in = nin;
+    if (nout > 0) _n_out = nout;
+}
+
+} // namespace lemga

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/learnmodel.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/learnmodel.cpp
@@ -74,7 +74,7 @@ LearnModel::LearnModel (UINT n_in, UINT n_out)
 bool LearnModel::serialize (std::ostream& os,
                             ver_list& vl) const {
     SERIALIZE_PARENT(Object, os, vl, 1);
-    return (os << _n_in << ' ' << _n_out << '\n');
+    return (bool)(os << _n_in << ' ' << _n_out << '\n');
 }
 
 bool LearnModel::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
@@ -83,7 +83,7 @@ bool LearnModel::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
     _n_in = 0; _n_out = 0;
     ptd = 0; ptw = 0; n_samples = 0;
     if (v == 0) return true;
-    return (is >> _n_in >> _n_out);
+    return (bool)(is >> _n_in >> _n_out);
 }
 
 /** @param out is the output from the learned hypothesis.

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/learnmodel.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/learnmodel.h
@@ -1,0 +1,204 @@
+// -*- C++ -*-
+#ifndef __LEMGA_LEARNMODEL_H__
+#define __LEMGA_LEARNMODEL_H__
+
+/** @file
+ *  @brief Type definitions, @link lemga::DataSet DataSet@endlink, and
+ *  @link lemga::LearnModel LearnModel@endlink class.
+ *  @todo: add input_dim check to dataset and learnmodel
+ *
+ *  $Id: learnmodel.h 2779 2006-05-09 06:49:33Z ling $
+ */
+
+#include <assert.h>
+#include <vector>
+#include "object.h"
+#include "dataset.h"
+#include "shared_ptr.h"
+
+#define VERBOSE_OUTPUT  1
+
+namespace lemga {
+
+typedef std::vector<REAL> Input;
+typedef std::vector<REAL> Output;
+
+typedef dataset<Input,Output> DataSet;
+typedef std::vector<REAL> DataWgt;
+typedef const_shared_ptr<DataSet> pDataSet;
+typedef const_shared_ptr<DataWgt> pDataWgt;
+
+/// Load a data set from a stream
+DataSet* load_data (std::istream&, UINT, UINT, UINT);
+DataSet* load_data (std::istream&, UINT);
+
+/** @brief A unified interface for learning models.
+ *
+ *  I try to provide
+ *  + r_error and c_error
+ *    for regression problems, r_error should be defined;
+ *    for classification problems, c_error should be defined;
+ *    these two errors can both be present
+ *
+ *  The training data is stored with the learning model (as a pointer)
+ *  Say: why (the benefit of store with, a pointer); maybe not a pointer
+ *  Say: what's the impact of doing this (what will be changed
+ *       from normal implementation)
+ *  Say: wgt: could be null if the model doesn't support ...otherwise shoud
+ *       be a probability vector (randome_sample)...
+ *
+ *  @anchor learnmodel_training_order
+ *  The flowchart of the learning ...
+ *  -# Create a new instance, load from a file, and/or reset an existing
+ *     one <code>lm->reset();</code>.
+ *  -# <code>lm->set_train_data(sample_data);</code>\n
+ *         Specify the training data
+ *  -# <code>err = lm->train();</code>\n
+ *         Usually, the return value has no meaning
+ *  -# <code>y = (*lm)(x);</code>\n
+ *         Apply the learning model to new data.
+ *
+ *  @todo documentation
+ *  @todo Do we really need two errors?
+ */
+class LearnModel : public Object {
+protected:
+    UINT _n_in;       ///< input dimension of the model
+    UINT _n_out;      ///< output dimension of the model
+    pDataSet ptd;     ///< pointer to the training data set
+    pDataWgt ptw;     ///< pointer to the sample weight (for training)
+    UINT n_samples;   ///< equal to @c ptd->size()
+
+    FILE* logf;       ///< file to record train/validate error
+
+public:
+    LearnModel (UINT n_in = 0, UINT n_out = 0);
+
+    //@{ @name Basic
+    virtual LearnModel* create () const = 0;
+    virtual LearnModel* clone () const = 0;
+
+    UINT n_input  () const { return _n_in;  }
+    UINT n_output () const { return _n_out; }
+
+    void set_log_file (FILE* f) { logf = f; }
+    //@}
+
+    //@{ @name Training related
+    /** @brief Whether the learning model/algorithm supports unequally
+     *  weighted data.
+     *  @return @c true if supporting; @c false otherwise. The default
+     *  is @c false, just for safety.
+     *  @sa set_train_data()
+     */
+    virtual bool support_weighted_data () const { return false; }
+
+    /// Error measure for regression problems
+    virtual REAL r_error (const Output& out, const Output& y) const;
+    /// Error measure for classification problems
+    virtual REAL c_error (const Output& out, const Output& y) const;
+
+    /// Training error (regression)
+    REAL train_r_error () const;
+    /// Training error (classification)
+    REAL train_c_error () const;
+    /// Test error (regression)
+    REAL test_r_error (const pDataSet&) const;
+    /// Test error (classification)
+    REAL test_c_error (const pDataSet&) const;
+
+    virtual void initialize () {
+        std::cerr << "!!! initialize() is depreciated.\n"
+                  << "!!! See the documentation of LearnModel and reset().\n";
+    }
+
+    /// Set the data set and sample weight to be used in training
+    virtual void set_train_data (const pDataSet&, const pDataWgt& = 0);
+    /// Return pointer to the embedded training data set
+    const pDataSet& train_data () const { return ptd; }
+    /* temporarily disabled; ptw in boosting base learners is reset
+     * after the training; disabled to be sure no one actually uses it
+    const pDataWgt& data_weight () const { return ptw; }
+     */
+
+    /** @brief Train with preset data set and sample weight.
+     */
+    virtual void train () = 0;
+
+    /// Cleaning up the learning model but keeping most settings.
+    /// @note This is probably needed after training or loading from file,
+    /// but before having another training.
+    virtual void reset ();
+    //@}
+
+    virtual Output operator() (const Input&) const = 0;
+
+    /** @brief Get the output of the hypothesis on the @a idx-th input.
+     *  @note It is possible to cache results to save computational effort.
+     */
+    virtual Output get_output (UINT idx) const {
+        assert(ptw != 0); // no data sampling
+        return operator()(ptd->x(idx)); }
+
+    //@{ @name Margin related
+    /** @brief The normalization term for margins.
+     *
+     *  The margin concept can be normalized or unnormalized. For example,
+     *  for a perceptron model, the unnormalized margin would be the wegithed
+     *  sum of the input features, and the normalized margin would be the
+     *  distance to the hyperplane, and the normalization term is the norm
+     *  of the hyperplane weight.
+     *
+     *  Since the normalization term is usually a constant, it would be
+     *  more efficient if it is precomputed instead of being calculated
+     *  every time when a margin is asked for. The best way is to use a
+     *  cache. Here I use a easier way: let the users decide when to
+     *  compute the normalization term.
+     */
+    virtual REAL margin_norm () const { return 1; }
+    /// Report the (unnormalized) margin of an example (@a x, @a y).
+    virtual REAL margin_of (const Input& x, const Output& y) const;
+    /** @brief Report the (unnormalized) margin of the example @a i.
+     *  @note It is possible to cache results to save computational effort.
+     */
+    virtual REAL margin (UINT i) const {
+        assert(ptw != 0); // no data sampling
+        return margin_of(ptd->x(i), ptd->y(i)); }
+    /// The minimal (unnormalized) in-sample margin.
+    REAL min_margin () const;
+    //@}
+
+    bool valid_dimensions (UINT, UINT) const;
+    inline bool valid_dimensions (const LearnModel& l) const {
+        return valid_dimensions(l.n_input(), l.n_output()); }
+
+    inline bool exact_dimensions (UINT i, UINT o) const {
+        return (i > 0 && o > 0 && valid_dimensions(i, o)); }
+    inline bool exact_dimensions (const LearnModel& l) const {
+        return exact_dimensions(l.n_input(), l.n_output()); }
+    inline bool exact_dimensions (const DataSet& d) const {
+        assert(d.size() > 0);
+        return exact_dimensions(d.x(0).size(), d.y(0).size()); }
+
+protected:
+    void set_dimensions (UINT, UINT);
+    inline void set_dimensions (const LearnModel& l) {
+        set_dimensions(l.n_input(), l.n_output()); }
+    inline void set_dimensions (const DataSet& d) {
+        assert(exact_dimensions(d));
+        set_dimensions(d.x(0).size(), d.y(0).size()); }
+
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+};
+
+typedef var_shared_ptr<LearnModel> pLearnModel;
+typedef const_shared_ptr<LearnModel> pcLearnModel;
+
+} // namespace lemga
+
+#ifdef  __LEARNMODEL_H__
+#warning "This header file may conflict with another `learnmodel.h' file."
+#endif
+#define __LEARNMODEL_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/nnlayer.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/nnlayer.cpp
@@ -1,0 +1,115 @@
+/** @file
+ *  $Id: nnlayer.cpp 2550 2006-01-17 04:00:54Z ling $
+ */
+
+#include <assert.h>
+#include <algorithm>
+#include <numeric>
+#include "random.h"
+#include "quickfun.h"
+#include "nnlayer.h"
+
+REGISTER_CREATOR(lemga::NNLayer);
+
+namespace lemga {
+
+NNLayer::NNLayer (UINT n_in, UINT n_unit)
+    : LearnModel(n_in, n_unit), w_min(-1), w_max(1),
+      w(n_unit*(n_in+1)), dw(n_unit*(n_in+1)), sig_der(n_unit)
+{
+    quick_tanh_setup();
+}
+
+bool NNLayer::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(LearnModel, os, vl, 1);
+    if (!(os << w_min << ' ' << w_max << '\n')) return false;
+    WVEC::const_iterator pw = w.begin();
+    for (UINT i = 0; i < _n_out; ++i) {
+        for (UINT j = 0; j <= _n_in; ++j, ++pw)
+            if (!(os << *pw << ' ')) return false;
+        os << '\n';
+    }
+    return true;
+}
+
+bool NNLayer::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(LearnModel, is, vl, 1, v);
+
+    if (v == 0) // Take care of _n_in and _n_out
+        if (!(is >> _n_in >> _n_out)) return false;
+    if (!(is >> w_min >> w_max) || w_min >= w_max) return false;
+
+    const UINT n_weights = _n_out * (_n_in+1);
+    w.resize(n_weights);
+    dw = WVEC(n_weights, 0);
+    sig_der = DVEC(_n_out);
+
+    for (UINT i = 0; i < n_weights; ++i)
+        if (!(is >> w[i])) return false;
+    return true;
+}
+
+void NNLayer::set_weight (const WVEC& wgt) {
+    assert(wgt.size() == _n_out * (_n_in+1));
+    w = wgt;
+}
+
+void NNLayer::clear_gradient () {
+    std::fill(dw.begin(), dw.end(), 0);
+}
+
+void NNLayer::initialize () {
+    for (WVEC::iterator pw = w.begin(); pw != w.end(); ++pw)
+        *pw = w_min + randu() * (w_max-w_min);
+    clear_gradient();
+}
+
+REAL NNLayer::sigmoid (REAL x) const {
+    stored_sigmoid = quick_tanh(x);
+    return stored_sigmoid;
+}
+
+REAL NNLayer::sigmoid_deriv (REAL x) const {
+    assert(stored_sigmoid == quick_tanh(x));
+    return (1 - stored_sigmoid*stored_sigmoid);
+}
+
+void NNLayer::feed_forward (const Input& x, Output& y) const {
+    assert(x.size() == n_input());
+    assert(y.size() == n_output());
+
+    WVEC::const_iterator pw = w.begin();
+    for (UINT i = 0; i < _n_out; ++i) {
+        const REAL th = *pw;
+        const REAL s = std::inner_product(x.begin(), x.end(), ++pw, th);
+        pw += _n_in;
+
+        y[i] = sigmoid(s);
+        sig_der[i] = sigmoid_deriv(s);
+    }
+}
+
+void NNLayer::back_propagate (const Input& x, const DVEC& dy, DVEC& dx) {
+    assert(x.size() == n_input());
+    assert(dy.size() == n_output());
+    assert(dx.size() == n_input());
+
+    std::fill(dx.begin(), dx.end(), 0);
+
+    WVEC::const_iterator pw = w.begin();
+    DVEC::iterator pdw = dw.begin();
+    for (UINT i = 0; i < _n_out; ++i) {
+        const REAL delta = dy[i] * sig_der[i];
+        *pdw += delta; ++pdw; ++pw;
+
+        DVEC::iterator pdx = dx.begin();
+        Input::const_iterator px = x.begin();
+        for (UINT j = _n_in; j; --j) {
+            *pdw++ += delta * (*px++);
+            *pdx++ += delta * (*pw++);
+        }
+    }
+}
+
+} // namespace lemga

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/nnlayer.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/nnlayer.h
@@ -1,0 +1,110 @@
+// -*- C++ -*-
+#ifndef __LEMGA_NNLAYER_H__
+#define __LEMGA_NNLAYER_H__
+
+/** @file
+ *  @brief Neural network layer @link lemga::NNLayer NNLayer@endlink.
+ *
+ *  $Id: nnlayer.h 2664 2006-03-07 19:50:51Z ling $
+ */
+
+#include <vector>
+#include "learnmodel.h"
+
+namespace lemga {
+
+/** @brief A layer in a neural network.
+ *
+ *  This class simulates a layer of neurons.
+ *
+ *  Here's usage information.
+ *
+ *  Here's some details.
+ *
+ *  Say, we have @a n neurons and @a m inputs. The output from
+ *  the neuron is
+ *  @f[ y_i=\theta(s_i),\quad s_i=\sum_{j=0}^m w_{ij}x_j, @f]
+ *  where @f$s_i@f$ is the weighted sum of inputs, @f$x_0\equiv1@f$,
+ *  and @f$w_{i0}@f$ is sort of the threshold. feed_forward() does
+ *  this calculation and saves @f$\theta'(s_i)@f$ for future use.
+ *
+ *  The ``chain rule'' for back-propagation says the derative w.r.t.
+ *  the input @a x can be calculated from that to the output @a y.
+ *  Define @f[
+ *   \delta_i \stackrel\Delta= \frac{\partial E}{\partial s_i}
+ *     = \frac{\partial E}{\partial y_i}\frac{\partial y_i}{\partial s_i}
+ *     = \frac{\partial E}{\partial y_i}\theta'(s_i). @f]
+ *  We have @f[
+ *   \frac{\partial E}{\partial w_{ij}}
+ *     = \frac{\partial E}{\partial s_i}
+ *         \frac{\partial s_i}{\partial w_{ij}}
+ *     = \delta_i x_j,\quad
+ *   \frac{\partial E}{\partial x_j}
+ *     = \sum_{i=1}^n \frac{\partial E}{\partial s_i}
+ *         \frac{\partial s_i}{\partial x_j}
+ *     = \sum_{i=1}^n \delta_i w_{ij}. @f]
+ *  These equations consitute the essense of back_propagate().
+ *
+ *  Modifying sigmoid() (which computes @f$\theta@f$) and
+ *  sigmoid_deriv() (which computes @f$\theta'@f$) is usually enough
+ *  to get a different type of layer.
+ *  @todo documentation
+ */
+class NNLayer : public LearnModel {
+    mutable REAL stored_sigmoid;
+
+public:
+    typedef std::vector<REAL> WVEC; ///< weight vector
+    typedef std::vector<REAL> DVEC; ///< derivative vector
+
+protected:
+    REAL w_min, w_max;
+    WVEC w;   ///< weights and thresholds
+    WVEC dw;  ///< deravatives: @a w -= lr * @a dw
+    mutable DVEC sig_der;  // f'(wsum)
+
+public:
+    explicit NNLayer (UINT n_in = 0, UINT n_unit = 0);
+    explicit NNLayer (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual NNLayer* create () const { return new NNLayer(); }
+    virtual NNLayer* clone () const { return new NNLayer(*this); }
+
+    UINT size () const { return n_output(); }
+
+    void set_weight_range (REAL min, REAL max) {
+        assert(min < max);
+        w_min = min; w_max = max;
+    }
+    const WVEC& weight () const { return w; }
+    void set_weight (const WVEC&);
+
+    const WVEC& gradient () const { return dw; }
+    void clear_gradient ();
+
+    virtual void initialize ();
+    virtual void train () { OBJ_FUNC_UNDEFINED("train"); }
+    virtual Output operator() (const Input& x) const {
+        Output y(n_output());
+        feed_forward(x, y);
+        return y;
+    }
+
+    void feed_forward (const Input&, Output&) const;
+    void back_propagate (const Input&, const DVEC&, DVEC&);
+
+protected:
+    virtual REAL sigmoid (REAL) const;
+    virtual REAL sigmoid_deriv (REAL) const;
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+};
+
+} // namespace lemga
+
+#ifdef  __NNLAYER_H__
+#warning "This header file may conflict with another `nnlayer.h' file."
+#endif
+#define __NNLAYER_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/object.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/object.cpp
@@ -1,0 +1,152 @@
+/** @file
+ *  $Id: object.cpp 2554 2006-01-18 02:55:21Z ling $
+ */
+
+#include <assert.h>
+#include <map>
+#include <sstream>
+#include "object.h"
+
+const Object::id_t Object::NIL_ID;
+
+typedef std::map<Object::id_t, _creator_t> _creator_map_t;
+
+/** @brief Wrapper for the static creator map.
+ *
+ *  The wrapper is to ensure @a cmap is initialized before it is used.
+ *  @see C++ FAQ Lite 10.11, 10.12, and 10.13
+ */
+static _creator_map_t& _creator_map () {
+    static _creator_map_t cmap;
+    return cmap;
+}
+
+/** @return @c true if @id is already registered. */
+inline static bool _creator_registered (const Object::id_t& id) {
+    return _creator_map().find(id) != _creator_map().end();
+}
+
+/** @brief Register @a id with creator @a cf.
+ *  @param id String of class identification.
+ *  @param cf Function pointer to the creator.
+ */
+_register_creator::_register_creator (const Object::id_t& id, _creator_t cf) {
+    assert(!_creator_registered(id));
+    _creator_map()[id] = cf;
+}
+
+/** Serialization ``writes'' the object to an output stream, which
+ *  helps to store, transport, and transform the object. See
+ *  C++ FAQ Lite 35 for a technical overview.
+ *
+ *  @param os Output stream
+ *  @param vl A list of version numbers (from its descendants)
+ *  @sa operator<<(std::ostream&, const Object&)
+ *
+ *  The first part of serialization must be the class name in full
+ *  (with namespaces if any) followed by a list of version numbers
+ *  from itself and its ancestors. A version number gives <EM>the
+ *  version of the serialization format</EM>, but not the version
+ *  of an object.
+ *
+ *  A class that adds some data to its parent's serialization should
+ *  call serialize() of its parent with its own version number appended
+ *  to @a vl. Eventually Object::serialize() is called to output the
+ *  class id and the list of versions.
+ *
+ *  @note A zero version number is reserved for pre-0.1 format.
+ *  @todo serialize() should both return false and set os's state
+ *  when fail
+ */
+bool Object::serialize (std::ostream& os, ver_list& vl) const {
+    assert(vl.size() > 0);
+    ver_list::const_iterator p = vl.begin();
+    os << "# " << id() << " v" << *p;
+    for (++p; p != vl.end(); ++p)
+        os << '.' << *p;
+    os << '\n';
+    return true;
+}
+
+static bool _get_id_ver (std::istream& is, Object::id_t& id,
+                         std::vector<UINT>& vl) {
+    assert(vl.empty());
+    const UINT ignore_size = 512;
+
+    // get the comment char #
+    char c;
+    if (!(is >> c)) return false;
+    if (c != '#') {
+        std::cerr << "_get_id_ver: Warning: # expected\n";
+        is.ignore(ignore_size, '#');
+    }
+
+    // get the rest of the line
+    char line[ignore_size];
+    is.getline(line, ignore_size);
+    std::istringstream iss(line);
+
+    // get the identity (class name)
+    if (!(iss >> id)) {
+        std::cerr << "_get_id_ver: Error: no class id?\n";
+        return false;
+    }
+
+    // get the version
+    vl.push_back(0); // we use 0 for unspecified versions
+    iss.ignore(ignore_size, 'v');
+    UINT v;
+    while (iss >> v) {
+        assert(v > 0);
+        vl.push_back(v);
+        iss.ignore(1);
+    }
+    if (vl.size() == 1) {
+        std::cerr << "_get_id_ver: Warning: pre-0.1 file format\n";
+        if (id == "AdaBoost.M1") id = "AdaBoost";
+        if (id.substr(0, 7) != "lemga::") id.insert(0, "lemga::");
+    }
+
+    return true;
+}
+
+/**
+ *  @todo better exception; documentation
+ *  @sa _register_creator, Object::unserialize, C++ FAQ Lite 35.8
+ */
+Object* Object::create (std::istream& is) {
+    id_t _id;
+    ver_list vl;
+    if (!_get_id_ver(is, _id, vl)) return 0;
+    assert(vl[0] == 0);
+
+    if (_creator_registered(_id)) {
+        Object* p = _creator_map()[_id]();
+        bool loaded = p->unserialize(is, vl, _id);
+        if (loaded && vl.size() == 1)
+            return p;
+        else if (loaded)
+            std::cerr << _id << "::create: newer format encountered\n";
+        delete p;
+    } else
+        std::cerr << "Class (" << _id << ") not regiestered\n";
+
+    return 0;
+}
+
+std::istream& operator>> (std::istream& is, Object& obj) {
+    Object::id_t id;
+    Object::ver_list vl;
+
+    // unserialize() judges whether id and obj are compatible
+    if (!_get_id_ver(is, id, vl) || !obj.unserialize(is, vl, id)) {
+        std::cerr << "operator>>: something wrong...\n";
+        is.setstate(std::ios::badbit);
+    } else if (vl.size() > 1) {
+        std::cerr << "operator>>: newer format encountered\n";
+        is.setstate(std::ios::badbit);
+    }
+    assert(vl[0] == 0);
+
+    return is;
+}

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/object.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/object.h
@@ -1,0 +1,182 @@
+// -*- C++ -*-
+#ifndef __COMMON_TYPES_OBJECT_H__
+#define __COMMON_TYPES_OBJECT_H__
+
+/** @file
+ *  @brief Object class, _register_creator, and other common types.
+ *
+ *  $Id: object.h 2554 2006-01-18 02:55:21Z ling $
+ */
+
+#ifdef size_t
+typedef size_t UINT;
+#else
+typedef unsigned long UINT;
+#endif
+
+typedef double REAL;
+
+#define INFINITESIMAL   (8e-16) ///< almost equal to 0, 1+x/2-1>0
+#define EPSILON         (1e-9)  ///< accumulated numerical error
+#undef  INFINITY
+/// Should avoid using INFINITY since it is a lazy trick.
+#define INFINITY        (5e30)
+
+#ifdef __cplusplus
+
+#include <stdio.h>
+#include <iostream>
+#include <string>
+#include <vector>
+
+/** @brief Stop the program and warn when an undefined function is called.
+ *
+ *  Some member functions may be @em optional for child classes. There
+ *  are two cases for an optional function:
+ *   -# It is declared as an interface; Some child classes may implement
+ *      it but others may not. This macro should be called in the interface
+ *      class. See NNLayer::train for an example.
+ *   -# It is defined and implemented but may be inappropriate for some
+ *      child classes. To prevent misuse of this function, use this macro
+ *      to redefine it in those child classes.
+ *
+ *  This macro will stop the program with a ``function undefined" error.
+ *
+ *  @note This approach differs from defining functions as pure virtual,
+ *  since using the latter way, a child class cannot be instantiated without
+ *  implementing all pure virtual functions, while some of them may not
+ *  be desired.
+ *
+ *  @todo A better macro name; Auto-extraction of function name (could be
+ *  done by __PRETTY_FUNCTION__ but is not compatible between compilers)
+ */
+#define OBJ_FUNC_UNDEFINED(fun)    \
+    std::cerr<<__FILE__":"<<__LINE__<<": "<<id()<<"::" fun " undefined.\n"; \
+    exit(-99);
+
+/** @brief The root (ancestor) of all classes.
+ *
+ *  Object class collects some very common and useful features. It has
+ *  a static string for identification and several funtional interfaces.
+ */
+class Object {
+    friend std::istream& operator>> (std::istream&, Object&);
+    friend std::ostream& operator<< (std::ostream&, const Object&);
+
+public:
+    virtual ~Object ()  {}
+
+    typedef std::string id_t;
+    /** @return Class ID string (class name) */
+    virtual const id_t& id () const = 0;
+
+    /** @brief Create a new object using the default constructor.
+     *
+     *  The code for a derived class Derived is always
+     *  @code return new Derived(); @endcode
+     */
+    virtual Object* create () const = 0;
+
+    /// Create a new object from an input stream.
+    static Object* create (std::istream&);
+
+    /** @brief Create a new object by replicating itself.
+     *  @return A pointer to the new copy.
+     *
+     *  The code for a derived class Derived is always
+     *  @code return new Derived(*this); @endcode
+     *  Though seemingly redundant, it helps to copy an object without
+     *  knowing the real type of the object.
+     *  @sa C++ FAQ Lite 20.6
+     */
+    virtual Object* clone () const = 0;
+
+protected:
+    static const id_t NIL_ID;
+    typedef UINT ver_t;
+    typedef std::vector<ver_t> ver_list;
+    /** @brief Serialize the object to an output stream.
+     *  @sa Macro SERIALIZE_PARENT, unserialize()
+     *
+     *  Each class should either have its own serialize() and a positive
+     *  version number, or ensure that all its descendants don't overload
+     *  serialize() thus have 0 as the version number. This way we can
+     *  safely assume, if we go down in the object hierarchy tree from
+     *  Object to the any class, the versions are positive numbers followed
+     *  by 0's. In other words, the version list is preceded by some 0's.
+     */
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    /** @brief Unserialize from an input stream.
+     *  @sa Macro UNSERIALIZE_PARENT, serialize()
+     *
+     *  The ID and version list are used for sanity check. For any parent
+     *  classes, the ID will be set to @a NIL_ID. Thus any classes that
+     *  is definitely some parent should assert ID == @a NIL_ID.
+     *
+     *  A class which previously did not have its own serialize() or
+     *  unserialize(), usually because it had nothing to store, can have
+     *  its own serialize() and unserialize() later on, as long as it takes
+     *  care of the 0 version number case in unserialize().
+     */
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID)
+    { return true; }
+};
+
+inline std::ostream& operator<< (std::ostream& os, const Object& obj) {
+    Object::ver_list vl_empty;
+    obj.serialize(os, vl_empty);
+    return os;
+}
+
+typedef Object* (*_creator_t) ();
+
+/** Unserialization from an input stream will create an object of a now
+ *  unknown class. To facilitate this process, each instantiable derived
+ *  class (that is, a class with all pure virtual functions implemented)
+ *  must have a creator and add it to this map. The way is to declare a
+ *  static _register_creator object in the .cpp file.
+ *  @code static const _register_creator _("Derived", _creator); @endcode
+ *  @sa C++ FAQ Lite 35.8
+ */
+struct _register_creator {
+    _register_creator(const Object::id_t&, _creator_t);
+};
+
+/// Use a prefix @a p to allow several classes in a same .cpp file
+#define REGISTER_CREATOR2(cls,p)                             \
+    static const Object::id_t p##_id_ = #cls;                \
+    static Object* p##_c_ () { return new cls; }             \
+    const Object::id_t& cls::id () const { return p##_id_; } \
+    static const _register_creator p##_(p##_id_, p##_c_)
+#define REGISTER_CREATOR(cls) REGISTER_CREATOR2(cls,)
+
+/** @brief Serialize parents (ancestors) part.
+ *  @param pcls Parent class.
+ *  @param os Output stream.
+ *  @param def_ver Current (default) version.
+ */
+#define SERIALIZE_PARENT(pcls,os,vl,def_ver) \
+    vl.push_back(def_ver); pcls::serialize(os, vl)
+
+/** @brief Unserialize parents and set current format number @a ver.
+ *  @param pcls Parent class (input).
+ *  @param is Input stream (input).
+ *  @param ver Version number for this class (output).
+ */
+#define UNSERIALIZE_PARENT(pcls,is,vl,def_ver,ver) \
+    if (!pcls::unserialize(is, vl)) return false; \
+    const ver_t ver = vl.back(); \
+    if (ver > def_ver) { \
+        std::cerr << this->id() \
+                  << ": unserialize: format newer than the program\n"; \
+        return false; \
+    } \
+    if (ver > 0) vl.pop_back()
+
+#endif // __cplusplus
+
+#ifdef  __OBJECT_H__
+#warning "This header file may conflict with another `object.h' file."
+#endif
+#define __OBJECT_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/optimize.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/optimize.h
@@ -1,0 +1,380 @@
+// -*- C++ -*-
+#ifndef __LEMGA_OPTIMIZE_H__
+#define __LEMGA_OPTIMIZE_H__
+
+/** @file
+ *  @brief Some generic optimization algorithms.
+ *
+ *  $Id: optimize.h 1917 2005-01-07 01:25:30Z ling $
+ */
+
+#include <assert.h>
+#include <iostream>
+#include <utility>
+#include "vectorop.h"
+
+namespace lemga {
+
+using namespace op;
+
+/** @brief Interface used in iterative optimization algorithms.
+ *
+ *  This template is used in joint with the generic optimization
+ *  algorithm iterative_optimize(). It describes functions that a
+ *  class have to provide in order to use iterative_optimize().
+ *
+ *  Some arithmetic operations on gradient are needed for optimization.
+ *  The full set required consists of
+ *   - @a u += @a v
+ *   - -@a v
+ *   - @a v *= @a r
+ *   - inner_product<@a typename> (@a u, @a v)
+ *  where @a u and @a v are weights/gradients and @a r the step length.
+ *
+ *  Using such interface improves the flexibility of code. However,
+ *  there are always concerns about the performance. Here are
+ *  several considerations for the sake of performance:
+ *
+ *  - The weight(s) is the variable to be ``searched'' in order to
+ *    optimize the cost. It is assumed to be stored somewhere (say,
+ *    in a derived class) and is not passed as a parameter to these
+ *    functions.
+ *  - direction() returns a const reference to a class member.
+ *  - The inheritance of different methods doesn't mean the parent
+ *    class could be changed without taking care of the classes
+ *    derived from it. This is just used as a way to share functions.
+ *  - step_lenth() return non-positive step length if the direction
+ *    is improper. (It could have returned a pair<bool,REAL>.)
+ *
+ *  @todo Does making these functions pure virtual sacrifice
+ *  the performance?
+ */
+template <class Dir, class Step>
+struct _search {
+    typedef Dir direction_type;
+    typedef Step step_length_type;
+
+    /// Initialize local variables.
+    void initialize () {}
+    /// Search direction at @a w.
+    const Dir& direction () { return dir; }
+    /// Should we go in direction @a d? How far?.
+    std::pair<bool,Step> step_length (const Dir& d) {
+        return std::make_pair(false, 0); }
+    /// Update the weight.
+    void update_weight (const Dir& d, const Step& s) {}
+    /// Stopping criteria.
+    bool satisfied () { return true; }
+protected:
+    Dir dir;
+};
+
+/// Main search routine.
+template <class SEARCH>
+void iterative_optimize (SEARCH s) {
+    s.initialize();
+    while (!s.satisfied()) {
+        const typename SEARCH::direction_type&
+            pd = s.direction();
+        const std::pair<bool, typename SEARCH::step_length_type>
+            stp = s.step_length(pd);
+
+        if (!stp.first) break;
+        s.update_weight(pd, stp.second);
+    }
+}
+
+/** @brief Gradient descent.
+ *  @todo Add options for on-line or batch mode; documentation
+ *  Why use get_weight() and set_weight(), not update_weight()?
+ *  (how much is the performance decrease)
+ */
+template <class LM, class Dir, class Step>
+struct _gradient_descent : public _search<Dir,Step> {
+    LM* plm;
+    Step learning_rate;
+
+    _gradient_descent (LM* lm, const Step& lr)
+        : _search<Dir,Step>(), plm(lm), learning_rate(lr) {}
+
+    void initialize () { stp_cnt = 0; w = plm->weight(); }
+
+    const Dir& direction () {
+        using namespace op;
+        return (this->dir = -plm->gradient());
+    }
+
+    std::pair<bool,Step> step_length (const Dir&) {
+        return std::make_pair(true, learning_rate);
+    }
+
+    void update_weight (Dir d, const Step& s) {
+        using namespace op;
+        w += (d *= s);
+        ++stp_cnt; plm->set_weight(w);
+    }
+
+    bool satisfied () { return plm->stop_opt(stp_cnt, plm->cost()); }
+
+protected:
+    Dir w;
+    unsigned int stp_cnt;
+};
+
+/** @brief Gradient descent with weight decay.
+ *
+ *  The cost function includes a regularization term which prefers
+ *  smaller weight values. That is, the cost to be minimized is
+ *  @f[ \hat{E} = E + \frac{\lambda}2 \Vert w\Vert^2. @f]
+ *  The updating rule thus becomes @f[
+ *    w \leftarrow w - \eta \frac{\partial\hat{E}}{\partial w}
+ *     = (1-\eta\lambda)w - \eta\frac{\partial E}{\partial w}.
+ *  @f]
+ *  @f$\lambda@f$ usually ranges from 0.01 to 0.1.
+ *
+ *  @todo Well, I guess weight decay is more a term in the cost
+ *  than an optimization technique. Though it is easy to add it
+ *  here (as an optimization technique).
+ */
+template <class LM, class Dir, class Step>
+struct _gd_weightdecay : public _gradient_descent<LM,Dir,Step> {
+    Step decay;
+
+    _gd_weightdecay (LM* lm, const Step& lr, const Step& dcy)
+        : _gradient_descent<LM,Dir,Step>(lm,lr), decay(dcy) {}
+
+    void update_weight (Dir d, const Step& s) {
+        using namespace op;
+        assert(s*decay < 1);
+        this->w *= (1 - s*decay);
+        this->w += (d *= s);
+        ++this->stp_cnt; this->plm->set_weight(this->w);
+    }
+};
+
+/** @brief Gradient descent with momentum.
+ *
+ *  With momentum, the weight change is accumulated: @f[
+ *    \Delta w\leftarrow-\eta\frac{\partial E}{\partial w}+\mu\Delta w.
+ *  @f]
+ *  When the derivative is roughly constant, this speeds up the
+ *  training by using an effectively larger learning rate @f[
+ *    \Delta w \approx -\frac{\eta}{1-\mu}\frac{\partial E}{\partial w}.
+ *  @f]
+ *  When the derivative somehow ``fluctuates'', the momentum stablizes
+ *  the optimization to some exent by effectively decreasing the
+ *  learning rate.
+ */
+template <class LM, class Dir, class Step>
+struct _gd_momentum : public _gradient_descent<LM,Dir,Step> {
+    Step momentum;
+
+    _gd_momentum (LM* lm, const Step& lr, const Step& m)
+        : _gradient_descent<LM,Dir,Step>(lm,lr), momentum(m) {}
+
+    const Dir& direction () {
+        assert(momentum >= 0 && momentum < 1);
+        using namespace op;
+        if (this->stp_cnt > 0) {
+            this->dir *= momentum;
+            this->dir += -this->plm->gradient();
+        }
+        else this->dir = -this->plm->gradient();
+        return this->dir;
+    }
+};
+
+template <class LM, class Dir, class Step, class Cost>
+struct _gd_adaptive : public _gradient_descent<LM,Dir,Step> {
+    using _gradient_descent<LM,Dir,Step>::plm;
+    using _gradient_descent<LM,Dir,Step>::learning_rate;
+    using _gradient_descent<LM,Dir,Step>::w;
+    using _gradient_descent<LM,Dir,Step>::stp_cnt;
+    Step alpha, beta;
+
+    _gd_adaptive (LM* lm, const Step& lr, const Step& a, const Step& b)
+        : _gradient_descent<LM,Dir,Step>(lm,lr), alpha(a), beta(b) {}
+
+    void initialize () {
+        _gradient_descent<LM,Dir,Step>::initialize();
+        old_cost = plm->cost();
+    }
+
+    std::pair<bool,Step> step_length (Dir d) {
+        assert(alpha >= 1 && beta < 1);
+        using namespace op;
+
+        Step lr = learning_rate;
+
+        d *= learning_rate;
+        Dir wd = w;
+        plm->set_weight(wd += d);
+        Cost c = plm->cost();
+        if (c < old_cost)
+            learning_rate *= alpha;
+        else {
+            do {
+                learning_rate *= beta;
+                d *= beta; wd = w;
+                plm->set_weight(wd += d);
+                c = plm->cost();
+            } while (!(c < old_cost) && learning_rate > 1e-6);
+            lr = learning_rate;
+        }
+
+        const bool cont = (c < old_cost);
+        if (cont) old_cost = c;
+        else plm->set_weight(w);
+        return std::make_pair(cont, lr);
+    }
+
+    void update_weight (Dir d, const Step& s) {
+        ++stp_cnt;
+        using namespace op;
+        w += (d *= s);
+        // DO NOT set_weight; done in step_length()
+    }
+
+    bool satisfied  () { return plm->stop_opt(stp_cnt, old_cost); }
+
+protected:
+    Cost old_cost;
+};
+
+namespace details {
+
+template <class LM, class Dir, class Step, class Cost>
+Step line_search (LM& lm, const Dir& w, Cost& cst3,
+                  const Dir& dir, Step step) {
+    using namespace op;
+    assert(w == lm.weight());
+    cst3 = lm.cost();
+    Step stp3 = 0;
+
+    Dir d = dir, wd = w; d *= step;
+    lm.set_weight(wd += d); Cost cst5 = lm.cost();
+    while (cst5 > cst3 && step > 2e-7) {
+        //std::cout << '-';
+        step *= 0.5; d *= 0.5; wd = w;
+        lm.set_weight(wd += d); cst5 = lm.cost();
+    }
+
+    if (cst5 > cst3) {
+        std::cerr << "\tWarning: not a descending direction\n";
+        lm.set_weight(w);   // undo
+        return 0;
+    }
+
+    Step stp1, stp5 = step;
+    do {
+        //std::cout << '*';
+        step += step;
+        stp1 = stp3;
+        stp3 = stp5; cst3 = cst5;
+        stp5 += step;
+        d = dir; d *= stp5; wd = w;
+        lm.set_weight(wd += d); cst5 = lm.cost();
+    } while (cst5 < cst3);
+
+    while (stp3 > stp1*1.01 || stp5 > stp3*1.01) {
+        //std::cout << '.';
+        Step stp2 = (stp1 + stp3) / 2;
+        Step stp4 = (stp3 + stp5) / 2;
+        d = dir; d *= stp2; wd = w;
+        lm.set_weight(wd += d); Cost cst2 = lm.cost();
+        d = dir; d *= stp4; wd = w;
+        lm.set_weight(wd += d); Cost cst4 = lm.cost();
+
+        if (cst4 < cst2 && cst4 < cst3) {
+            stp1 = stp3;
+            stp3 = stp4; cst3 = cst4;
+        }
+        else if (cst2 < cst3) {
+            stp5 = stp3;
+            stp3 = stp2; cst3 = cst2;
+        }
+        else {
+            stp1 = stp2;
+            stp5 = stp4;
+        }
+    }
+    //std::cout << "\tcost = " << cst3 << ", step = " << stp3 << '\n';
+    return stp3;
+}
+
+} // namespace lemga::details
+
+template <class LM, class Dir, class Step, class Cost>
+struct _line_search : public _gradient_descent<LM,Dir,Step> {
+    using _gradient_descent<LM,Dir,Step>::plm;
+    using _gradient_descent<LM,Dir,Step>::learning_rate;
+    using _gradient_descent<LM,Dir,Step>::w;
+    using _gradient_descent<LM,Dir,Step>::stp_cnt;
+
+    _line_search (LM* lm, const Step& lr)
+        : _gradient_descent<LM,Dir,Step>(lm,lr) {}
+
+    void initialize () {
+        _gradient_descent<LM,Dir,Step>::initialize();
+        cost_w = plm->cost();
+    }
+
+    std::pair<bool,Step> step_length (const Dir& d) {
+        const Step stp =
+            details::line_search(*plm, w, cost_w, d, learning_rate);
+        return std::make_pair((stp>0), stp);
+    }
+
+    bool satisfied () { return plm->stop_opt(stp_cnt, cost_w); }
+
+protected:
+    Cost cost_w;
+};
+
+template <class LM, class Dir, class Step, class Cost>
+struct _conjugate_gradient : public _line_search<LM,Dir,Step,Cost> {
+    using _gradient_descent<LM,Dir,Step>::plm;
+    using _gradient_descent<LM,Dir,Step>::w;
+    using _gradient_descent<LM,Dir,Step>::stp_cnt;
+    using _search<Dir,Step>::dir;
+
+    _conjugate_gradient (LM* lm, const Step& lr)
+        : _line_search<LM,Dir,Step,Cost>(lm,lr) {}
+
+    const Dir& direction () {
+        // get g
+        const Dir g = plm->gradient();
+        const Step g_norm = op::inner_product<Step>(g, g);
+
+        using namespace op;
+        // get d
+        if (stp_cnt == 0)
+            dir = -g;
+        else {
+            const Step g_dot_old = op::inner_product<Step>(g, g_old);
+            assert(g_norm_old > 0);
+            Step beta = (g_norm - g_dot_old) / g_norm_old;
+            if (beta < 0) beta = 0;
+
+            dir *= beta;
+            dir += -g;
+        }
+
+        g_old = g;
+        g_norm_old = g_norm;
+
+        return dir;
+    }
+
+private:
+    Dir g_old;
+    Step g_norm_old;
+};
+
+} // namespace lemga
+
+#ifdef  __OPTIMIZE_H__
+#warning "This header file may conflict with another `optimize.h' file."
+#endif
+#define __OPTIMIZE_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/perceptron.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/perceptron.cpp
@@ -1,0 +1,644 @@
+/** @file
+ *  $Id: perceptron.cpp 2891 2006-11-08 03:17:31Z ling $
+ */
+
+// "Fixed bias" means we still use the bias term, but do not change it.
+// This is to simulate a perceptron without the bias term. An alternative
+// is to modify the dset_distract (for RCD) and those update rules (for
+// other algorithms) to not add "1" to input vectors. Although this approach
+// is simpler (to implement), it causes extra troubles with saving/loading
+// or importing from SVM.
+
+#define STUMP_DOUBLE_DIRECTIONS    0
+
+#include <assert.h>
+#include <cmath>
+#include <numeric>
+#include "random.h"
+#include "utility.h"
+#include "stump.h"
+#include "perceptron.h"
+
+REGISTER_CREATOR(lemga::Perceptron);
+
+typedef std::vector<REAL> RVEC;
+typedef std::vector<RVEC> RMAT;
+
+#define DOTPROD(x,y) std::inner_product(x.begin(), x.end(), y.begin(), .0)
+// The version without bias
+#define DOTPROD_NB(x,y) std::inner_product(x.begin(),x.end()-1,y.begin(),.0)
+
+inline RVEC randvec (UINT n) {
+    RVEC x(n);
+    for (UINT i = 0; i < n; ++i)
+        x[i] = 2*randu() - 1;
+    return x;
+}
+
+inline RVEC coorvec (UINT n, UINT c) {
+    RVEC x(n, 0);
+    x[c] = 1;
+    return x;
+}
+
+inline void normalize (RVEC& v, REAL thr = 0) {
+    REAL s = DOTPROD(v, v);
+    assert(s > 0);
+    if (s <= thr) return;
+    s = 1 / std::sqrt(s);
+    for (RVEC::iterator p = v.begin(); p != v.end(); ++p)
+        *p *= s;
+}
+
+RMAT randrot (UINT n, bool bias_row = false, bool conjugate = true) {
+    RMAT m(n);
+    if (bias_row)
+        m.back() = coorvec(n, n-1);
+
+    for (UINT i = 0; i+bias_row < n; ++i) {
+        m[i] = randvec(n);
+        if (bias_row) m[i][n-1] = 0;
+        if (!conjugate) continue;
+
+        // make m[i] independent
+        for (UINT k = 0; k < i; ++k) {
+            REAL t = DOTPROD(m[i], m[k]);
+            for (UINT j = 0; j < n; ++j)
+                m[i][j] -= t * m[k][j];
+        }
+        // normalize m[i]
+        normalize(m[i]);
+    }
+    return m;
+}
+
+namespace lemga {
+
+/// Update the weight @a wgt along the direction @a dir.
+/// If necessary, the whole @a wgt will be negated.
+void update_wgt (RVEC& wgt, const RVEC& dir, const RMAT& X, const RVEC& y) {
+    const UINT dim = wgt.size();
+    assert(dim == dir.size());
+    const UINT n_samples = X.size();
+    assert(n_samples == y.size());
+
+    RVEC xn(n_samples), yn(n_samples);
+#if STUMP_DOUBLE_DIRECTIONS
+    REAL bias = 0;
+#endif
+    for (UINT i = 0; i < n_samples; ++i) {
+        assert(X[i].size() == dim);
+        const REAL x_d = DOTPROD(X[i], dir);
+        REAL x_new = 0, y_new = 0;
+        if (x_d != 0) {
+            y_new = (x_d > 0)? y[i] : -y[i];
+            REAL x_w = DOTPROD(X[i], wgt);
+            x_new = x_w / x_d;
+        }
+#if STUMP_DOUBLE_DIRECTIONS
+        else
+            bias += (DOTPROD(X[i], wgt) > 0)? y[i] : -y[i];
+#endif
+        xn[i] = x_new; yn[i] = y_new;
+    }
+
+#if STUMP_DOUBLE_DIRECTIONS
+    REAL th1, th2;
+    bool ir, pos;
+    Stump::train_1d(xn, yn, bias, ir, pos, th1, th2);
+    const REAL w_d_new = -(th1 + th2) / 2;
+#else
+    const REAL w_d_new = - Stump::train_1d(xn, yn);
+#endif
+
+    for (UINT j = 0; j < dim; ++j)
+        wgt[j] += w_d_new * dir[j];
+
+#if STUMP_DOUBLE_DIRECTIONS
+    if (!pos)
+        for (UINT j = 0; j < dim; ++j)
+            wgt[j] = -wgt[j];
+#endif
+
+    // use a big threshold to reduce the # of normalization
+    normalize(wgt, 1e10);
+}
+
+void dset_extract (const pDataSet& ptd, RMAT& X, RVEC& y) {
+    UINT n = ptd->size();
+    X.resize(n); y.resize(n);
+    for (UINT i = 0; i < n; ++i) {
+        X[i] = ptd->x(i);
+        X[i].push_back(1);
+        y[i] = ptd->y(i)[0];
+    }
+}
+
+inline void dset_mult_wgt (const pDataWgt& ptw, RVEC& y) {
+    UINT n = y.size();
+    assert(ptw->size() == n);
+    for (UINT i = 0; i < n; ++i)
+        y[i] *= (*ptw)[i];
+}
+
+Perceptron::Perceptron (UINT n_in)
+    : LearnModel(n_in, 1), wgt(n_in+1,0), resample(0),
+      train_method(RCD_BIAS), learn_rate(0.002), min_cst(0),
+      max_run(1000), with_fld(false), fixed_bias(false)
+{
+}
+
+Perceptron::Perceptron (const SVM& s)
+    : LearnModel(s), wgt(_n_in+1,0), resample(0),
+      train_method(RCD_BIAS), learn_rate(0.002), min_cst(0),
+      max_run(1000), with_fld(false), fixed_bias(false)
+{
+    assert(s.kernel().id() == kernel::Linear().id());
+
+    const UINT nsv = s.n_support_vectors();
+    for (UINT i = 0; i < nsv; ++i) {
+        const Input sv = s.support_vector(i);
+        const REAL coef = s.support_vector_coef(i);
+        assert(sv.size() == _n_in);
+        for (UINT k = 0; k < _n_in; ++k)
+            wgt[k] += coef * sv[k];
+    }
+    wgt.back() = s.bias();
+}
+
+bool Perceptron::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(LearnModel, os, vl, 1);
+    for (UINT i = 0; i <= _n_in; ++i)
+        if (!(os << wgt[i] << ' ')) return false;
+    return (os << '\n');
+}
+
+bool Perceptron::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(LearnModel, is, vl, 1, v);
+
+    wgt.resize(_n_in+1);
+    for (UINT i = 0; i <= _n_in; ++i)
+        if (!(is >> wgt[i])) return false;
+    return true;
+}
+
+void Perceptron::set_weight (const WEIGHT& w) {
+    assert(w.size() > 1);
+    set_dimensions(w.size()-1, 1);
+    wgt = w;
+}
+
+void Perceptron::initialize () {
+    if (ptd != 0) set_dimensions(*ptd);
+    assert(_n_in > 0);
+    wgt.resize(_n_in + 1);
+    for (UINT i = 0; i < _n_in + (fixed_bias? 0:1); ++i)
+        wgt[i] = randu() * 0.1 - 0.05; // small random numbers
+}
+
+Perceptron::WEIGHT Perceptron::fld () const {
+    assert(ptd != 0 && ptw != 0);
+
+    // get the mean
+    Input m1(_n_in, 0), m2(_n_in, 0);
+    REAL w1 = 0, w2 = 0;
+    for (UINT i = 0; i < n_samples; ++i) {
+        const Input& x = ptd->x(i);
+        REAL y = ptd->y(i)[0];
+        REAL w = (*ptw)[i];
+
+        if (y > 0) {
+            w1 += w;
+            for (UINT k = 0; k < _n_in; ++k)
+                m1[k] += w * x[k];
+        } else {
+            w2 += w;
+            for (UINT k = 0; k < _n_in; ++k)
+                m2[k] += w * x[k];
+        }
+    }
+    assert(w1 > 0 && w2 > 0 && std::fabs(w1+w2-1) < EPSILON);
+    for (UINT k = 0; k < _n_in; ++k) {
+        m1[k] /= w1; m2[k] /= w2;
+    }
+
+    // get the covariance
+    RMAT A(_n_in, RVEC(_n_in, 0));
+    RVEC diff(_n_in);
+    for (UINT i = 0; i < n_samples; ++i) {
+        const Input& x = ptd->x(i);
+        REAL y = ptd->y(i)[0];
+        REAL w = (*ptw)[i];
+
+        if (y > 0)
+            for (UINT k = 0; k < _n_in; ++k)
+                diff[k] = x[k] - m1[k];
+        else
+            for (UINT k = 0; k < _n_in; ++k)
+                diff[k] = x[k] - m2[k];
+        // we only need the upper triangular part
+        for (UINT j = 0; j < _n_in; ++j)
+            for (UINT k = j; k < _n_in; ++k)
+                A[j][k] += w * diff[j] * diff[k];
+    }
+
+    for (UINT k = 0; k < _n_in; ++k)
+        diff[k] = m1[k] - m2[k];
+
+    RVEC w;
+    bool not_reg = true;
+    while (!ldivide(A, diff, w)) {
+        assert(not_reg); not_reg = false; // should only happen once
+        REAL tr = 0;
+        for (UINT j = 0; j < _n_in; ++j)
+            tr += A[j][j];
+        const REAL gamma = 1e-10; // see [Friedman 1989]
+        const REAL adj = gamma/(1-gamma) * tr/_n_in;
+        for (UINT j = 0; j < _n_in; ++j)
+            A[j][j] += adj;
+#if VERBOSE_OUTPUT
+        std::cerr << "LDA: The class covariance matrix estimate is "
+            "regularized by\n\tan eigenvalue shinkage parameter "
+                  << gamma << '\n';
+#endif
+    }
+
+    w.push_back(- (DOTPROD(m1,w) * w2 + DOTPROD(m2,w) * w1));
+    return w;
+}
+
+inline UINT randcdf (REAL r, const RVEC& cdf) {
+    UINT b = 0, e = cdf.size()-1;
+    while (b+1 < e) {
+        UINT m = (b + e) / 2;
+        if (r < cdf[m]) e = m;
+        else b = m;
+    }
+    return b;
+}
+
+void Perceptron::train () {
+    assert(ptd != 0 && ptw != 0 && ptd->size() == n_samples);
+    set_dimensions(*ptd);
+    const UINT dim = _n_in+1;
+    // but what is updated might be of a smaller size
+    const UINT udim = _n_in + (fixed_bias? 0:1);
+
+    RVEC cdf;
+    if (resample) {
+        cdf.resize(n_samples+1);
+        cdf[0] = 0;
+        for (UINT i = 0; i < n_samples; ++i)
+            cdf[i+1] = cdf[i] + (*ptw)[i];
+        assert(cdf[n_samples]-1 > -EPSILON && cdf[n_samples]-1 < EPSILON);
+    }
+
+    wgt.resize(dim);
+    const REAL bias_save = wgt.back();
+    if (with_fld) wgt = fld();
+    if (fixed_bias)
+        wgt.back() = bias_save;
+
+    RMAT X; RVEC Y;
+    dset_extract(ptd, X, Y);
+
+#define RAND_IDX() (resample? randcdf(randu(),cdf) : UINT(randu()*n_samples))
+#define SAMPWGT(i) (resample? 1 : (*ptw)[i]*n_samples)
+#define GET_XYO(i)         \
+    const Input& x = X[i]; \
+    const REAL y = Y[i];   \
+    const REAL o = DOTPROD(wgt,x)
+
+    log_error(0);
+    switch (train_method) {
+    case PERCEPTRON:
+    case ADALINE:
+        for (UINT i = 0; i < max_run; ++i) {
+            for (UINT j = 0; j < n_samples; ++j) {
+                const UINT idx = RAND_IDX();
+                GET_XYO(idx);
+                if (y * o > 0) continue;
+                REAL deriv = (train_method == PERCEPTRON? y : (y - o));
+                REAL adj = learn_rate * SAMPWGT(idx) * deriv;
+
+                for (UINT k = 0; k < udim; ++k)
+                    wgt[k] += adj * x[k];
+            }
+            log_error(i+1);
+        }
+        break;
+
+    case POCKET_RATCHET:
+    case POCKET: {
+        bool ratchet = (train_method == POCKET_RATCHET);
+        RVEC best_w(wgt);
+        REAL run = 0, err = train_c_error();
+        bool err_valid = true;
+        REAL best_run = run, best_err = err;
+        for (UINT i = 0; i < max_run; ++i) {
+            for (UINT j = 0; j < n_samples; ++j) {
+                const UINT idx = RAND_IDX();
+                GET_XYO(idx);
+
+                if (y * o > 0) {
+                    run += SAMPWGT(idx);
+                    if (run > best_run) {
+                        if (!err_valid) err = train_c_error();
+                        err_valid = true;
+                        if (!ratchet || err < best_err) {
+                            best_run = run;
+                            best_err = err;
+                            best_w = wgt;
+                        }
+                        if (err <= 0) break;
+                    }
+                } else {
+                    run = 0;
+                    err_valid = false;
+
+                    const REAL adj = SAMPWGT(idx) * y;
+                    for (UINT k = 0; k < udim; ++k)
+                        wgt[k] += adj * x[k];
+                }
+            }
+            wgt.swap(best_w); log_error(i+1, best_err); wgt.swap(best_w);
+        }
+        wgt.swap(best_w);
+    }
+        break;
+
+    case AVE_PERCEPTRON_RAND:
+    case AVE_PERCEPTRON: {
+        assert(train_method != AVE_PERCEPTRON || !resample);
+        RVEC ave_wgt(dim, 0);
+        REAL run = 0;
+        for (UINT i = 0; i < max_run; ++i) {
+            for (UINT j = 0; j < n_samples; ++j) {
+                const UINT idx = (train_method == AVE_PERCEPTRON)?
+                    j : RAND_IDX();
+                GET_XYO(idx);
+                if (y * o > 0)
+                    run += SAMPWGT(idx);
+                else {
+                    for (UINT k = 0; k < dim; ++k)
+                        ave_wgt[k] += run * wgt[k];
+
+                    const REAL adj = SAMPWGT(idx) * y;
+                    for (UINT k = 0; k < udim; ++k)
+                        wgt[k] += adj * x[k];
+                    run = SAMPWGT(idx);
+                }
+            }
+            RVEC tmp_wgt(ave_wgt);
+            for (UINT k = 0; k < dim; ++k)
+                tmp_wgt[k] += run * wgt[k];
+            wgt.swap(tmp_wgt); log_error(i+1); wgt.swap(tmp_wgt);
+        }
+        for (UINT k = 0; k < dim; ++k)
+            wgt[k] = ave_wgt[k] + run * wgt[k];
+    }
+        break;
+
+    case ROMMA_AGG_RAND:
+    case ROMMA_AGG:
+    case ROMMA_RAND:
+    case ROMMA: {
+        bool fixed = (train_method == ROMMA || train_method == ROMMA_AGG);
+        assert(!fixed || !resample);
+        REAL bnd = (train_method == ROMMA || train_method == ROMMA_RAND)?
+            0 : (1-EPSILON);
+        for (UINT i = 0; i < max_run; ++i) {
+            for (UINT j = 0; j < n_samples; ++j) {
+                const UINT idx = fixed? j : RAND_IDX();
+                GET_XYO(idx); const REAL& w_x = o;
+                if (y * w_x > bnd) continue;
+
+                REAL w_w = DOTPROD(wgt, wgt);
+                REAL x_x = 1 + DOTPROD(x, x);
+                REAL x2w2 = x_x * w_w;
+                REAL deno = x2w2 - w_x*w_x;
+                REAL c = (x2w2 - y*w_x) / deno;
+                REAL d = w_w * (y - w_x) / deno;
+
+                wgt[0] = c*wgt[0] + d;
+                for (UINT k = 0; k < _n_in; ++k)
+                    wgt[k+1] = c*wgt[k+1] + d*x[k];
+            }
+            log_error(i+1);
+        }
+    }
+        break;
+
+    case SGD_HINGE:
+    case SGD_MLSE: {
+        const REAL C = 0; // C is lambda
+
+        for (UINT i = 0; i < max_run; ++i) {
+            for (UINT j = 0; j < n_samples; ++j) {
+                const UINT idx = RAND_IDX();
+                GET_XYO(idx);
+
+                if (y*o < 1) {
+                    REAL shrink = 1 - C * learn_rate;
+                    REAL deriv = (train_method == SGD_HINGE? y : (y - o));
+                    REAL adj = learn_rate * SAMPWGT(idx) * deriv;
+                    for (UINT k = 0; k < udim; ++k)
+                        wgt[k] = shrink * wgt[k] + adj * x[k];
+                }
+            }
+            log_error(i+1);
+        }
+    }
+        break;
+
+#undef RAND_IDX
+#undef SAMPWGT
+#define CYCLE(r)  (((r)+dim-1) % udim)
+#define UPDATE_WGT(d) update_wgt(wgt, d, X, Y)
+#define INIT_RCD() {                      \
+    dset_mult_wgt(ptw, Y);                \
+}
+
+    case COORDINATE_DESCENT: {
+        INIT_RCD();
+        for (UINT r = 0; r < max_run; ++r) {
+            UPDATE_WGT(coorvec(dim, CYCLE(r)));
+            log_error(r+1);
+        }
+    }
+        break;
+
+    case FIXED_RCD:
+    case FIXED_RCD_CONJ:
+    case FIXED_RCD_BIAS:
+    case FIXED_RCD_CONJ_BIAS: {
+        bool bias_row = (train_method == FIXED_RCD_BIAS ||
+                         train_method == FIXED_RCD_CONJ_BIAS);
+        bool conjugate = (train_method == FIXED_RCD_CONJ ||
+                          train_method == FIXED_RCD_CONJ_BIAS);
+        RMAT A = randrot(dim, bias_row || fixed_bias, conjugate);
+
+        INIT_RCD();
+        for (UINT r = 0; r < max_run; ++r) {
+            UPDATE_WGT(A[CYCLE(r)]);
+            log_error(r+1);
+        }
+    }
+        break;
+
+    case RCD:
+    case RCD_CONJ:
+    case RCD_BIAS:
+    case RCD_CONJ_BIAS: {
+        bool bias_row = (train_method == RCD_BIAS ||
+                         train_method == RCD_CONJ_BIAS);
+        bool conjugate = (train_method == RCD_CONJ ||
+                          train_method == RCD_CONJ_BIAS);
+        RMAT A;
+
+        INIT_RCD();
+        for (UINT r = 0; r < max_run; ++r) {
+            const UINT c = CYCLE(r);
+            if (c == CYCLE(0))
+                A = randrot(dim, bias_row || fixed_bias, conjugate);
+            UPDATE_WGT(A[c]);
+            log_error(r+1);
+        }
+    }
+        break;
+
+    case RCD_GRAD_BATCH_RAND:
+    case RCD_GRAD_BATCH:
+    case RCD_GRAD_RAND:
+    case RCD_GRAD: {
+        bool online = (train_method == RCD_GRAD ||
+                       train_method == RCD_GRAD_RAND);
+        bool wrand = (train_method == RCD_GRAD_RAND ||
+                      train_method == RCD_GRAD_BATCH_RAND);
+        // gradient of sum weight*y*<w,x> over all unsatisfied examples
+        INIT_RCD();
+        for (UINT r = 0; r < max_run; ++r) {
+            RVEC dir(dim, 0);
+            if (r % 5 == 0 && wrand) {
+                dir = randvec(dim);
+            } else if (online) {
+                UINT idx, cnt = 0;
+                REAL o;
+                do {
+                    ++cnt;
+                    idx = UINT(randu() * n_samples);
+                    o = DOTPROD(wgt, X[idx]);
+                } while (Y[idx] * o > 0 && cnt < 2*n_samples);
+                // if we've tried too many times, just use any X
+                dir = X[idx];
+            } else {
+                bool no_err = true;
+                for (UINT j = 0; j < n_samples; ++j) {
+                    GET_XYO(j);
+                    if (y * o > 0) continue;
+                    no_err = false;
+                    for (UINT k = 0; k < udim; ++k)
+                        dir[k] += y * x[k];
+                }
+                if (no_err) break;
+            }
+
+            if (fixed_bias)
+                dir.back() = 0;
+            UPDATE_WGT(dir);
+            log_error(r+1);
+        }
+    }
+        break;
+
+    case RCD_GRAD_MIXED_BATCH_INITRAND:
+    case RCD_GRAD_MIXED_BATCH:
+    case RCD_GRAD_MIXED_INITRAND:
+    case RCD_GRAD_MIXED: {
+        bool online = (train_method == RCD_GRAD_MIXED ||
+                       train_method == RCD_GRAD_MIXED_INITRAND);
+        bool init_rand = (train_method == RCD_GRAD_MIXED_INITRAND ||
+                          train_method == RCD_GRAD_MIXED_BATCH_INITRAND);
+
+        INIT_RCD();
+        for (UINT r = 0; r < max_run; ++r) {
+            RVEC dir(dim, 0);
+            if (init_rand)
+                dir = randvec(dim);
+            UINT cnt = 0;
+
+            for (UINT j = 0; j < n_samples; ++j) {
+                UINT idx = (online? UINT(randu() * n_samples) : j);
+                GET_XYO(idx);
+                if (y * o > 0) continue;
+                ++cnt;
+                REAL adj = y*n_samples * randu();
+                for (UINT k = 0; k < udim; ++k)
+                    dir[k] += adj * x[k];
+            }
+            //if (cnt == 0 && !online) break;
+
+            if (cnt == 0 && !init_rand)
+                dir = randvec(dim);
+            if (fixed_bias)
+                dir.back() = 0;
+            UPDATE_WGT(dir);
+            log_error(r+1);
+        }
+    }
+        break;
+
+    case RCD_MIXED: {
+        INIT_RCD();
+        RMAT A;
+        for (UINT r = 0; r < max_run; ++r) {
+            UINT c = r % (2*udim);
+            RVEC dir;
+            if (c < udim)
+                dir = coorvec(dim, CYCLE(c));
+            else {
+                if (c == udim) A = randrot(dim, fixed_bias, false);
+                dir = A[c-udim]; // CYCLE doesn't change anything
+            }
+            UPDATE_WGT(dir);
+            log_error(r+1);
+        }
+    }
+        break;
+
+    default:
+        assert(false);
+    }
+
+    assert(!fixed_bias || train_method == AVE_PERCEPTRON_RAND ||
+           train_method == AVE_PERCEPTRON || wgt.back() == bias_save);
+}
+
+#define INPUT_SUM(w,x)  \
+    std::inner_product(x.begin(), x.end(), w.begin(), w.back())
+
+Output Perceptron::operator() (const Input& x) const {
+    assert(x.size() == n_input());
+    REAL sum = INPUT_SUM(wgt, x);
+    return Output(1, (sum>=0)? 1 : -1);
+}
+
+REAL Perceptron::margin_of (const Input& x, const Output& y) const {
+    assert(std::fabs(std::fabs(y[0]) - 1) < INFINITESIMAL);
+    return INPUT_SUM(wgt, x) * y[0];
+}
+
+REAL Perceptron::w_norm () const {
+    REAL s = DOTPROD_NB(wgt, wgt);
+    return std::sqrt(s);
+}
+
+void Perceptron::log_error (UINT, REAL err) const {
+    if (logf != NULL) {
+        if (err < 0) err = train_c_error();
+        fprintf(logf, "%g ", err);
+    }
+}
+
+} // namespace lemga

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/perceptron.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/perceptron.cpp
@@ -170,7 +170,7 @@ bool Perceptron::serialize (std::ostream& os, ver_list& vl) const {
     SERIALIZE_PARENT(LearnModel, os, vl, 1);
     for (UINT i = 0; i <= _n_in; ++i)
         if (!(os << wgt[i] << ' ')) return false;
-    return (os << '\n');
+    return (bool)(os << '\n');
 }
 
 bool Perceptron::unserialize (std::istream& is, ver_list& vl, const id_t& d) {

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/perceptron.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/perceptron.h
@@ -1,0 +1,136 @@
+// -*- C++ -*-
+#ifndef __LEMGA_PERCEPTRON_H__
+#define __LEMGA_PERCEPTRON_H__
+
+/** @file
+ *  @brief @link lemga::Perceptron Perceptron@endlink class.
+ *
+ *  $Id: perceptron.h 2891 2006-11-08 03:17:31Z ling $
+ */
+
+#include <vector>
+#include "learnmodel.h"
+#include "svm.h"
+
+namespace lemga {
+
+/** @brief %Perceptron models a type of artificial neural network that
+ *  consists of only one neuron, invented by Frank Rosenblatt in 1957.
+ *
+ *  We use the convention that @f$w_0@f$ is the negative threshold,
+ *  or equivalently, letting @f$x_0=1@f$. When presented with input
+ *  @f$x@f$, the perceptron outputs
+ *  @f[ o = \theta(s),\quad s=\sum_i w_ix_i, @f]
+ *  where @f$\theta(\cdot)@f$ is usually the sign function,
+ *
+ *  The learning algorithm updates the weight according to
+ *  @f[ w^{(t+1)} = w^{(t)} + \eta (y-o) x, @f]
+ *  where @f$y@f$ is the desired output. If @f$\theta@f$ is the sign,
+ *  the learning rate @f$\eta@f$ can be omitted since it just scales
+ *  @f$w@f$.
+ *
+ *  @note If @f$o@f$ is replaced by @f$s@f$, the sum before the function
+ *  @f$\theta@f$, the algorithm is then called the ADALINE learning.
+ */
+class Perceptron : public LearnModel {
+public:
+    typedef std::vector<REAL> WEIGHT;
+    enum TRAIN_METHOD {
+        // These are known algorithms
+        PERCEPTRON,          // Rosenblatt's learning rule
+        ADALINE,
+        POCKET,              // Gallant's pocket algorithm
+        POCKET_RATCHET,
+        AVE_PERCEPTRON,      // Freund's average-perceptron
+        ROMMA,
+        ROMMA_AGG,
+        SGD_HINGE,           // Zhang's stochastic gradient descent
+        SGD_MLSE,            // on SVM hinge loss or modified least square
+        // These are the recommended ones of my algorithms
+        RCD,
+        RCD_BIAS,
+        RCD_GRAD,
+        // Below are just for research comparison
+        AVE_PERCEPTRON_RAND,
+        ROMMA_RAND,
+        ROMMA_AGG_RAND,
+        COORDINATE_DESCENT,
+        FIXED_RCD,
+        FIXED_RCD_CONJ,
+        FIXED_RCD_BIAS,
+        FIXED_RCD_CONJ_BIAS,
+        RCD_CONJ,
+        RCD_CONJ_BIAS,
+        RCD_GRAD_BATCH,
+        RCD_GRAD_RAND,
+        RCD_GRAD_BATCH_RAND,
+        RCD_MIXED,
+        RCD_GRAD_MIXED,
+        RCD_GRAD_MIXED_INITRAND,
+        RCD_GRAD_MIXED_BATCH,
+        RCD_GRAD_MIXED_BATCH_INITRAND,
+        // Old definitions
+        RAND_COOR_DESCENT = RCD,
+        RAND_COOR_DESCENT_BIAS = RCD_BIAS,
+        RAND_CONJ_DESCENT = RCD_CONJ,
+        RAND_CONJ_DESCENT_BIAS = RCD_CONJ_BIAS,
+        GRADIENT_COOR_DESCENT_ONLINE = RCD_GRAD
+    };
+
+protected:
+    WEIGHT wgt;      ///< wgt.back() is the bias
+    // only for online-type algorithms; RCD always uses reweighting
+    bool resample;   ///< reweighting or resampling
+    TRAIN_METHOD train_method;
+    REAL learn_rate, min_cst;
+    UINT max_run;
+    bool with_fld;   ///< start training with FLD?
+    bool fixed_bias; ///< using a fixed bias?
+
+public:
+    explicit Perceptron (UINT n_in = 0);
+    Perceptron (const SVM&);
+    explicit Perceptron (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual Perceptron* create () const { return new Perceptron(); }
+    virtual Perceptron* clone () const { return new Perceptron(*this); }
+
+    WEIGHT weight () const { return wgt; }
+    void set_weight (const WEIGHT&);
+
+    void start_with_fld (bool b = true) { with_fld = b; }
+    void set_fixed_bias (bool b = false) { fixed_bias = b; }
+    void use_resample (bool s = true) { resample = true; }
+    void set_train_method (TRAIN_METHOD m) { train_method = m; }
+    /** @param lr learning rate.
+     *  @param mincst minimal cost (error) need to be achieved during
+     *         training.
+     *  @param maxrun maximal # of epochs the training should take.
+     */
+    void set_parameter (REAL lr, REAL mincst, UINT maxrun) {
+        learn_rate = lr; min_cst = mincst; max_run = maxrun; }
+
+    virtual bool support_weighted_data () const { return true; }
+    virtual void initialize ();
+    WEIGHT fld () const;
+    virtual void train ();
+    virtual Output operator() (const Input&) const;
+
+    virtual REAL margin_norm () const { return w_norm(); }
+    virtual REAL margin_of (const Input&, const Output&) const;
+    REAL w_norm () const;
+
+protected:
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+    virtual void log_error (UINT, REAL = -1) const;
+};
+
+} // namespace lemga
+
+#ifdef  __PERCEPTRON_H__
+#warning "This header file may conflict with another `perceptron.h' file."
+#endif
+#define __PERCEPTRON_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/quickfun.c
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/quickfun.c
@@ -1,0 +1,50 @@
+/** @file
+ *  $Id: quickfun.c 1789 2004-04-23 05:15:44Z ling $
+ */
+
+#include <assert.h>
+#include <math.h>
+#include "quickfun.h"
+
+#define round(x)        ((UINT)(x+0.5))
+
+#define TANH_RANGE0     1.84   /* tanh(1.84) = 0.95079514... */
+#define TANH_RANGE1     4.5    /* tanh(4.5)  = 0.99975321... */
+#define TANH_STEP0      0.001
+#define TANH_STEP1      0.005
+
+#define TANH_FACTOR0    (1/TANH_STEP0)
+#define TANH_FACTOR1    (1/TANH_STEP1)
+#define TANH_SIZE0      (round(TANH_FACTOR0*TANH_RANGE0)+1)
+#define TANH_SIZE1      (round(TANH_FACTOR1*(TANH_RANGE1-TANH_RANGE0))+1)
+
+/* note: C doesn't have boolean type */
+static int tanh_table_ready = 0;
+static REAL tanh_table0[TANH_SIZE0], tanh_table1[TANH_SIZE1];
+
+void quick_tanh_setup (void) {
+    UINT i;
+    if (tanh_table_ready) return;
+
+    for (i = 0; i < TANH_SIZE0; ++i)
+        tanh_table0[i] = tanh(i * TANH_STEP0);
+    for (i = 0; i < TANH_SIZE1; ++i)
+        tanh_table1[i] = tanh(i * TANH_STEP1 + TANH_RANGE0);
+    tanh_table_ready = 1;
+}
+
+static REAL quick_tanh_p (REAL x) {
+    if (x <= TANH_RANGE0)
+        return tanh_table0[round(x * TANH_FACTOR0)];
+    else if (x <= TANH_RANGE1)
+        return tanh_table1[round((x - TANH_RANGE0) * TANH_FACTOR1)];
+    return 0.9998;
+}
+
+REAL quick_tanh (REAL x) {
+    assert(tanh_table_ready);
+
+    if (x < 0)
+        return -quick_tanh_p(-x);
+    return quick_tanh_p(x);
+}

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/quickfun.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/quickfun.h
@@ -1,0 +1,24 @@
+#ifndef __QUICKFUN_H__
+#define __QUICKFUN_H__
+#define __COMMON_TYPES_QUICKFUN_H__
+
+#include "object.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void quick_tanh_setup (void);
+REAL quick_tanh (REAL x);
+
+#ifdef __cplusplus
+}
+#endif
+
+#else /* def __QUICKFUN_H__ */
+
+#ifndef __COMMON_TYPES_QUICKFUN_H__
+ #error This header file conflicts with another "quickfun.h" file.
+#endif
+
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/random.c
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/random.c
@@ -1,0 +1,40 @@
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "random.h"
+
+void set_seed (unsigned int seed)
+{
+    if (seed == 0 || seed > RAND_MAX) {
+        /* use time() to set the seed */
+        time_t t = time(NULL);
+        assert(t > 0);
+        seed = t;
+    }
+    fprintf(stderr, "random seed = %u\n", seed);
+    srand(seed);
+}
+
+REAL randn () {
+    static int saved = 0;
+    static REAL saved_val;
+    REAL rsq, v1, v2, ratio;
+
+    if (saved) {
+        saved = 0;
+        return saved_val;
+    }
+
+    do {
+        v1 = 2*randu()-1;
+        v2 = 2*randu()-1;
+        rsq = v1*v1 + v2*v2;
+    } while (rsq >= 1 || rsq == 0);
+    ratio = sqrt(-2 * log(rsq)/rsq);
+
+    saved_val = v1 * ratio;
+    saved = 1;
+    return v2 * ratio;
+}

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/random.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/random.h
@@ -1,0 +1,36 @@
+/* random.h -- Define several random distributions
+ *
+ * Copyright (C) 2001 Ling Li
+ * ling@caltech.edu
+ */
+
+#ifndef __RANDOM_H__
+#define __RANDOM_H__
+#define __COMMON_TYPES_RANDOM_H__
+
+#include <stdlib.h>
+#include "object.h"
+
+typedef REAL PROBAB;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void set_seed (unsigned int seed);
+/* randu: [0, 1); randuc: [0, 1] */
+#define randu()    (rand() / (RAND_MAX + 1.0))
+#define randuc()   (rand() / (PROBAB) RAND_MAX)
+REAL randn ();
+
+#ifdef __cplusplus
+}
+#endif
+
+#else /* __RANDOM_H__ */
+
+#ifndef __COMMON_TYPES_RANDOM_H__
+ #error This header file conflicts with another "random.h" file.
+#endif
+
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/shared_ptr.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/shared_ptr.h
@@ -1,0 +1,103 @@
+// -*- C++ -*-
+#ifndef __CPP_ADDON_SHARED_PTR_H__
+#define __CPP_ADDON_SHARED_PTR_H__
+
+/** @file
+ *  @brief Shared pointers with reference count.
+ *
+ *  $Id: shared_ptr.h 1907 2004-12-11 00:51:14Z ling $
+ */
+
+/** @warning Do not use this class. Use const_shared_ptr or var_shared_ptr.
+ *  @note I guess it is not thread-safe.
+ *  @note See boost.org for a better and more complicated implementation.
+ */
+template <typename T>
+class _shared_ptr {
+protected:
+    T* ptr;
+    UINT* pcnt;
+
+    void delete_this () {
+        if (valid() && !(--*pcnt)) {
+            delete ptr; delete pcnt;
+            ptr = 0; pcnt = 0;
+        }
+    }
+
+    /// @c false if the pointer is null.
+    bool valid () const {
+        assert((!ptr && !pcnt) || (ptr && pcnt && *pcnt > 0));
+        return (ptr != 0);
+    }
+
+    UINT use_count () const { assert(valid()); return *pcnt; }
+    bool unique () const { return (use_count() == 1); }
+
+public:
+    explicit _shared_ptr (T* p = 0) : ptr(p), pcnt(0) {
+        if (p) { pcnt = new UINT(1); assert(valid()); } }
+    _shared_ptr (const _shared_ptr<T>& s) : ptr(s.ptr), pcnt(s.pcnt) {
+        if (valid()) ++(*pcnt); }
+    ~_shared_ptr () { delete_this(); }
+
+    const _shared_ptr<T>& operator= (const _shared_ptr<T>& s) {
+        if (this == &s) return *this;
+        delete_this();
+        ptr = s.ptr; pcnt = s.pcnt;
+        if (valid()) ++(*pcnt);
+        return *this;
+    }
+    bool operator!= (const T* p) const { return ptr != p; }
+    bool operator== (const T* p) const { return ptr == p; }
+    bool operator!= (const _shared_ptr& p) const { return ptr != p.ptr; }
+    bool operator== (const _shared_ptr& p) const { return ptr == p.ptr; }
+    bool operator! () const { return !ptr; }
+
+    typedef bool (_shared_ptr::*implicit_bool_type) () const;
+    operator implicit_bool_type () const {
+        return ptr? &_shared_ptr::valid : 0;
+    }
+};
+
+/// Shared pointers (whose content can not be changed).
+template <typename T>
+class const_shared_ptr : public _shared_ptr<T> {
+    using _shared_ptr<T>::valid;
+    using _shared_ptr<T>::ptr;
+public:
+    const_shared_ptr () {}
+    const_shared_ptr (T* p) : _shared_ptr<T>(p) {}
+    const_shared_ptr (const const_shared_ptr<T>& s) : _shared_ptr<T>(s) {}
+
+    const const_shared_ptr<T>& operator= (const const_shared_ptr<T>& s) {
+        _shared_ptr<T>::operator=(s);
+        return *this;
+    }
+    const T* operator-> () const { assert(valid()); return ptr; }
+    const T& operator* () const { assert(valid()); return *ptr; }
+};
+
+/// Shared pointers (whose content can be changed).
+template <typename T>
+class var_shared_ptr : public _shared_ptr<T> {
+    using _shared_ptr<T>::valid;
+    using _shared_ptr<T>::ptr;
+public:
+    var_shared_ptr () {}
+    var_shared_ptr (T* p) : _shared_ptr<T>(p) {}
+    var_shared_ptr (const var_shared_ptr<T>& s) : _shared_ptr<T>(s) {}
+
+    const var_shared_ptr<T>& operator= (const var_shared_ptr<T>& s) {
+        _shared_ptr<T>::operator=(s);
+        return *this;
+    }
+    T* operator-> () const { assert(valid()); return ptr; }
+    T& operator* () const { assert(valid()); return *ptr; }
+};
+
+#ifdef  __SHARED_PTR_H__
+#warning "This header file may conflict with another `shared_ptr.h' file."
+#endif
+#define __SHARED_PTR_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.cpp
@@ -1,0 +1,207 @@
+/** @file
+ *  $Id: stump.cpp 2891 2006-11-08 03:17:31Z ling $
+ */
+
+#include <assert.h>
+#include <cmath>
+#include <algorithm>
+#include <vector>
+#include <map>
+#include "stump.h"
+
+REGISTER_CREATOR(lemga::Stump);
+
+namespace lemga {
+
+bool Stump::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(LearnModel, os, vl, 2);
+    return (os << idx << ' ' << bd1 << ' ' << bd2 << ' '
+               << (dir? 'P':'N') << '\n');
+}
+
+bool Stump::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(LearnModel, is, vl, 2, v);
+
+    if (v == 0) { /* Take care of _n_in and _n_out */
+        if (!(is >> _n_in)) return false;
+        assert(_n_out == 1);
+    }
+    /* common part for ver 0, 1, and 2 */
+    if (!(is >> idx >> bd1)) return false;
+    bd2 = bd1;
+    if (v >= 2)
+        if (!(is >> bd2) || bd1 > bd2) return false;
+    char c;
+    if (!(is >> c) || (c != 'P' && c != 'N')) return false;
+    dir = (c == 'P');
+    return true;
+}
+
+typedef std::map<REAL,REAL>::iterator MI;
+
+REAL Stump::train_1d (const std::vector<REAL>& x, const std::vector<REAL>& yw)
+{
+    const UINT N = x.size();
+    assert(yw.size() == N);
+
+    // combine examples with same input, and sort them
+    std::map<REAL,REAL> xy;
+    for (UINT i = 0; i < N; ++i)
+        xy[x[i]] += yw[i];
+    UINT n = xy.size();
+    xy[xy.begin()->first-2] = 1;    // insert a "very small" x
+    assert(xy.size() == n+1);
+    for (MI p, pn = xy.begin(); p = pn++, p != xy.end();)
+        if (p->second > -INFINITESIMAL && p->second < INFINITESIMAL)
+            xy.erase(p);
+
+    n = xy.size();
+    xy[xy.rbegin()->first+2] = 1;   // a "very large" x
+    assert(n > 0 && xy.size() == n+1);
+    const MI xyb = xy.begin();
+
+    REAL minthr = 0, mine = INFINITY, e = - xyb->second;
+    REAL cur_x = xyb->first;
+    for (MI p = xyb; n; --n) {
+        e += p->second;
+        assert(p != xyb || e == 0);
+        REAL nxt_x = (++p)->first;
+        REAL cur_thr = (cur_x + nxt_x) / 2;
+        cur_x = nxt_x;
+
+        if (e < mine) {
+            mine = e; minthr = cur_thr;
+        }
+    }
+
+    return minthr;
+}
+
+/* yw_inf is yw[infinity] */
+REAL Stump::train_1d (const std::vector<REAL>& x, const std::vector<REAL>& yw,
+                      REAL yw_inf, bool& ir, bool& mind, REAL& th1, REAL& th2)
+{
+    const UINT N = x.size();
+    assert(yw.size() == N);
+
+    // combine examples with same input, and sort them
+    std::map<REAL,REAL> xy;
+    for (UINT i = 0; i < N; ++i)
+        xy[x[i]] += yw[i];
+#ifndef NDEBUG
+    UINT n = xy.size();
+#endif
+    xy[xy.begin()->first-2] = 1;    // insert a "very small" x
+    assert(xy.size() == n+1);
+    for (MI p, pn = xy.begin(); p = pn++, p != xy.end();)
+        if (p->second > -INFINITESIMAL && p->second < INFINITESIMAL)
+            xy.erase(p);
+
+#ifndef NDEBUG
+    // check whether a constant function is enough
+    bool all_the_same = true;
+    MI pb = xy.begin(); ++pb;
+    for (MI p = pb; p != xy.end(); ++p)
+        if (p->second < -INFINITESIMAL) { all_the_same = false; break; }
+
+    if (!all_the_same) {
+        all_the_same = true;
+        for (MI p = pb; p != xy.end(); ++p)
+            if (p->second > INFINITESIMAL) { all_the_same = false; break; }
+    }
+
+    if (all_the_same)
+        std::cerr << "Stump: Warning: all y's are the same.\n";
+#endif
+    const MI xyb = xy.begin(), xye = xy.end();
+
+    REAL mine = 0, maxe = 0, e = -1;
+    MI mint, maxt, p;
+    for (mint = maxt = p = xyb; p != xye; ++p) {
+        e += p->second;
+        assert(p != xyb || e == 0);
+        if (e < mine) {
+            mine = e; mint = p;
+        } else if (e > maxe) {
+            maxe = e; maxt = p;
+        }
+        // we prefer middle indices
+        if (mint == xyb && e == 0) mint = p;
+        if (maxt == xyb && e == 0) maxt = p;
+    }
+    e = (1-e-yw_inf) / 2;// error of y = sgn(x > -Inf)
+    mine += e;           // starting with y = -1
+    maxe = 1 - (maxe+e); // starting with y = 1
+
+    // unify the solution to mind, mine, and mint
+    if (std::fabs(mine - maxe) < EPSILON) {
+        MI nxtt = mint; ++nxtt;
+        mind = (mint != xyb && nxtt != xye);
+    }
+    else mind = (mine < maxe);
+    if (!mind) {
+        mine = maxe; mint = maxt;
+    }
+
+    MI nxtt = mint; ++nxtt;
+    ir = (mint != xyb && nxtt != xye);
+    assert(!ir || !all_the_same);
+    th1 = mint->first;
+    if (ir)
+        th2 = nxtt->first;
+    else
+        th2 = th1 + 2;
+
+    return mine;
+}
+
+/* Find the optimal dimension and threshold */
+void Stump::train () {
+    const UINT N = n_samples;
+    assert(ptd != 0 && ptw != 0 && ptd->size() == N);
+    set_dimensions(*ptd);
+
+    // weight the examples
+    std::vector<REAL> yw(N);
+    for (UINT i = 0; i < N; ++i)
+        yw[i] = ptd->y(i)[0] * (*ptw)[i];
+
+    REAL minerr = 2;
+    bool minir = true;
+
+    std::vector<REAL> x(N);
+    for (UINT d = 0; d < _n_in; ++d) {
+        for (UINT i = 0; i < N; ++i)
+            x[i] = ptd->x(i)[d];
+
+        bool mind, ir;
+        REAL th1, th2;
+        REAL mine = train_1d(x, yw, 0, ir, mind, th1, th2);
+
+        if (mine < minerr) {
+            minerr = mine;
+            minir = ir;
+            dir = mind; idx = d;
+            bd1 = th1; bd2 = th2;
+        }
+    }
+
+    if (!minir)
+        std::cerr << "Stump: Warning: threshold out of range.\n";
+}
+
+Output Stump::operator() (const Input& x) const {
+    assert(idx < n_input() && x.size() == n_input());
+    assert(bd2 >= bd1);
+    REAL y = x[idx]*2 - (bd1 + bd2);
+    if (hard || bd1 == bd2)
+        y = (y < 0)? -1 : 1;
+    else {
+        y /= bd2 - bd1;
+        y = (y<-1)? -1 : (y>1)? 1 : y;
+    }
+    return Output(1, dir? y : -y);
+}
+
+} // namespace lemga

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.cpp
@@ -52,9 +52,11 @@ REAL Stump::train_1d (const std::vector<REAL>& x, const std::vector<REAL>& yw)
     UINT n = xy.size();
     xy[xy.begin()->first-2] = 1;    // insert a "very small" x
     assert(xy.size() == n+1);
-    for (MI p, pn = xy.begin(); p = pn++, p != xy.end();)
+    for (MI p = xy.begin(); p != xy.end();)
         if (p->second > -INFINITESIMAL && p->second < INFINITESIMAL)
-            xy.erase(p);
+            p = xy.erase(p);
+        else
+            ++p;
 
     n = xy.size();
     xy[xy.rbegin()->first+2] = 1;   // a "very large" x
@@ -94,9 +96,11 @@ REAL Stump::train_1d (const std::vector<REAL>& x, const std::vector<REAL>& yw,
 #endif
     xy[xy.begin()->first-2] = 1;    // insert a "very small" x
     assert(xy.size() == n+1);
-    for (MI p, pn = xy.begin(); p = pn++, p != xy.end();)
+    for (MI p = xy.begin(); p != xy.end();)
         if (p->second > -INFINITESIMAL && p->second < INFINITESIMAL)
-            xy.erase(p);
+            p = xy.erase(p);
+        else
+            ++p;
 
 #ifndef NDEBUG
     // check whether a constant function is enough

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.cpp
@@ -15,7 +15,7 @@ namespace lemga {
 
 bool Stump::serialize (std::ostream& os, ver_list& vl) const {
     SERIALIZE_PARENT(LearnModel, os, vl, 2);
-    return (os << idx << ' ' << bd1 << ' ' << bd2 << ' '
+    return (bool)(os << idx << ' ' << bd1 << ' ' << bd2 << ' '
                << (dir? 'P':'N') << '\n');
 }
 

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.h
@@ -1,0 +1,61 @@
+// -*- C++ -*-
+#ifndef __LEMGA_STUMP_H__
+#define __LEMGA_STUMP_H__
+
+/** @file
+ *  @brief @link lemga::Stump Decision stump@endlink class.
+ *
+ *  $Id: stump.h 2891 2006-11-08 03:17:31Z ling $
+ */
+
+#include "learnmodel.h"
+
+namespace lemga {
+
+/** @brief Decision stump.
+ *  @todo Documentation
+ */
+class Stump : public LearnModel {
+    UINT idx;
+    REAL bd1, bd2;///< threshold is (bd1+bd2)/2
+    bool dir;     ///< \c true: sgn(x[idx] - th); \c false: -sgn(x[idx] - th).
+    bool hard;    ///< use the hard threshold?
+
+public:
+    explicit Stump (UINT n_in = 0)
+        : LearnModel(n_in, 1), idx(0), bd1(0), bd2(0), hard(true) {}
+    explicit Stump (std::istream& is) { is >> *this; }
+
+    virtual const id_t& id () const;
+    virtual Stump* create () const { return new Stump(); }
+    virtual Stump* clone () const { return new Stump(*this); }
+
+    UINT index () const { return idx; }
+    REAL threshold () const { return (bd1+bd2)/2; }
+    bool direction () const { return dir; }
+    bool soft_threshold () const { return !hard; }
+    void use_soft_threshold (bool s = true) { hard = !s; }
+
+    virtual bool support_weighted_data () const { return true; }
+
+    virtual void train ();
+    /// Find the optimal threshold and direction (prefer the middle thresholds)
+    static REAL train_1d (const std::vector<REAL>&, const std::vector<REAL>&,
+                          REAL, bool&, bool&, REAL&, REAL&);
+    /// Find the optimal threshold for positive direction
+    static REAL train_1d (const std::vector<REAL>&, const std::vector<REAL>&);
+
+    virtual Output operator() (const Input&) const;
+
+protected:
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+};
+
+} // namespace lemga
+
+#ifdef  __STUMP_H__
+#warning "This header file may conflict with another `stump.h' file."
+#endif
+#define __STUMP_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/stump.h
@@ -23,7 +23,7 @@ class Stump : public LearnModel {
 
 public:
     explicit Stump (UINT n_in = 0)
-        : LearnModel(n_in, 1), idx(0), bd1(0), bd2(0), hard(true) {}
+        : LearnModel(n_in, 1), idx(0), bd1(0), bd2(0), dir(true), hard(true) {}
     explicit Stump (std::istream& is) { is >> *this; }
 
     virtual const id_t& id () const;

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/svm.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/svm.cpp
@@ -1,0 +1,428 @@
+/** @file
+ *  $Id: svm.cpp 2782 2006-05-15 19:25:35Z ling $
+ */
+
+#include <assert.h>
+#include <cmath>
+#include "../../libsvm-2.81/svm.h"
+#include "svm.h"
+
+REGISTER_CREATOR(lemga::SVM);
+
+// In order to access nSV, we have to copy svm_model here.
+// Comments removed. Please see svm.cpp for details.
+// Any direct use of svm_model is marked with /* direct access svm_model */
+struct svm_model {
+    svm_parameter param;
+    int nr_class;
+    int l;
+    svm_node **SV;
+    double **sv_coef;
+    double *rho;
+    double *probA;
+    double *probB;
+    int *label;
+    int *nSV;
+    int free_sv;
+};
+
+namespace lemga {
+
+typedef struct svm_node* p_svm_node;
+
+#ifndef NDEBUG
+static bool param_equal (const struct svm_parameter& a,
+                         const struct svm_parameter& b) {
+    struct svm_parameter a2 = a, b2 = b;
+    a2.C = b2.C = 0;
+    return !std::memcmp(&a2, &b2, sizeof(struct svm_parameter));
+}
+#endif
+
+struct SVM_detail {
+    struct svm_parameter param;
+    struct svm_problem prob;
+    struct svm_model *model;
+    struct svm_node *x_space;
+    UINT n_class;
+    int *labels;
+    bool trained; // the wrapper was not loaded from file (ONLY FOR DEBUG)
+
+    SVM_detail ();
+    ~SVM_detail () {
+        clean_model(); clean_data(); svm_destroy_param(&param); }
+    bool fill_svm_problem (const pDataSet&, const pDataWgt&);
+    bool train (const pDataSet&, const pDataWgt&);
+    void clean_model ();
+    void clean_data ();
+};
+
+SVM_detail::SVM_detail () : model(0), x_space(0), trained(false) {
+    // default LIBSVM parameters, copied from svm-train.c
+    param.svm_type = C_SVC;
+    param.degree = 3;
+    param.gamma = 0;
+    param.coef0 = 0;
+    param.nu = 0.5;
+    param.cache_size = 128;
+    param.eps = 1e-3;
+    param.p = 0.1;
+    param.shrinking = 1;
+    param.probability = 0;
+    param.nr_weight = 0;
+    param.weight_label = NULL;
+    param.weight = NULL;
+}
+
+void SVM_detail::clean_model () {
+    trained = false;
+    if (!model) return;
+    svm_destroy_model(model);
+    delete[] labels;
+    model = 0;
+}
+
+void SVM_detail::clean_data () {
+    if (!x_space) return;
+    delete[] prob.x; delete[] prob.y;
+    delete[] prob.W;
+    delete[] x_space; x_space = 0;
+}
+
+p_svm_node fill_svm_node (const Input& x, struct svm_node *pool) {
+    for (UINT j = 0; j < x.size(); ++j, ++pool) {
+        pool->index = j+1;
+        pool->value = x[j];
+    }
+    pool->index = -1;
+    return ++pool;
+}
+
+bool SVM_detail::fill_svm_problem (const pDataSet& ptd, const pDataWgt& ptw) {
+    assert(ptd->size() == ptw->size());
+    const UINT n_samples = ptd->size();
+    if (n_samples == 0 || ptd->y(0).size() != 1) return false;
+    const UINT n_in = ptd->x(0).size();
+
+    clean_data();
+    prob.l = n_samples;
+    prob.x = new p_svm_node[n_samples];
+    prob.y = new double[n_samples];
+    prob.W = new double[n_samples];
+    x_space = new struct svm_node[n_samples*(n_in+1)];
+    if (!x_space) return false;
+
+    struct svm_node *psn = x_space;
+    for (UINT i = 0; i < n_samples; ++i) {
+        prob.x[i] = psn;
+        prob.y[i] = ptd->y(i)[0];
+        psn = fill_svm_node(ptd->x(i), psn);
+        prob.W[i] = (*ptw)[i] * n_samples;
+    }
+    return true;
+}
+
+bool SVM_detail::train (const pDataSet& ptd, const pDataWgt& ptw) {
+    if (!fill_svm_problem(ptd, ptw)) {
+        std::cerr << "Error in filling SVM problem (training data)\n";
+        return false;
+    }
+    const char* error_msg = svm_check_parameter(&prob,&param);
+    if (error_msg) {
+        std::cerr << "Error: " << error_msg << '\n';
+        return false;
+    }
+
+    clean_model();
+    model = svm_train(&prob, &param);
+    trained = true;
+    n_class = svm_get_nr_class(model);
+    labels = new int[n_class];
+    svm_get_labels(model, labels);
+    return true;
+}
+
+namespace kernel {
+
+void Linear::set_params (SVM_detail* sd) const {
+    sd->param.kernel_type = ::LINEAR;
+}
+
+void Polynomial::set_params (SVM_detail* sd) const {
+    sd->param.kernel_type = ::POLY;
+    sd->param.degree = degree;
+    sd->param.gamma = gamma;
+    sd->param.coef0 = coef0;
+}
+
+void RBF::set_params (SVM_detail* sd) const {
+    sd->param.kernel_type = ::RBF;
+    sd->param.gamma = gamma;
+}
+
+void Sigmoid::set_params (SVM_detail* sd) const {
+    sd->param.kernel_type = ::SIGMOID;
+    sd->param.gamma = gamma;
+    sd->param.coef0 = coef0;
+}
+
+void Stump::set_params (SVM_detail* sd) const {
+    sd->param.kernel_type = ::STUMP;
+}
+
+void Perceptron::set_params (SVM_detail* sd) const {
+    sd->param.kernel_type = ::PERCEPTRON;
+}
+
+} // namespace kernel
+
+bool SVM::serialize (std::ostream& os, ver_list& vl) const {
+    SERIALIZE_PARENT(LearnModel, os, vl, 1);
+
+    // we will not save the detail
+    assert(sv.size() == coef.size());
+    assert(ker != 0 || sv.size() == 0);
+    if (!(os << (ker != 0) << ' ' << regC << ' ' << sv.size() << '\n'))
+        return false;
+    // the kernel
+    if (ker != 0)
+        if (!(os << *ker)) return false;
+    // support vectors and coefficients
+    for (UINT i = 0; i < sv.size(); ++i) {
+        assert(sv[i].size() == _n_in);
+        for (UINT j = 0; j < _n_in; ++j)
+            if (!(os << sv[i][j] << ' ')) return false;
+        if (!(os << coef[i] << '\n')) return false;
+    }
+    // the bias
+    return (os << coef0 << '\n');
+}
+
+bool SVM::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
+    if (d != id() && d != NIL_ID) return false;
+    UNSERIALIZE_PARENT(LearnModel, is, vl, 1, v);
+    assert(v > 0);
+
+    assert(detail != 0);
+    reset_model();
+    if (ker != 0) delete ker; ker = 0;
+
+    UINT has_kernel, nsv;
+    if (!(is >> has_kernel >> regC >> nsv) || has_kernel > 1 || regC < 0)
+        return false;
+    if (!has_kernel && nsv > 0) return false;
+
+    if (has_kernel) {
+        kernel::Kernel* k = (kernel::Kernel*) Object::create(is);
+        if (k == 0) return false;
+        set_kernel(*k); // don't directly assign the kernel
+        delete k;
+    }
+    sv.resize(nsv); coef.resize(nsv);
+    for (UINT i = 0; i < nsv; ++i) {
+        Input svi(_n_in);
+        for (UINT j = 0; j < _n_in; ++j)
+            if (!(is >> svi[j])) return false;
+        sv[i].swap(svi);
+        if (!(is >> coef[i])) return false;
+    }
+    return (is >> coef0);
+}
+
+SVM::SVM (UINT n_in) : LearnModel(n_in, 1), ker(0), regC(1), coef0(0) {
+    detail = new struct SVM_detail;
+}
+
+SVM::SVM (const kernel::Kernel& k, UINT n_in)
+    : LearnModel(n_in, 1), ker(0), regC(1), coef0(0) {
+    detail = new struct SVM_detail;
+    set_kernel(k);
+}
+
+SVM::SVM (const SVM& s) : LearnModel(s),
+    ker(0), regC(s.regC), sv(s.sv), coef(s.coef), coef0(s.coef0) {
+    detail = new struct SVM_detail;
+    if (s.ker != 0) set_kernel(*s.ker);
+    assert(param_equal(detail->param, s.detail->param));
+}
+
+SVM::SVM (std::istream& is) : LearnModel(), ker(0) {
+    detail = new struct SVM_detail;
+    is >> *this;
+}
+
+SVM::~SVM () {
+    delete detail;
+    if (ker != 0) delete ker;
+}
+
+const SVM& SVM::operator= (const SVM& s) {
+    if (&s == this) return *this;
+    assert(ker != s.ker);
+
+    delete detail;
+    if (ker != 0) delete ker; ker = 0;
+
+    LearnModel::operator=(s);
+    regC = s.regC;
+    sv = s.sv; coef = s.coef; coef0 = s.coef0;
+    detail = new struct SVM_detail;
+    if (s.ker != 0) set_kernel(*s.ker);
+    assert(param_equal(detail->param, s.detail->param));
+    return *this;
+}
+
+REAL SVM::kernel (const Input& x1, const Input& x2) const {
+    assert(ker != 0);
+#ifndef NDEBUG
+    assert(detail);
+    struct svm_node sx1[n_input()+1], sx2[n_input()+1];
+    fill_svm_node(x1, sx1);
+    fill_svm_node(x2, sx2);
+    REAL svmk = svm_kernel(sx1, sx2, detail->param);
+#endif
+    REAL k = (*ker)(x1, x2);
+    assert(std::fabs(svmk - k) < EPSILON);
+    return k;
+}
+
+void SVM::set_kernel (const kernel::Kernel& k) {
+    if (&k == ker) return;
+
+    if (ker != 0) {
+        delete ker;
+        reset_model();  // since kernel is also used for testing
+    }
+    ker = k.clone();
+    ker->set_params(detail);
+}
+
+void SVM::initialize () {
+    reset_model();
+}
+
+void SVM::reset_model () {
+    detail->clean_model(); detail->clean_data();
+    sv.clear(); coef.clear(); coef0 = 0;
+}
+
+void SVM::train () {
+    assert(ptd && n_samples == ptd->size());
+    assert(ker != 0);
+    set_dimensions(*ptd);
+
+    reset_model();
+    detail->param.C = regC;
+    if (!detail->train(ptd, ptw)) exit(-1);
+    assert(detail && detail->model && detail->x_space);
+    assert(detail->n_class > 0 && detail->n_class <= 2);
+
+    // copy the trained model to local
+    /* direct access svm_model */
+    const UINT nsv = detail->model->l;
+    sv.resize(nsv); coef.resize(nsv);
+    bool flip = false; // whether to flip coefficients and bias
+    if (detail->n_class == 1) {
+        assert(nsv == 0);
+        coef0 = detail->labels[0];
+    } else {
+        flip = (detail->labels[0] < detail->labels[1]);
+        REAL rho = detail->model->rho[0];
+        coef0 = flip? rho : -rho;
+    }
+    for (UINT i = 0; i < nsv; ++i) {
+        svm_node *SVi = detail->model->SV[i];
+        Input svi(_n_in, 0);
+        for (; SVi->index != -1; ++SVi) {
+            assert(SVi->index > 0 && (UINT) SVi->index <= _n_in);
+            svi[SVi->index-1] = SVi->value;
+        }
+        sv[i].swap(svi);
+        REAL ci = detail->model->sv_coef[0][i];
+        coef[i] = flip? -ci : ci;
+    }
+
+#ifdef NDEBUG
+    // destroy the original model (but keep the param) to save memory
+    detail->clean_model(); detail->clean_data();
+#endif
+}
+
+REAL SVM::margin_of (const Input& x, const Input& y) const {
+    assert(std::fabs(std::fabs(y[0]) - 1) < INFINITESIMAL);
+    return signed_margin(x) * y[0];
+}
+
+REAL SVM::signed_margin (const Input& x) const {
+    assert(x.size() == n_input());
+    assert(ker != 0);
+
+    const UINT nsv = n_support_vectors();
+    REAL sum = bias();
+    for (UINT i = 0; i < nsv; ++i)
+        sum += support_vector_coef(i) * (*ker)(support_vector(i), x);
+
+#ifndef NDEBUG
+    assert(detail);
+    if (!detail->trained) return sum;
+
+    assert(detail->model && detail->x_space);
+    struct svm_node sx[n_input()+1];
+    fill_svm_node(x, sx);
+    double m = detail->labels[0];
+    if (nsv > 0) {
+        svm_predict_values(detail->model, sx, &m);
+        if (detail->labels[0] < detail->labels[1]) m = -m;
+    }
+    assert(std::fabs(sum - m) < EPSILON);
+#endif
+
+    return sum;
+}
+
+REAL SVM::w_norm () const {
+    assert(ker != 0);
+    const UINT nsv = n_support_vectors();
+
+    REAL sum = 0;
+    for (UINT i = 0; i < nsv; ++i) {
+        for (UINT j = i; j < nsv; ++j) {
+            REAL ip = (*ker)(support_vector(i), support_vector(j))
+                * support_vector_coef(i) * support_vector_coef(j);
+            sum += ip + (i==j? 0 : ip);
+#ifndef NDEBUG
+            assert(detail);
+            if (!detail->trained) continue;
+
+            assert(detail->model && detail->x_space);
+            /* direct access svm_model */
+            REAL ve = svm_kernel(detail->model->SV[i],
+                                 detail->model->SV[j], detail->param)
+                * detail->model->sv_coef[0][i] * detail->model->sv_coef[0][j];
+            assert(std::fabs(ip - ve) < EPSILON);
+#endif
+        }
+    }
+    assert(sum >= 0);
+    return std::sqrt(sum);
+}
+
+Output SVM::operator() (const Input& x) const {
+    assert(x.size() == n_input());
+
+    REAL y = (signed_margin(x) > 0? 1 : -1);
+#ifndef NDEBUG
+    assert(detail);
+    if (!detail->trained) return Output(1, y);
+
+    assert(detail->model && detail->x_space);
+    struct svm_node sx[n_input()+1];
+    fill_svm_node(x, sx);
+    REAL l = svm_predict(detail->model, sx);
+    assert(std::fabs(y - l) < INFINITESIMAL);
+#endif
+
+    return Output(1, y);
+}
+
+} // namespace lemga

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/svm.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/svm.cpp
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <cmath>
+#include <cstring>
 #include "../../libsvm-2.81/svm.h"
 #include "svm.h"
 

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/svm.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/svm.cpp
@@ -196,7 +196,7 @@ bool SVM::serialize (std::ostream& os, ver_list& vl) const {
         if (!(os << coef[i] << '\n')) return false;
     }
     // the bias
-    return (os << coef0 << '\n');
+    return (bool)(os << coef0 << '\n');
 }
 
 bool SVM::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
@@ -227,7 +227,7 @@ bool SVM::unserialize (std::istream& is, ver_list& vl, const id_t& d) {
         sv[i].swap(svi);
         if (!(is >> coef[i])) return false;
     }
-    return (is >> coef0);
+    return (bool)(is >> coef0);
 }
 
 SVM::SVM (UINT n_in) : LearnModel(n_in, 1), ker(0), regC(1), coef0(0) {

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/svm.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/svm.h
@@ -1,0 +1,76 @@
+// -*- C++ -*-
+#ifndef __LEMGA_SVM_H__
+#define __LEMGA_SVM_H__
+
+/** @file
+ *  @brief A LEMGA interface to LIBSVM.
+ *
+ *  $Id: svm.h 2664 2006-03-07 19:50:51Z ling $
+ */
+
+#include "learnmodel.h"
+#include "kernel.h"
+
+namespace lemga {
+
+/// Hide LIBSVM details so other files don't need to include LIBSVM header.
+struct SVM_detail;
+
+class SVM : public LearnModel {
+private:
+    SVM_detail *detail;
+    kernel::Kernel *ker;
+    // Why not var_shared_ptr? because kernel is not meant to be shared
+    REAL regC;              // regularization parameter C
+    std::vector<Input> sv;  // support vectors
+    std::vector<REAL> coef; // @f$y_i\alpha_i@f$
+    REAL coef0;             // the bias
+
+public:
+    explicit SVM (UINT n_in = 0);
+    explicit SVM (const kernel::Kernel&, UINT n_in = 0);
+    SVM (const SVM&);
+    explicit SVM (std::istream&);
+    virtual ~SVM ();
+    const SVM& operator= (const SVM&);
+
+    virtual const id_t& id () const;
+    virtual SVM* create () const { return new SVM(); }
+    virtual SVM* clone () const { return new SVM(*this); }
+
+    REAL C () const { return regC; }
+    void set_C (REAL c) { regC = c; }
+    UINT n_support_vectors () const { return sv.size(); }
+    const Input& support_vector (UINT i) const { return sv[i]; }
+    /// @return @f$y_i\alpha_i@f$
+    REAL support_vector_coef (UINT i) const { return coef[i]; }
+    REAL bias () const { return coef0; }
+    const kernel::Kernel& kernel () const { return *ker; }
+    REAL kernel (const Input&, const Input&) const;
+    void set_kernel (const kernel::Kernel&);
+
+    virtual bool support_weighted_data () const { return true; }
+    virtual void initialize ();
+    virtual void train ();
+
+    virtual Output operator() (const Input&) const;
+    virtual REAL margin_norm () const { return w_norm(); }
+    virtual REAL margin_of (const Input&, const Output&) const;
+    REAL w_norm () const;
+
+protected:
+    /// Gives the signed belief for 2-class problems
+    /// (positive belief means the larger label)
+    REAL signed_margin (const Input&) const;
+    void reset_model ();
+    virtual bool serialize (std::ostream&, ver_list&) const;
+    virtual bool unserialize (std::istream&, ver_list&, const id_t& = NIL_ID);
+};
+
+} // namespace lemga
+
+#ifdef  __SVM_H__
+#warning "This header file may conflict with another `svm.h' file."
+#endif
+#define __SVM_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/utility.cpp
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/utility.cpp
@@ -1,0 +1,59 @@
+/** @file
+ *  $Id: utility.cpp 2631 2006-02-08 21:58:14Z ling $
+ */
+
+#include <cmath>
+#include <assert.h>
+#include "utility.h"
+
+typedef std::vector<REAL> RVEC;
+typedef std::vector<RVEC> RMAT;
+
+// from the Numerical Recipes in C
+bool Cholesky_decomp (RMAT& A, RVEC& p) {
+    const UINT n = A.size();
+    assert(p.size() == n);
+    for (UINT i = 0; i < n; ++i) {
+        for (UINT j = i; j < n; ++j) {
+            REAL sum = A[i][j];
+            for (UINT k = 0; k < i; ++k)
+                sum -= A[i][k] * A[j][k];
+            if (i == j) {
+                if (sum <= 0)
+                    return false;
+                p[i] = std::sqrt(sum);
+            } else
+                A[j][i] = sum / p[i];
+        }
+    }
+    return true;
+}
+
+// from the Numerical Recipes in C
+void Cholesky_linsol (const RMAT& A, const RVEC& p, const RVEC& b, RVEC& x) {
+    const UINT n = A.size();
+    assert(p.size() == n && b.size() == n);
+    x.resize(n);
+
+    for (UINT i = 0; i < n; ++i) {
+        REAL sum = b[i];
+        for (UINT k = 0; k < i; ++k)
+            sum -= A[i][k] * x[k];
+        x[i] = sum / p[i];
+    }
+    for (UINT i = n; i--;) {
+        REAL sum = x[i];
+        for (UINT k = i+1; k < n; ++k)
+            sum -= A[k][i] * x[k];
+        x[i] = sum / p[i];
+    }
+}
+
+bool ldivide (RMAT& A, const RVEC& b, RVEC& x) {
+    const UINT n = A.size();
+    assert(b.size() == n);
+    RVEC p(n);
+    if (!Cholesky_decomp(A, p)) return false;
+    Cholesky_linsol(A, p, b, x);
+    return true;
+}

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/utility.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/utility.h
@@ -1,0 +1,56 @@
+// -*- C++ -*-
+#ifndef __LEMGA_UTILITY_H__
+#define __LEMGA_UTILITY_H__
+
+/** @file
+ *  @brief Some utility functions.
+ *
+ *  $Id: utility.h 2631 2006-02-08 21:58:14Z ling $
+ */
+
+#include <vector>
+#include "object.h"
+
+/** Solve inv(@a A) * @a b, when @a A is symmetric and positive-definite.
+ *  Actually we only need the upper triangular part of @a A.
+ */
+bool ldivide (std::vector<std::vector<REAL> >& A,
+              const std::vector<REAL>& b, std::vector<REAL>& x);
+
+/// Gray code: start from all 0's, and iteratively go through all numbers
+template<class N>
+bool gray_next (std::vector<N>& v, typename std::vector<N>::size_type& p) {
+    typename std::vector<N>::size_type n = v.size();
+    assert(n > 0);
+
+    // by default we alter the last bit
+    p = n - 1;
+    bool more = true;
+
+    // find the largest n such that v[n] == 1
+    while (--n && v[n] == 0) /* empty */;
+
+    if (n > 0) {
+        typename std::vector<N>::size_type j = n;
+        bool xor_sum = true;
+        while (n--)
+            xor_sum = xor_sum ^ (v[n] != 0);
+        if (xor_sum) p = j - 1;
+    } else if (v[0] != 0) {
+        p = 0; more = false;
+    }
+    v[p] = (v[p] == 0);
+    return more;
+}
+
+template<class N>
+bool gray_next (std::vector<N>& v) {
+    typename std::vector<N>::size_type p;
+    return gray_next(v, p);
+}
+
+#ifdef  __UTILITY_H__
+#warning "This header file may conflict with another `utility.h' file."
+#endif
+#define __UTILITY_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/vectorop.h
+++ b/skordinal/classifiers/src/orensemble/python/lemga-20060516/lemga/vectorop.h
@@ -1,0 +1,88 @@
+// -*- C++ -*-
+#ifndef __STL_ADDON_VECTOROP_H__
+#define __STL_ADDON_VECTOROP_H__
+
+/** @file
+ *  @brief Add basic arithmetic support to @c vector.
+ *
+ *  Let @a u and @a v be two vectos and @a r be a scalar. This file defines
+ *  the following operators:
+ *   - @a u += @a v
+ *   - -\a v
+ *   - @a v *= @a r
+ *   - inner_product<@a typename> (@a u, @a v)
+ *
+ *  @note The template can `recursively' apply itself to vectors of vectors,
+ *  such as two matrices of real numbers could add up (if they have the
+ *  same size).
+ *
+ *  @warning @a u, @a v, and @a r can have different base types. For example,
+ *  if @a u is a double vector and @a v an integer vector. When an
+ *  inappropriate coercion happens, the compiler may complain (with @c gcc,
+ *  turn options @c -Wconversion or @c -Wall on).
+ *
+ *  $Id: vectorop.h 1907 2004-12-11 00:51:14Z ling $
+ */
+
+#include <assert.h>
+#include <vector>
+
+namespace lemga {
+namespace op {
+
+using std::vector;
+
+/// @a u += @a v.
+template <typename R, typename N>
+vector<R>& operator+= (vector<R>& u, const vector<N>& v) {
+    assert(u.size() == v.size());
+    typename vector<R>::iterator x = u.begin();
+    typename vector<N>::const_iterator y = v.begin();
+    for (; x != u.end(); ++x, ++y) *x += *y;
+    return u;
+}
+
+/// -@a v.
+template <typename R>
+vector<R> operator- (const vector<R>& v) {
+    vector<R> s(v);
+    for (typename vector<R>::iterator x = s.begin(); x != s.end(); ++x)
+        *x = -*x;
+    return s;
+}
+
+/** @brief Inner product of @a u and @a v.
+ *
+ *  The return type has to be explicitly specified, e.g.,\n
+ *  <code>double ip = inner_product<double>(u, v);</code>\n
+ *  The compiler will still complain if there is `downward' coercion.
+ */
+template <typename R, typename N>
+inline R inner_product (const R& u, const N& v) {
+    return u * v;
+}
+template <typename RET, typename R, typename N>
+RET inner_product (const vector<R>& u, const vector<N>& v) {
+    assert(u.size() == v.size());
+    RET s(0);
+    typename vector<R>::const_iterator x = u.begin();
+    typename vector<N>::const_iterator y = v.begin();
+    for (; x != u.end(); ++x, ++y) s += inner_product<RET>(*x, *y);
+    return s;
+}
+
+/// @a v *= @a r.
+template <typename R, typename N>
+vector<R>& operator*= (vector<R>& v, const N& r) {
+    for (typename vector<R>::iterator x = v.begin(); x != v.end(); ++x)
+        *x *= r;
+    return v;
+}
+
+}} // namespace lemga::op
+
+#ifdef  __VECTOROP_H__
+#warning "This header file may conflict with another `vectorop.h' file."
+#endif
+#define __VECTOROP_H__
+#endif

--- a/skordinal/classifiers/src/orensemble/python/libsvm-2.81/svm.cpp
+++ b/skordinal/classifiers/src/orensemble/python/libsvm-2.81/svm.cpp
@@ -1,0 +1,3164 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <float.h>
+#include <string.h>
+#include <stdarg.h>
+#include "svm.h"
+typedef float Qfloat;
+typedef signed char schar;
+#ifndef min
+template <class T> inline T min(T x,T y) { return (x<y)?x:y; }
+#endif
+#ifndef max
+template <class T> inline T max(T x,T y) { return (x>y)?x:y; }
+#endif
+template <class T> inline void swap(T& x, T& y) { T t=x; x=y; y=t; }
+template <class S, class T> inline void clone(T*& dst, S* src, int n)
+{
+	dst = new T[n];
+	memcpy((void *)dst,(void *)src,sizeof(T)*n);
+}
+#define INF HUGE_VAL
+#define TAU 1e-12
+#define Malloc(type,n) (type *)malloc((n)*sizeof(type))
+#if 1
+void info(char *fmt,...)
+{
+	va_list ap;
+	va_start(ap,fmt);
+	vprintf(fmt,ap);
+	va_end(ap);
+}
+void info_flush()
+{
+	fflush(stdout);
+}
+#else
+void info(char *fmt,...) {}
+void info_flush() {}
+#endif
+
+//
+// Kernel Cache
+//
+// l is the number of total data items
+// size is the cache size limit in bytes
+//
+class Cache
+{
+public:
+	Cache(int l,int size);
+	~Cache();
+
+	// request data [0,len)
+	// return some position p where [p,len) need to be filled
+	// (p >= len if nothing needs to be filled)
+	int get_data(const int index, Qfloat **data, int len);
+	void swap_index(int i, int j);	// future_option
+private:
+	int l;
+	int size;
+	struct head_t
+	{
+		head_t *prev, *next;	// a cicular list
+		Qfloat *data;
+		int len;		// data[0,len) is cached in this entry
+	};
+
+	head_t *head;
+	head_t lru_head;
+	void lru_delete(head_t *h);
+	void lru_insert(head_t *h);
+};
+
+Cache::Cache(int l_,int size_):l(l_),size(size_)
+{
+	head = (head_t *)calloc(l,sizeof(head_t));	// initialized to 0
+	size /= sizeof(Qfloat);
+	size -= l * sizeof(head_t) / sizeof(Qfloat);
+	size = max(size, 2*l);	// cache must be large enough for two columns
+	lru_head.next = lru_head.prev = &lru_head;
+}
+
+Cache::~Cache()
+{
+	for(head_t *h = lru_head.next; h != &lru_head; h=h->next)
+		free(h->data);
+	free(head);
+}
+
+void Cache::lru_delete(head_t *h)
+{
+	// delete from current location
+	h->prev->next = h->next;
+	h->next->prev = h->prev;
+}
+
+void Cache::lru_insert(head_t *h)
+{
+	// insert to last position
+	h->next = &lru_head;
+	h->prev = lru_head.prev;
+	h->prev->next = h;
+	h->next->prev = h;
+}
+
+int Cache::get_data(const int index, Qfloat **data, int len)
+{
+	head_t *h = &head[index];
+	if(h->len) lru_delete(h);
+	int more = len - h->len;
+
+	if(more > 0)
+	{
+		// free old space
+		while(size < more)
+		{
+			head_t *old = lru_head.next;
+			lru_delete(old);
+			free(old->data);
+			size += old->len;
+			old->data = 0;
+			old->len = 0;
+		}
+
+		// allocate new space
+		h->data = (Qfloat *)realloc(h->data,sizeof(Qfloat)*len);
+		size -= more;
+		swap(h->len,len);
+	}
+
+	lru_insert(h);
+	*data = h->data;
+	return len;
+}
+
+void Cache::swap_index(int i, int j)
+{
+	if(i==j) return;
+
+	if(head[i].len) lru_delete(&head[i]);
+	if(head[j].len) lru_delete(&head[j]);
+	swap(head[i].data,head[j].data);
+	swap(head[i].len,head[j].len);
+	if(head[i].len) lru_insert(&head[i]);
+	if(head[j].len) lru_insert(&head[j]);
+
+	if(i>j) swap(i,j);
+	for(head_t *h = lru_head.next; h!=&lru_head; h=h->next)
+	{
+		if(h->len > i)
+		{
+			if(h->len > j)
+				swap(h->data[i],h->data[j]);
+			else
+			{
+				// give up
+				lru_delete(h);
+				free(h->data);
+				size += h->len;
+				h->data = 0;
+				h->len = 0;
+			}
+		}
+	}
+}
+
+//
+// Kernel evaluation
+//
+// the static method k_function is for doing single kernel evaluation
+// the constructor of Kernel prepares to calculate the l*l kernel matrix
+// the member function get_Q is for getting one column from the Q Matrix
+//
+class QMatrix {
+public:
+	virtual Qfloat *get_Q(int column, int len) const = 0;
+	virtual Qfloat *get_QD() const = 0;
+	virtual void swap_index(int i, int j) const = 0;
+	virtual ~QMatrix() {}
+};
+
+class Kernel: public QMatrix {
+public:
+	Kernel(int l, svm_node * const * x, const svm_parameter& param);
+	virtual ~Kernel();
+
+	static double k_function(const svm_node *x, const svm_node *y,
+				 const svm_parameter& param);
+	virtual Qfloat *get_Q(int column, int len) const = 0;
+	virtual Qfloat *get_QD() const = 0;
+	virtual void swap_index(int i, int j) const	// no so const...
+	{
+		swap(x[i],x[j]);
+		if(x_square) swap(x_square[i],x_square[j]);
+	}
+protected:
+
+	double (Kernel::*kernel_function)(int i, int j) const;
+
+private:
+	const svm_node **x;
+	double *x_square;
+
+	// svm_parameter
+	const int kernel_type;
+	const double degree;
+	const double gamma;
+	const double coef0;
+
+	static double dot(const svm_node *px, const svm_node *py);
+	static double norm_1(const svm_node *, const svm_node *);
+	static double norm_2(const svm_node *, const svm_node *);
+	double kernel_linear(int i, int j) const
+	{
+		return dot(x[i],x[j]);
+	}
+	double kernel_poly(int i, int j) const
+	{
+		return pow(gamma*dot(x[i],x[j])+coef0,degree);
+	}
+	double kernel_rbf(int i, int j) const
+	{
+		return exp(-gamma*(x_square[i]+x_square[j]-2*dot(x[i],x[j])));
+	}
+	double kernel_sigmoid(int i, int j) const
+	{
+		return tanh(gamma*dot(x[i],x[j])+coef0);
+	}
+	double kernel_stump(int i, int j) const
+	{
+		return -norm_1(x[i],x[j]);
+	}
+	double kernel_perceptron(int i, int j) const
+	{
+		double n2 = x_square[i]+x_square[j]-2*dot(x[i],x[j]);
+		return (n2>0)? -sqrt(n2) : 0;
+	}
+};
+
+Kernel::Kernel(int l, svm_node * const * x_, const svm_parameter& param)
+:kernel_type(param.kernel_type), degree(param.degree),
+ gamma(param.gamma), coef0(param.coef0)
+{
+	switch(kernel_type)
+	{
+		case LINEAR:
+			kernel_function = &Kernel::kernel_linear;
+			break;
+		case POLY:
+			kernel_function = &Kernel::kernel_poly;
+			break;
+		case RBF:
+			kernel_function = &Kernel::kernel_rbf;
+			break;
+		case SIGMOID:
+			kernel_function = &Kernel::kernel_sigmoid;
+			break;
+		case STUMP:
+			kernel_function = &Kernel::kernel_stump;
+			break;
+		case PERCEPTRON:
+			kernel_function = &Kernel::kernel_perceptron;
+			break;
+	}
+
+	clone(x,x_,l);
+
+	if(kernel_type == RBF || kernel_type == PERCEPTRON)
+	{
+		x_square = new double[l];
+		for(int i=0;i<l;i++)
+			x_square[i] = dot(x[i],x[i]);
+	}
+	else
+		x_square = 0;
+}
+
+Kernel::~Kernel()
+{
+	delete[] x;
+	delete[] x_square;
+}
+
+double Kernel::dot(const svm_node *px, const svm_node *py)
+{
+	double sum = 0;
+	while(px->index != -1 && py->index != -1)
+	{
+		if(px->index == py->index)
+		{
+			sum += px->value * py->value;
+			++px;
+			++py;
+		}
+		else
+		{
+			if(px->index > py->index)
+				++py;
+			else
+				++px;
+		}			
+	}
+	return sum;
+}
+
+double svm_kernel(const svm_node *x, const svm_node *y,
+		  const svm_parameter& param)
+{
+	return Kernel::k_function(x, y, param);
+}
+
+double Kernel::norm_1(const svm_node *x, const svm_node *y)
+{
+	double sum = 0;
+	while (x->index != -1 && y->index != -1)
+	{
+		if (x->index == y->index)
+		{
+			sum += fabs(x->value - y->value);
+			++x;
+			++y;
+		}
+		else if (x->index > y->index)
+		{
+			sum += fabs(y->value);
+			++y;
+		}
+		else
+		{
+			sum += fabs(x->value);
+			++x;
+		}
+	}
+	while (x->index != -1)
+	{
+		sum += fabs(x->value);
+		++x;
+	}
+	while (y->index != -1)
+	{
+		sum += fabs(y->value);
+		++y;
+	}
+	return sum;
+}
+
+double Kernel::norm_2(const svm_node *x, const svm_node *y)
+{
+	double sum = 0;
+	while (x->index != -1 && y->index !=-1)
+	{
+		if (x->index == y->index)
+		{
+			double d = x->value - y->value;
+			sum += d*d;
+			++x;
+			++y;
+		}
+		else if (x->index > y->index)
+		{	
+			sum += y->value * y->value;
+			++y;
+		}
+		else
+		{
+			sum += x->value * x->value;
+			++x;
+		}
+	}
+	while (x->index != -1)
+	{
+		sum += x->value * x->value;
+		++x;
+	}
+	while (y->index != -1)
+	{
+		sum += y->value * y->value;
+		++y;
+	}
+	return sum;
+}
+
+double Kernel::k_function(const svm_node *x, const svm_node *y,
+			  const svm_parameter& param)
+{
+	switch(param.kernel_type)
+	{
+		case LINEAR:
+			return dot(x,y);
+		case POLY:
+			return pow(param.gamma*dot(x,y)+param.coef0,param.degree);
+		case RBF:
+			return exp(-param.gamma*norm_2(x,y));
+		case SIGMOID:
+			return tanh(param.gamma*dot(x,y)+param.coef0);
+		case STUMP:
+			return -norm_1(x,y);
+		case PERCEPTRON:
+			return -sqrt(norm_2(x,y));
+		default:
+			return 0;	/* Unreachable */
+	}
+}
+
+// Generalized SMO+SVMlight algorithm
+// Solves:
+//
+//	min 0.5(\alpha^T Q \alpha) + b^T \alpha
+//
+//		y^T \alpha = \delta
+//		y_i = +1 or -1
+//		0 <= alpha_i <= Cp for y_i = 1
+//		0 <= alpha_i <= Cn for y_i = -1
+//
+// Given:
+//
+//	Q, b, y, Cp, Cn, and an initial feasible point \alpha
+//	l is the size of vectors and matrices
+//	eps is the stopping criterion
+//
+// solution will be put in \alpha, objective value will be put in obj
+//
+class Solver {
+public:
+	Solver() {};
+	virtual ~Solver() {};
+
+	struct SolutionInfo {
+		double obj;
+		double rho;
+		double upper_bound_p;
+		double upper_bound_n;
+		double r;	// for Solver_NU
+	};
+
+	/** the solver with different C_i */
+	void Solve(int l, const QMatrix& Q, const double *b_, const schar *y_,
+		   double *alpha_, const double *C_, double eps,
+		   SolutionInfo* si, int shrinking);
+
+	void Solve(int l, const QMatrix& Q, const double *b_, const schar *y_,
+		   double *alpha_, double Cp, double Cn, double eps,
+		   SolutionInfo* si, int shrinking);
+protected:
+	int active_size;
+	schar *y;
+	double *G;		// gradient of objective function
+
+	/** the enum is removed to allow examples to be both at
+	    the upper bound and at the lower bound (if C = 0)
+	enum { LOWER_BOUND, UPPER_BOUND, FREE };
+	*/
+	static const char FREE = 0;
+	static const char LOWER_BOUND = 1; // bit 1
+	static const char UPPER_BOUND = 2; // bit 2
+
+	char *alpha_status;	// LOWER_BOUND, UPPER_BOUND, FREE
+	double *alpha;
+	const QMatrix *Q;
+	const Qfloat *QD;
+	double eps;
+	double *C; // the weighted C_i
+	double *b;
+	int *active_set;
+	double *G_bar;		// gradient, if we treat free variables as 0
+	int l;
+	bool unshrinked;	// XXX
+
+	double get_C(int i)
+	{
+		return C[i];
+	}
+	/** the following modification is for maintaining the alpha_status */
+	void update_alpha_status(int i)
+	{
+		alpha_status[i] = FREE;
+		if (alpha[i] <= 0)
+			alpha_status[i] |= LOWER_BOUND;
+		if (alpha[i] >= get_C(i))
+			alpha_status[i] |= UPPER_BOUND;
+	}
+	bool is_upper_bound(int i) { return alpha_status[i] & UPPER_BOUND; }
+	bool is_lower_bound(int i) { return alpha_status[i] & LOWER_BOUND; }
+	bool is_free(int i) { return alpha_status[i] == FREE; }
+	void swap_index(int i, int j);
+	void reconstruct_gradient();
+	virtual int select_working_set(int &i, int &j);
+	virtual int max_violating_pair(int &i, int &j);
+	virtual double calculate_rho();
+	virtual void do_shrinking();
+};
+
+void Solver::swap_index(int i, int j)
+{
+	Q->swap_index(i,j);
+	swap(y[i],y[j]);
+	swap(G[i],G[j]);
+	swap(alpha_status[i],alpha_status[j]);
+	swap(alpha[i],alpha[j]);
+	swap(b[i],b[j]);
+	swap(active_set[i],active_set[j]);
+	swap(G_bar[i],G_bar[j]);
+	swap(C[i], C[j]);
+}
+
+void Solver::reconstruct_gradient()
+{
+	// reconstruct inactive elements of G from G_bar and free variables
+
+	if(active_size == l) return;
+
+	int i;
+	for(i=active_size;i<l;i++)
+		G[i] = G_bar[i] + b[i];
+	
+	for(i=0;i<active_size;i++)
+		if(is_free(i))
+		{
+			const Qfloat *Q_i = Q->get_Q(i,l);
+			double alpha_i = alpha[i];
+			for(int j=active_size;j<l;j++)
+				G[j] += alpha_i * Q_i[j];
+		}
+}
+
+void Solver::Solve(int l, const QMatrix& Q, const double *b_, const schar *y_,
+		   double *alpha_, const double* C_, double eps,
+		   SolutionInfo* si, int shrinking)
+{
+	this->l = l;
+	this->Q = &Q;
+	QD=Q.get_QD();
+	clone(b, b_,l);
+	clone(y, y_,l);
+	clone(alpha,alpha_,l);
+	clone(C, C_, l);
+	this->eps = eps;
+	unshrinked = false;
+
+	// initialize alpha_status
+	{
+		alpha_status = new char[l];
+		for(int i=0;i<l;i++)
+			update_alpha_status(i);
+	}
+
+	// initialize active set (for shrinking)
+	{
+		active_set = new int[l];
+		for(int i=0;i<l;i++)
+			active_set[i] = i;
+		active_size = l;
+	}
+
+	// initialize gradient
+	{
+		G = new double[l];
+		G_bar = new double[l];
+		int i;
+		for(i=0;i<l;i++)
+		{
+			G[i] = b[i];
+			G_bar[i] = 0;
+		}
+		for(i=0;i<l;i++)
+			if(!is_lower_bound(i))
+			{
+				const Qfloat *Q_i = Q.get_Q(i,l);
+				double alpha_i = alpha[i];
+				int j;
+				for(j=0;j<l;j++)
+					G[j] += alpha_i*Q_i[j];
+				if(is_upper_bound(i))
+					for(j=0;j<l;j++)
+						G_bar[j] += get_C(i) * Q_i[j];
+			}
+	}
+
+	// optimization step
+
+	int iter = 0;
+	int counter = min(l,1000)+1;
+
+	while(1)
+	{
+		// show progress and do shrinking
+
+		if(--counter == 0)
+		{
+			counter = min(l,1000);
+			if(shrinking) do_shrinking();
+			info("."); info_flush();
+		}
+
+		int i,j;
+		if(select_working_set(i,j)!=0)
+		{
+			// reconstruct the whole gradient
+			reconstruct_gradient();
+			// reset active set size and check
+			active_size = l;
+			info("*"); info_flush();
+			if(select_working_set(i,j)!=0)
+				break;
+			else
+				counter = 1;	// do shrinking next iteration
+		}
+		
+		++iter;
+
+		// update alpha[i] and alpha[j], handle bounds carefully
+		
+		const Qfloat *Q_i = Q.get_Q(i,active_size);
+		const Qfloat *Q_j = Q.get_Q(j,active_size);
+
+		double C_i = get_C(i);
+		double C_j = get_C(j);
+
+		double old_alpha_i = alpha[i];
+		double old_alpha_j = alpha[j];
+
+		if(y[i]!=y[j])
+		{
+			double quad_coef = Q_i[i]+Q_j[j]+2*Q_i[j];
+			if (quad_coef <= 0)
+				quad_coef = TAU;
+			double delta = (-G[i]-G[j])/quad_coef;
+			double diff = alpha[i] - alpha[j];
+			alpha[i] += delta;
+			alpha[j] += delta;
+			
+			if(diff > 0)
+			{
+				if(alpha[j] < 0)
+				{
+					alpha[j] = 0;
+					alpha[i] = diff;
+				}
+			}
+			else
+			{
+				if(alpha[i] < 0)
+				{
+					alpha[i] = 0;
+					alpha[j] = -diff;
+				}
+			}
+			if(diff > C_i - C_j)
+			{
+				if(alpha[i] > C_i)
+				{
+					alpha[i] = C_i;
+					alpha[j] = C_i - diff;
+				}
+			}
+			else
+			{
+				if(alpha[j] > C_j)
+				{
+					alpha[j] = C_j;
+					alpha[i] = C_j + diff;
+				}
+			}
+		}
+		else
+		{
+			double quad_coef = Q_i[i]+Q_j[j]-2*Q_i[j];
+			if (quad_coef <= 0)
+				quad_coef = TAU;
+			double delta = (G[i]-G[j])/quad_coef;
+			double sum = alpha[i] + alpha[j];
+			alpha[i] -= delta;
+			alpha[j] += delta;
+
+			if(sum > C_i)
+			{
+				if(alpha[i] > C_i)
+				{
+					alpha[i] = C_i;
+					alpha[j] = sum - C_i;
+				}
+			}
+			else
+			{
+				if(alpha[j] < 0)
+				{
+					alpha[j] = 0;
+					alpha[i] = sum;
+				}
+			}
+			if(sum > C_j)
+			{
+				if(alpha[j] > C_j)
+				{
+					alpha[j] = C_j;
+					alpha[i] = sum - C_j;
+				}
+			}
+			else
+			{
+				if(alpha[i] < 0)
+				{
+					alpha[i] = 0;
+					alpha[j] = sum;
+				}
+			}
+		}
+
+		// update G
+
+		double delta_alpha_i = alpha[i] - old_alpha_i;
+		double delta_alpha_j = alpha[j] - old_alpha_j;
+		
+		for(int k=0;k<active_size;k++)
+		{
+			G[k] += Q_i[k]*delta_alpha_i + Q_j[k]*delta_alpha_j;
+		}
+
+		// update alpha_status and G_bar
+
+		{
+			bool ui = is_upper_bound(i);
+			bool uj = is_upper_bound(j);
+			update_alpha_status(i);
+			update_alpha_status(j);
+			int k;
+			if(ui != is_upper_bound(i))
+			{
+				Q_i = Q.get_Q(i,l);
+				if(ui)
+					for(k=0;k<l;k++)
+						G_bar[k] -= C_i * Q_i[k];
+				else
+					for(k=0;k<l;k++)
+						G_bar[k] += C_i * Q_i[k];
+			}
+
+			if(uj != is_upper_bound(j))
+			{
+				Q_j = Q.get_Q(j,l);
+				if(uj)
+					for(k=0;k<l;k++)
+						G_bar[k] -= C_j * Q_j[k];
+				else
+					for(k=0;k<l;k++)
+						G_bar[k] += C_j * Q_j[k];
+			}
+		}
+	}
+
+	// calculate rho
+
+	si->rho = calculate_rho();
+
+	// calculate objective value
+	{
+		double v = 0;
+		int i;
+		for(i=0;i<l;i++)
+			v += alpha[i] * (G[i] + b[i]);
+
+		si->obj = v/2;
+	}
+
+	// put back the solution
+	{
+		for(int i=0;i<l;i++)
+			alpha_[active_set[i]] = alpha[i];
+	}
+
+	// juggle everything back
+	/*{
+		for(int i=0;i<l;i++)
+			while(active_set[i] != i)
+				swap_index(i,active_set[i]);
+				// or Q.swap_index(i,active_set[i]);
+	}*/
+
+	info("\noptimization finished, #iter = %d\n",iter);
+
+	delete[] b;
+	delete[] y;
+	delete[] C;
+	delete[] alpha;
+	delete[] alpha_status;
+	delete[] active_set;
+	delete[] G;
+	delete[] G_bar;
+}
+
+void Solver::Solve(int l, const QMatrix& Q, const double *b_, const schar *y_,
+		   double *alpha_, double Cp, double Cn, double eps,
+		   SolutionInfo* si, int shrinking)
+{
+	double* C_ = new double[l];
+	for (int i = 0; i < l; ++i)
+		C_[i] = (y_[i] > 0 ? Cp : Cn);
+	Solve(l, Q, b_, y_, alpha_, C_, eps, si, shrinking);
+	si->upper_bound_p = Cp;
+	si->upper_bound_n = Cn;
+	delete[] C_;
+}
+
+// return 1 if already optimal, return 0 otherwise
+int Solver::select_working_set(int &out_i, int &out_j)
+{
+	// return i,j such that
+	// i: maximizes -y_i * grad(f)_i, i in I_up(\alpha)
+	// j: minimizes the decrease of obj value
+	//    (if quadratic coefficeint <= 0, replace it with tau)
+	//    -y_j*grad(f)_j < -y_i*grad(f)_i, j in I_low(\alpha)
+	
+	double Gmax = -INF;
+	double Gmax2 = -INF;
+	int Gmax_idx = -1;
+	int Gmin_idx = -1;
+	double obj_diff_min = INF;
+
+	for(int t=0;t<active_size;t++)
+		if(y[t]==+1)	
+		{
+			if(!is_upper_bound(t))
+				if(-G[t] >= Gmax)
+				{
+					Gmax = -G[t];
+					Gmax_idx = t;
+				}
+		}
+		else
+		{
+			if(!is_lower_bound(t))
+				if(G[t] >= Gmax)
+				{
+					Gmax = G[t];
+					Gmax_idx = t;
+				}
+		}
+
+	int i = Gmax_idx;
+	const Qfloat *Q_i = NULL;
+	if(i != -1) // NULL Q_i not accessed: Gmax=-INF if i=-1
+		Q_i = Q->get_Q(i,active_size);
+
+	for(int j=0;j<active_size;j++)
+	{
+		if(y[j]==+1)
+		{
+			if (!is_lower_bound(j))
+			{
+				double grad_diff=Gmax+G[j];
+				if (G[j] >= Gmax2)
+					Gmax2 = G[j];
+				if (grad_diff > 0)
+				{
+					double obj_diff; 
+					double quad_coef=Q_i[i]+QD[j]-2*y[i]*Q_i[j];
+					if (quad_coef > 0)
+						obj_diff = -(grad_diff*grad_diff)/quad_coef;
+					else
+						obj_diff = -(grad_diff*grad_diff)/TAU;
+
+					if (obj_diff <= obj_diff_min)
+					{
+						Gmin_idx=j;
+						obj_diff_min = obj_diff;
+					}
+				}
+			}
+		}
+		else
+		{
+			if (!is_upper_bound(j))
+			{
+				double grad_diff= Gmax-G[j];
+				if (-G[j] >= Gmax2)
+					Gmax2 = -G[j];
+				if (grad_diff > 0)
+				{
+					double obj_diff; 
+					double quad_coef=Q_i[i]+QD[j]+2*y[i]*Q_i[j];
+					if (quad_coef > 0)
+						obj_diff = -(grad_diff*grad_diff)/quad_coef;
+					else
+						obj_diff = -(grad_diff*grad_diff)/TAU;
+
+					if (obj_diff <= obj_diff_min)
+					{
+						Gmin_idx=j;
+						obj_diff_min = obj_diff;
+					}
+				}
+			}
+		}
+	}
+
+	if(Gmax+Gmax2 < eps)
+		return 1;
+
+	out_i = Gmax_idx;
+	out_j = Gmin_idx;
+	return 0;
+}
+
+// return 1 if already optimal, return 0 otherwise
+int Solver::max_violating_pair(int &out_i, int &out_j)
+{
+	// return i,j: maximal violating pair
+
+	double Gmax1 = -INF;		// max { -y_i * grad(f)_i | i in I_up(\alpha) }
+	int Gmax1_idx = -1;
+
+	double Gmax2 = -INF;		// max { y_i * grad(f)_i | i in I_low(\alpha) }
+	int Gmax2_idx = -1;
+
+	for(int i=0;i<active_size;i++)
+	{
+		if(y[i]==+1)	// y = +1
+		{
+			if(!is_upper_bound(i))	// d = +1
+			{
+				if(-G[i] >= Gmax1)
+				{
+					Gmax1 = -G[i];
+					Gmax1_idx = i;
+				}
+			}
+			if(!is_lower_bound(i))	// d = -1
+			{
+				if(G[i] >= Gmax2)
+				{
+					Gmax2 = G[i];
+					Gmax2_idx = i;
+				}
+			}
+		}
+		else		// y = -1
+		{
+			if(!is_upper_bound(i))	// d = +1
+			{
+				if(-G[i] >= Gmax2)
+				{
+					Gmax2 = -G[i];
+					Gmax2_idx = i;
+				}
+			}
+			if(!is_lower_bound(i))	// d = -1
+			{
+				if(G[i] >= Gmax1)
+				{
+					Gmax1 = G[i];
+					Gmax1_idx = i;
+				}
+			}
+		}
+	}
+
+	if(Gmax1+Gmax2 < eps)
+ 		return 1;
+
+	out_i = Gmax1_idx;
+	out_j = Gmax2_idx;
+	return 0;
+}
+
+void Solver::do_shrinking()
+{
+	int i,j,k;
+	if(max_violating_pair(i,j)!=0) return;
+	double Gm1 = -y[j]*G[j];
+	double Gm2 = y[i]*G[i];
+
+	// shrink
+	
+	for(k=0;k<active_size;k++)
+	{
+		if(is_lower_bound(k))
+		{
+			if(y[k]==+1)
+			{
+				if(-G[k] >= Gm1) continue;
+			}
+			else	if(-G[k] >= Gm2) continue;
+		}
+		else if(is_upper_bound(k))
+		{
+			if(y[k]==+1)
+			{
+				if(G[k] >= Gm2) continue;
+			}
+			else	if(G[k] >= Gm1) continue;
+		}
+		else continue;
+
+		--active_size;
+		swap_index(k,active_size);
+		--k;	// look at the newcomer
+	}
+
+	// unshrink, check all variables again before final iterations
+
+	if(unshrinked || -(Gm1 + Gm2) > eps*10) return;
+	
+	unshrinked = true;
+	reconstruct_gradient();
+
+	for(k=l-1;k>=active_size;k--)
+	{
+		if(is_lower_bound(k))
+		{
+			if(y[k]==+1)
+			{
+				if(-G[k] < Gm1) continue;
+			}
+			else	if(-G[k] < Gm2) continue;
+		}
+		else if(is_upper_bound(k))
+		{
+			if(y[k]==+1)
+			{
+				if(G[k] < Gm2) continue;
+			}
+			else	if(G[k] < Gm1) continue;
+		}
+		else continue;
+
+		swap_index(k,active_size);
+		active_size++;
+		++k;	// look at the newcomer
+	}
+}
+
+double Solver::calculate_rho()
+{
+	double r;
+	int nr_free = 0;
+	double ub = INF, lb = -INF, sum_free = 0;
+	for(int i=0;i<active_size;i++)
+	{
+		double yG = y[i]*G[i];
+
+		if(is_lower_bound(i))
+		{
+			if(y[i] > 0)
+				ub = min(ub,yG);
+			else
+				lb = max(lb,yG);
+		}
+		else if(is_upper_bound(i))
+		{
+			if(y[i] < 0)
+				ub = min(ub,yG);
+			else
+				lb = max(lb,yG);
+		}
+		else
+		{
+			++nr_free;
+			sum_free += yG;
+		}
+	}
+
+	if(nr_free>0)
+		r = sum_free/nr_free;
+	else
+		r = (ub+lb)/2;
+
+	return r;
+}
+
+//
+// Solver for nu-svm classification and regression
+//
+// additional constraint: e^T \alpha = constant
+//
+class Solver_NU : public Solver
+{
+public:
+	Solver_NU() {}
+	void Solve(int l, const QMatrix& Q, const double *b, const schar *y,
+		   double *alpha, double Cp, double Cn, double eps,
+		   SolutionInfo* si, int shrinking)
+	{
+		this->si = si;
+		Solver::Solve(l,Q,b,y,alpha,Cp,Cn,eps,si,shrinking);
+	}
+private:
+	SolutionInfo *si;
+	int select_working_set(int &i, int &j);
+	double calculate_rho();
+	void do_shrinking();
+};
+
+// return 1 if already optimal, return 0 otherwise
+int Solver_NU::select_working_set(int &out_i, int &out_j)
+{
+	// return i,j such that y_i = y_j and
+	// i: maximizes -y_i * grad(f)_i, i in I_up(\alpha)
+	// j: minimizes the decrease of obj value
+	//    (if quadratic coefficeint <= 0, replace it with tau)
+	//    -y_j*grad(f)_j < -y_i*grad(f)_i, j in I_low(\alpha)
+
+	double Gmaxp = -INF;
+	double Gmaxp2 = -INF;
+	int Gmaxp_idx = -1;
+
+	double Gmaxn = -INF;
+	double Gmaxn2 = -INF;
+	int Gmaxn_idx = -1;
+
+	int Gmin_idx = -1;
+	double obj_diff_min = INF;
+
+	for(int t=0;t<active_size;t++)
+		if(y[t]==+1)
+		{
+			if(!is_upper_bound(t))
+				if(-G[t] >= Gmaxp)
+				{
+					Gmaxp = -G[t];
+					Gmaxp_idx = t;
+				}
+		}
+		else
+		{
+			if(!is_lower_bound(t))
+				if(G[t] >= Gmaxn)
+				{
+					Gmaxn = G[t];
+					Gmaxn_idx = t;
+				}
+		}
+
+	int ip = Gmaxp_idx;
+	int in = Gmaxn_idx;
+	const Qfloat *Q_ip = NULL;
+	const Qfloat *Q_in = NULL;
+	if(ip != -1) // NULL Q_ip not accessed: Gmaxp=-INF if ip=-1
+		Q_ip = Q->get_Q(ip,active_size);
+	if(in != -1)
+		Q_in = Q->get_Q(in,active_size);
+
+	for(int j=0;j<active_size;j++)
+	{
+		if(y[j]==+1)
+		{
+			if (!is_lower_bound(j))	
+			{
+				double grad_diff=Gmaxp+G[j];
+				if (G[j] >= Gmaxp2)
+					Gmaxp2 = G[j];
+				if (grad_diff > 0)
+				{
+					double obj_diff; 
+					double quad_coef = Q_ip[ip]+QD[j]-2*Q_ip[j];
+					if (quad_coef > 0)
+						obj_diff = -(grad_diff*grad_diff)/quad_coef;
+					else
+						obj_diff = -(grad_diff*grad_diff)/TAU;
+
+					if (obj_diff <= obj_diff_min)
+					{
+						Gmin_idx=j;
+						obj_diff_min = obj_diff;
+					}
+				}
+			}
+		}
+		else
+		{
+			if (!is_upper_bound(j))
+			{
+				double grad_diff=Gmaxn-G[j];
+				if (-G[j] >= Gmaxn2)
+					Gmaxn2 = -G[j];
+				if (grad_diff > 0)
+				{
+					double obj_diff; 
+					double quad_coef = Q_in[in]+QD[j]-2*Q_in[j];
+					if (quad_coef > 0)
+						obj_diff = -(grad_diff*grad_diff)/quad_coef;
+					else
+						obj_diff = -(grad_diff*grad_diff)/TAU;
+
+					if (obj_diff <= obj_diff_min)
+					{
+						Gmin_idx=j;
+						obj_diff_min = obj_diff;
+					}
+				}
+			}
+		}
+	}
+
+	if(max(Gmaxp+Gmaxp2,Gmaxn+Gmaxn2) < eps)
+ 		return 1;
+
+	if (y[Gmin_idx] == +1)
+		out_i = Gmaxp_idx;
+	else
+		out_i = Gmaxn_idx;
+	out_j = Gmin_idx;
+
+	return 0;
+}
+
+void Solver_NU::do_shrinking()
+{
+	double Gmax1 = -INF;	// max { -y_i * grad(f)_i | y_i = +1, i in I_up(\alpha) }
+	double Gmax2 = -INF;	// max { y_i * grad(f)_i | y_i = +1, i in I_low(\alpha) }
+	double Gmax3 = -INF;	// max { -y_i * grad(f)_i | y_i = -1, i in I_up(\alpha) }
+	double Gmax4 = -INF;	// max { y_i * grad(f)_i | y_i = -1, i in I_low(\alpha) }
+
+	// find maximal violating pair first
+	int k;
+	for(k=0;k<active_size;k++)
+	{
+		if(!is_upper_bound(k))
+		{
+			if(y[k]==+1)
+			{
+				if(-G[k] > Gmax1) Gmax1 = -G[k];
+			}
+			else	if(-G[k] > Gmax3) Gmax3 = -G[k];
+		}
+		if(!is_lower_bound(k))
+		{
+			if(y[k]==+1)
+			{	
+				if(G[k] > Gmax2) Gmax2 = G[k];
+			}
+			else	if(G[k] > Gmax4) Gmax4 = G[k];
+		}
+	}
+
+	// shrinking
+
+	double Gm1 = -Gmax2;
+	double Gm2 = -Gmax1;
+	double Gm3 = -Gmax4;
+	double Gm4 = -Gmax3;
+
+	for(k=0;k<active_size;k++)
+	{
+		if(is_lower_bound(k))
+		{
+			if(y[k]==+1)
+			{
+				if(-G[k] >= Gm1) continue;
+			}
+			else	if(-G[k] >= Gm3) continue;
+		}
+		else if(is_upper_bound(k))
+		{
+			if(y[k]==+1)
+			{
+				if(G[k] >= Gm2) continue;
+			}
+			else	if(G[k] >= Gm4) continue;
+		}
+		else continue;
+
+		--active_size;
+		swap_index(k,active_size);
+		--k;	// look at the newcomer
+	}
+
+	// unshrink, check all variables again before final iterations
+
+	if(unshrinked || max(-(Gm1+Gm2),-(Gm3+Gm4)) > eps*10) return;
+	
+	unshrinked = true;
+	reconstruct_gradient();
+
+	for(k=l-1;k>=active_size;k--)
+	{
+		if(is_lower_bound(k))
+		{
+			if(y[k]==+1)
+			{
+				if(-G[k] < Gm1) continue;
+			}
+			else	if(-G[k] < Gm3) continue;
+		}
+		else if(is_upper_bound(k))
+		{
+			if(y[k]==+1)
+			{
+				if(G[k] < Gm2) continue;
+			}
+			else	if(G[k] < Gm4) continue;
+		}
+		else continue;
+
+		swap_index(k,active_size);
+		active_size++;
+		++k;	// look at the newcomer
+	}
+}
+
+double Solver_NU::calculate_rho()
+{
+	int nr_free1 = 0,nr_free2 = 0;
+	double ub1 = INF, ub2 = INF;
+	double lb1 = -INF, lb2 = -INF;
+	double sum_free1 = 0, sum_free2 = 0;
+
+	for(int i=0;i<active_size;i++)
+	{
+		if(y[i]==+1)
+		{
+			if(is_lower_bound(i))
+				ub1 = min(ub1,G[i]);
+			else if(is_upper_bound(i))
+				lb1 = max(lb1,G[i]);
+			else
+			{
+				++nr_free1;
+				sum_free1 += G[i];
+			}
+		}
+		else
+		{
+			if(is_lower_bound(i))
+				ub2 = min(ub2,G[i]);
+			else if(is_upper_bound(i))
+				lb2 = max(lb2,G[i]);
+			else
+			{
+				++nr_free2;
+				sum_free2 += G[i];
+			}
+		}
+	}
+
+	double r1,r2;
+	if(nr_free1 > 0)
+		r1 = sum_free1/nr_free1;
+	else
+		r1 = (ub1+lb1)/2;
+	
+	if(nr_free2 > 0)
+		r2 = sum_free2/nr_free2;
+	else
+		r2 = (ub2+lb2)/2;
+	
+	si->r = (r1+r2)/2;
+	return (r1-r2)/2;
+}
+
+//
+// Q matrices for various formulations
+//
+class SVC_Q: public Kernel
+{ 
+public:
+	SVC_Q(const svm_problem& prob, const svm_parameter& param, const schar *y_)
+	:Kernel(prob.l, prob.x, param)
+	{
+		clone(y,y_,prob.l);
+		cache = new Cache(prob.l,(int)(param.cache_size*(1<<20)));
+		QD = new Qfloat[prob.l];
+		for(int i=0;i<prob.l;i++)
+			QD[i]= (Qfloat)(this->*kernel_function)(i,i);
+	}
+	
+	Qfloat *get_Q(int i, int len) const
+	{
+		Qfloat *data;
+		int start;
+		if((start = cache->get_data(i,&data,len)) < len)
+		{
+			for(int j=start;j<len;j++)
+				data[j] = (Qfloat)(y[i]*y[j]*(this->*kernel_function)(i,j));
+		}
+		return data;
+	}
+
+	Qfloat *get_QD() const
+	{
+		return QD;
+	}
+
+	void swap_index(int i, int j) const
+	{
+		cache->swap_index(i,j);
+		Kernel::swap_index(i,j);
+		swap(y[i],y[j]);
+		swap(QD[i],QD[j]);
+	}
+
+	~SVC_Q()
+	{
+		delete[] y;
+		delete cache;
+		delete[] QD;
+	}
+private:
+	schar *y;
+	Cache *cache;
+	Qfloat *QD;
+};
+
+class ONE_CLASS_Q: public Kernel
+{
+public:
+	ONE_CLASS_Q(const svm_problem& prob, const svm_parameter& param)
+	:Kernel(prob.l, prob.x, param)
+	{
+		cache = new Cache(prob.l,(int)(param.cache_size*(1<<20)));
+		QD = new Qfloat[prob.l];
+		for(int i=0;i<prob.l;i++)
+			QD[i]= (Qfloat)(this->*kernel_function)(i,i);
+	}
+	
+	Qfloat *get_Q(int i, int len) const
+	{
+		Qfloat *data;
+		int start;
+		if((start = cache->get_data(i,&data,len)) < len)
+		{
+			for(int j=start;j<len;j++)
+				data[j] = (Qfloat)(this->*kernel_function)(i,j);
+		}
+		return data;
+	}
+
+	Qfloat *get_QD() const
+	{
+		return QD;
+	}
+
+	void swap_index(int i, int j) const
+	{
+		cache->swap_index(i,j);
+		Kernel::swap_index(i,j);
+		swap(QD[i],QD[j]);
+	}
+
+	~ONE_CLASS_Q()
+	{
+		delete cache;
+		delete[] QD;
+	}
+private:
+	Cache *cache;
+	Qfloat *QD;
+};
+
+class SVR_Q: public Kernel
+{ 
+public:
+	SVR_Q(const svm_problem& prob, const svm_parameter& param)
+	:Kernel(prob.l, prob.x, param)
+	{
+		l = prob.l;
+		cache = new Cache(l,(int)(param.cache_size*(1<<20)));
+		QD = new Qfloat[2*l];
+		sign = new schar[2*l];
+		index = new int[2*l];
+		for(int k=0;k<l;k++)
+		{
+			sign[k] = 1;
+			sign[k+l] = -1;
+			index[k] = k;
+			index[k+l] = k;
+			QD[k]= (Qfloat)(this->*kernel_function)(k,k);
+			QD[k+l]=QD[k];
+		}
+		buffer[0] = new Qfloat[2*l];
+		buffer[1] = new Qfloat[2*l];
+		next_buffer = 0;
+	}
+
+	void swap_index(int i, int j) const
+	{
+		swap(sign[i],sign[j]);
+		swap(index[i],index[j]);
+		swap(QD[i],QD[j]);
+	}
+	
+	Qfloat *get_Q(int i, int len) const
+	{
+		Qfloat *data;
+		int real_i = index[i];
+		if(cache->get_data(real_i,&data,l) < l)
+		{
+			for(int j=0;j<l;j++)
+				data[j] = (Qfloat)(this->*kernel_function)(real_i,j);
+		}
+
+		// reorder and copy
+		Qfloat *buf = buffer[next_buffer];
+		next_buffer = 1 - next_buffer;
+		schar si = sign[i];
+		for(int j=0;j<len;j++)
+			buf[j] = si * sign[j] * data[index[j]];
+		return buf;
+	}
+
+	Qfloat *get_QD() const
+	{
+		return QD;
+	}
+
+	~SVR_Q()
+	{
+		delete cache;
+		delete[] sign;
+		delete[] index;
+		delete[] buffer[0];
+		delete[] buffer[1];
+		delete[] QD;
+	}
+private:
+	int l;
+	Cache *cache;
+	schar *sign;
+	int *index;
+	mutable int next_buffer;
+	Qfloat *buffer[2];
+	Qfloat *QD;
+};
+
+//
+// construct and solve various formulations
+//
+static void solve_c_svc(
+	const svm_problem *prob, const svm_parameter* param,
+	double *alpha, Solver::SolutionInfo* si, const double *C_)
+{
+	int l = prob->l;
+	double *minus_ones = new double[l];
+	schar *y = new schar[l];
+
+	int i;
+
+	for(i=0;i<l;i++)
+	{
+		alpha[i] = 0;
+		minus_ones[i] = -1;
+		if(prob->y[i] > 0) y[i] = +1; else y[i]=-1;
+	}
+
+	Solver s;
+	s.Solve(l, SVC_Q(*prob,*param,y), minus_ones, y,
+		alpha, C_, param->eps, si, param->shrinking);
+
+	for(i=0;i<l;i++)
+		alpha[i] *= y[i];
+
+	delete[] minus_ones;
+	delete[] y;
+}
+
+static void solve_nu_svc(
+	const svm_problem *prob, const svm_parameter *param,
+	double *alpha, Solver::SolutionInfo* si)
+{
+	int i;
+	int l = prob->l;
+	double nu = param->nu;
+
+	schar *y = new schar[l];
+
+	for(i=0;i<l;i++)
+		if(prob->y[i]>0)
+			y[i] = +1;
+		else
+			y[i] = -1;
+
+	double sum_pos = nu*l/2;
+	double sum_neg = nu*l/2;
+
+	for(i=0;i<l;i++)
+		if(y[i] == +1)
+		{
+			alpha[i] = min(1.0,sum_pos);
+			sum_pos -= alpha[i];
+		}
+		else
+		{
+			alpha[i] = min(1.0,sum_neg);
+			sum_neg -= alpha[i];
+		}
+
+	double *zeros = new double[l];
+
+	for(i=0;i<l;i++)
+		zeros[i] = 0;
+
+	Solver_NU s;
+	s.Solve(l, SVC_Q(*prob,*param,y), zeros, y,
+		alpha, 1.0, 1.0, param->eps, si,  param->shrinking);
+	double r = si->r;
+
+	info("C = %f\n",1/r);
+
+	for(i=0;i<l;i++)
+		alpha[i] *= y[i]/r;
+
+	si->rho /= r;
+	si->obj /= (r*r);
+	si->upper_bound_p = 1/r;
+	si->upper_bound_n = 1/r;
+
+	delete[] y;
+	delete[] zeros;
+}
+
+static void solve_one_class(
+	const svm_problem *prob, const svm_parameter *param,
+	double *alpha, Solver::SolutionInfo* si)
+{
+	int l = prob->l;
+	double *zeros = new double[l];
+	schar *ones = new schar[l];
+	int i;
+
+	int n = (int)(param->nu*prob->l);	// # of alpha's at upper bound
+
+	for(i=0;i<n;i++)
+		alpha[i] = 1;
+	if(n<prob->l)
+		alpha[n] = param->nu * prob->l - n;
+	for(i=n+1;i<l;i++)
+		alpha[i] = 0;
+
+	for(i=0;i<l;i++)
+	{
+		zeros[i] = 0;
+		ones[i] = 1;
+	}
+
+	Solver s;
+	s.Solve(l, ONE_CLASS_Q(*prob,*param), zeros, ones,
+		alpha, 1.0, 1.0, param->eps, si, param->shrinking);
+
+	delete[] zeros;
+	delete[] ones;
+}
+
+static void solve_epsilon_svr(
+	const svm_problem *prob, const svm_parameter *param,
+	double *alpha, Solver::SolutionInfo* si, const double *C_)
+{
+	int l = prob->l;
+	double *alpha2 = new double[2*l];
+	double *linear_term = new double[2*l];
+	double *C2 = new double[2*l];
+	schar *y = new schar[2*l];
+	int i;
+
+	for(i=0;i<l;i++)
+	{
+		alpha2[i] = 0;
+		linear_term[i] = param->p - prob->y[i];
+		y[i] = 1;
+		C2[i] = C_[i];
+
+		alpha2[i+l] = 0;
+		linear_term[i+l] = param->p + prob->y[i];
+		y[i+l] = -1;
+		C2[i+l] = C_[i];
+	}
+
+	Solver s;
+	s.Solve(2*l, SVR_Q(*prob,*param), linear_term, y,
+		alpha2, C2, param->eps, si, param->shrinking);
+
+	for(i=0;i<l;i++)
+		alpha[i] = alpha2[i] - alpha2[i+l];
+
+	delete[] alpha2;
+	delete[] linear_term;
+	delete[] C2;
+	delete[] y;
+}
+
+static void solve_nu_svr(
+	const svm_problem *prob, const svm_parameter *param,
+	double *alpha, Solver::SolutionInfo* si)
+{
+	int l = prob->l;
+	double C = param->C;
+	double *alpha2 = new double[2*l];
+	double *linear_term = new double[2*l];
+	schar *y = new schar[2*l];
+	int i;
+
+	double sum = C * param->nu * l / 2;
+	for(i=0;i<l;i++)
+	{
+		alpha2[i] = alpha2[i+l] = min(sum,C);
+		sum -= alpha2[i];
+
+		linear_term[i] = - prob->y[i];
+		y[i] = 1;
+
+		linear_term[i+l] = prob->y[i];
+		y[i+l] = -1;
+	}
+
+	Solver_NU s;
+	s.Solve(2*l, SVR_Q(*prob,*param), linear_term, y,
+		alpha2, C, C, param->eps, si, param->shrinking);
+
+	info("epsilon = %f\n",-si->r);
+
+	for(i=0;i<l;i++)
+		alpha[i] = alpha2[i] - alpha2[i+l];
+
+	delete[] alpha2;
+	delete[] linear_term;
+	delete[] y;
+}
+
+//
+// decision_function
+//
+struct decision_function
+{
+	double *alpha;
+	double rho;	
+};
+
+decision_function svm_train_one(
+	const svm_problem *prob, const svm_parameter *param,
+	double Cp, double Cn)
+{
+	double *alpha = Malloc(double,prob->l);
+	Solver::SolutionInfo si;
+	double *C_ = NULL;
+
+	if (prob->W){
+		C_ = new double[prob->l];
+		for(int i=0;i<prob->l;i++) C_[i] = prob->W[i] * param->C;
+	}
+	else if (param->svm_type == C_SVC){
+		C_ = new double[prob->l];
+		for(int i=0;i<prob->l;i++) C_[i] = (prob->y[i] > 0 ? Cp : Cn);
+	}
+	else if (param->svm_type == EPSILON_SVR){
+		C_ = new double[prob->l];
+		for(int i=0;i<prob->l;i++) C_[i] = param->C;
+	}
+
+	switch(param->svm_type)
+	{
+		case C_SVC:
+			solve_c_svc(prob,param,alpha,&si,C_);
+			break;
+		case NU_SVC:
+			info("Warning!! weighted mode not supported for NU_SVC");
+			solve_nu_svc(prob,param,alpha,&si);
+			break;
+		case ONE_CLASS:
+			info("Warning!! weighted mode not supported for ONE_CLASS");
+			solve_one_class(prob,param,alpha,&si);
+			break;
+		case EPSILON_SVR:
+			solve_epsilon_svr(prob,param,alpha,&si,C_);
+			break;
+		case NU_SVR:
+			info("Warning!! weighted mode not supported for NU_SVR");
+			solve_nu_svr(prob,param,alpha,&si);
+			break;
+	}
+
+	info("obj = %f, rho = %f\n",si.obj,si.rho);
+
+	// output SVs
+
+	int nSV = 0;
+	int nBSV = 0;
+	for(int i=0;i<prob->l;i++)
+	{
+		if(fabs(alpha[i]) > 0)
+		{
+			++nSV;
+			if(C_){
+				if(fabs(alpha[i]) >= C_[i])
+					++nBSV;
+			}
+			else if(prob->y[i] > 0)
+			{
+				if(fabs(alpha[i]) >= si.upper_bound_p)
+					++nBSV;
+			}
+			else
+			{
+				if(fabs(alpha[i]) >= si.upper_bound_n)
+					++nBSV;
+			}
+		}
+	}
+
+	if (C_) delete[] C_;
+	info("nSV = %d, nBSV = %d\n",nSV,nBSV);
+
+	decision_function f;
+	f.alpha = alpha;
+	f.rho = si.rho;
+	return f;
+}
+
+//
+// svm_model
+//
+struct svm_model
+{
+	svm_parameter param;	// parameter
+	int nr_class;		// number of classes, = 2 in regression/one class svm
+	int l;			// total #SV
+	svm_node **SV;		// SVs (SV[l])
+	double **sv_coef;	// coefficients for SVs in decision functions (sv_coef[n-1][l])
+	double *rho;		// constants in decision functions (rho[n*(n-1)/2])
+	double *probA;          // pariwise probability information
+	double *probB;
+
+	// for classification only
+
+	int *label;		// label of each class (label[n])
+	int *nSV;		// number of SVs for each class (nSV[n])
+				// nSV[0] + nSV[1] + ... + nSV[n-1] = l
+	// XXX
+	int free_sv;		// 1 if svm_model is created by svm_load_model
+				// 0 if svm_model is created by svm_train
+};
+
+// Platt's binary SVM Probablistic Output: an improvement from Lin et al.
+void sigmoid_train(
+	int l, const double *dec_values, const double *labels, 
+	double& A, double& B)
+{
+	double prior1=0, prior0 = 0;
+	int i;
+
+	for (i=0;i<l;i++)
+		if (labels[i] > 0) prior1+=1;
+		else prior0+=1;
+	
+	int max_iter=100; 	// Maximal number of iterations
+	double min_step=1e-10;	// Minimal step taken in line search
+	double sigma=1e-3;	// For numerically strict PD of Hessian
+	double eps=1e-5;
+	double hiTarget=(prior1+1.0)/(prior1+2.0);
+	double loTarget=1/(prior0+2.0);
+	double *t=Malloc(double,l);
+	double fApB,p,q,h11,h22,h21,g1,g2,det,dA,dB,gd,stepsize;
+	double newA,newB,newf,d1,d2;
+	int iter; 
+	
+	// Initial Point and Initial Fun Value
+	A=0.0; B=log((prior0+1.0)/(prior1+1.0));
+	double fval = 0.0;
+
+	for (i=0;i<l;i++)
+	{
+		if (labels[i]>0) t[i]=hiTarget;
+		else t[i]=loTarget;
+		fApB = dec_values[i]*A+B;
+		if (fApB>=0)
+			fval += t[i]*fApB + log(1+exp(-fApB));
+		else
+			fval += (t[i] - 1)*fApB +log(1+exp(fApB));
+	}
+	for (iter=0;iter<max_iter;iter++)
+	{
+		// Update Gradient and Hessian (use H' = H + sigma I)
+		h11=sigma; // numerically ensures strict PD
+		h22=sigma;
+		h21=0.0;g1=0.0;g2=0.0;
+		for (i=0;i<l;i++)
+		{
+			fApB = dec_values[i]*A+B;
+			if (fApB >= 0)
+			{
+				p=exp(-fApB)/(1.0+exp(-fApB));
+				q=1.0/(1.0+exp(-fApB));
+			}
+			else
+			{
+				p=1.0/(1.0+exp(fApB));
+				q=exp(fApB)/(1.0+exp(fApB));
+			}
+			d2=p*q;
+			h11+=dec_values[i]*dec_values[i]*d2;
+			h22+=d2;
+			h21+=dec_values[i]*d2;
+			d1=t[i]-p;
+			g1+=dec_values[i]*d1;
+			g2+=d1;
+		}
+
+		// Stopping Criteria
+		if (fabs(g1)<eps && fabs(g2)<eps)
+			break;
+
+		// Finding Newton direction: -inv(H') * g
+		det=h11*h22-h21*h21;
+		dA=-(h22*g1 - h21 * g2) / det;
+		dB=-(-h21*g1+ h11 * g2) / det;
+		gd=g1*dA+g2*dB;
+
+
+		stepsize = 1; 		// Line Search
+		while (stepsize >= min_step)
+		{
+			newA = A + stepsize * dA;
+			newB = B + stepsize * dB;
+
+			// New function value
+			newf = 0.0;
+			for (i=0;i<l;i++)
+			{
+				fApB = dec_values[i]*newA+newB;
+				if (fApB >= 0)
+					newf += t[i]*fApB + log(1+exp(-fApB));
+				else
+					newf += (t[i] - 1)*fApB +log(1+exp(fApB));
+			}
+			// Check sufficient decrease
+			if (newf<fval+0.0001*stepsize*gd)
+			{
+				A=newA;B=newB;fval=newf;
+				break;
+			}
+			else
+				stepsize = stepsize / 2.0;
+		}
+
+		if (stepsize < min_step)
+		{
+			info("Line search fails in two-class probability estimates\n");
+			break;
+		}
+	}
+
+	if (iter>=max_iter)
+		info("Reaching maximal iterations in two-class probability estimates\n");
+	free(t);
+}
+
+double sigmoid_predict(double decision_value, double A, double B)
+{
+	double fApB = decision_value*A+B;
+	if (fApB >= 0)
+		return exp(-fApB)/(1.0+exp(-fApB));
+	else
+		return 1.0/(1+exp(fApB)) ;
+}
+
+// Method 2 from the multiclass_prob paper by Wu, Lin, and Weng
+void multiclass_probability(int k, double **r, double *p)
+{
+	int t,j;
+	int iter = 0, max_iter=max(100,k);
+	double **Q=Malloc(double *,k);
+	double *Qp=Malloc(double,k);
+	double pQp, eps=0.005/k;
+	
+	for (t=0;t<k;t++)
+	{
+		p[t]=1.0/k;  // Valid if k = 1
+		Q[t]=Malloc(double,k);
+		Q[t][t]=0;
+		for (j=0;j<t;j++)
+		{
+			Q[t][t]+=r[j][t]*r[j][t];
+			Q[t][j]=Q[j][t];
+		}
+		for (j=t+1;j<k;j++)
+		{
+			Q[t][t]+=r[j][t]*r[j][t];
+			Q[t][j]=-r[j][t]*r[t][j];
+		}
+	}
+	for (iter=0;iter<max_iter;iter++)
+	{
+		// stopping condition, recalculate QP,pQP for numerical accuracy
+		pQp=0;
+		for (t=0;t<k;t++)
+		{
+			Qp[t]=0;
+			for (j=0;j<k;j++)
+				Qp[t]+=Q[t][j]*p[j];
+			pQp+=p[t]*Qp[t];
+		}
+		double max_error=0;
+		for (t=0;t<k;t++)
+		{
+			double error=fabs(Qp[t]-pQp);
+			if (error>max_error)
+				max_error=error;
+		}
+		if (max_error<eps) break;
+		
+		for (t=0;t<k;t++)
+		{
+			double diff=(-Qp[t]+pQp)/Q[t][t];
+			p[t]+=diff;
+			pQp=(pQp+diff*(diff*Q[t][t]+2*Qp[t]))/(1+diff)/(1+diff);
+			for (j=0;j<k;j++)
+			{
+				Qp[j]=(Qp[j]+diff*Q[t][j])/(1+diff);
+				p[j]/=(1+diff);
+			}
+		}
+	}
+	if (iter>=max_iter)
+		info("Exceeds max_iter in multiclass_prob\n");
+	for(t=0;t<k;t++) free(Q[t]);
+	free(Q);
+	free(Qp);
+}
+
+// Cross-validation decision values for probability estimates
+void svm_binary_svc_probability(
+	const svm_problem *prob, const svm_parameter *param,
+	double Cp, double Cn, double& probA, double& probB)
+{
+	int i;
+	int nr_fold = 5;
+	int *perm = Malloc(int,prob->l);
+	double *dec_values = Malloc(double,prob->l);
+
+	// random shuffle
+	for(i=0;i<prob->l;i++) perm[i]=i;
+	for(i=0;i<prob->l;i++)
+	{
+		int j = i+rand()%(prob->l-i);
+		swap(perm[i],perm[j]);
+	}
+	for(i=0;i<nr_fold;i++)
+	{
+		int begin = i*prob->l/nr_fold;
+		int end = (i+1)*prob->l/nr_fold;
+		int j,k;
+		struct svm_problem subprob;
+
+		subprob.l = prob->l-(end-begin);
+		subprob.x = Malloc(struct svm_node*,subprob.l);
+		subprob.y = Malloc(double,subprob.l);
+			
+		k=0;
+		for(j=0;j<begin;j++)
+		{
+			subprob.x[k] = prob->x[perm[j]];
+			subprob.y[k] = prob->y[perm[j]];
+			++k;
+		}
+		for(j=end;j<prob->l;j++)
+		{
+			subprob.x[k] = prob->x[perm[j]];
+			subprob.y[k] = prob->y[perm[j]];
+			++k;
+		}
+		int p_count=0,n_count=0;
+		for(j=0;j<k;j++)
+			if(subprob.y[j]>0)
+				p_count++;
+			else
+				n_count++;
+
+		if(p_count==0 && n_count==0)
+			for(j=begin;j<end;j++)
+				dec_values[perm[j]] = 0;
+		else if(p_count > 0 && n_count == 0)
+			for(j=begin;j<end;j++)
+				dec_values[perm[j]] = 1;
+		else if(p_count == 0 && n_count > 0)
+			for(j=begin;j<end;j++)
+				dec_values[perm[j]] = -1;
+		else
+		{
+			svm_parameter subparam = *param;
+			subparam.probability=0;
+			subparam.C=1.0;
+			subparam.nr_weight=2;
+			subparam.weight_label = Malloc(int,2);
+			subparam.weight = Malloc(double,2);
+			subparam.weight_label[0]=+1;
+			subparam.weight_label[1]=-1;
+			subparam.weight[0]=Cp;
+			subparam.weight[1]=Cn;
+			struct svm_model *submodel = svm_train(&subprob,&subparam);
+			for(j=begin;j<end;j++)
+			{
+				svm_predict_values(submodel,prob->x[perm[j]],&(dec_values[perm[j]])); 
+				// ensure +1 -1 order; reason not using CV subroutine
+				dec_values[perm[j]] *= submodel->label[0];
+			}		
+			svm_destroy_model(submodel);
+			svm_destroy_param(&subparam);
+			free(subprob.x);
+			free(subprob.y);
+		}
+	}		
+	sigmoid_train(prob->l,dec_values,prob->y,probA,probB);
+	free(dec_values);
+	free(perm);
+}
+
+// Return parameter of a Laplace distribution 
+double svm_svr_probability(
+	const svm_problem *prob, const svm_parameter *param)
+{
+	int i;
+	int nr_fold = 5;
+	double *ymv = Malloc(double,prob->l);
+	double mae = 0;
+
+	svm_parameter newparam = *param;
+	newparam.probability = 0;
+	svm_cross_validation(prob,&newparam,nr_fold,ymv);
+	for(i=0;i<prob->l;i++)
+	{
+		ymv[i]=prob->y[i]-ymv[i];
+		mae += fabs(ymv[i]);
+	}		
+	mae /= prob->l;
+	double std=sqrt(2*mae*mae);
+	int count=0;
+	mae=0;
+	for(i=0;i<prob->l;i++)
+	        if (fabs(ymv[i]) > 5*std) 
+                        count=count+1;
+		else 
+		        mae+=fabs(ymv[i]);
+	mae /= (prob->l-count);
+	info("Prob. model for test data: target value = predicted value + z,\nz: Laplace distribution e^(-|z|/sigma)/(2sigma),sigma= %g\n",mae);
+	free(ymv);
+	return mae;
+}
+
+
+// label: label name, start: begin of each class, count: #data of classes, perm: indices to the original data
+// perm, length l, must be allocated before calling this subroutine
+void svm_group_classes(const svm_problem *prob, int *nr_class_ret, int **label_ret, int **start_ret, int **count_ret, int *perm)
+{
+	int l = prob->l;
+	int max_nr_class = 16;
+	int nr_class = 0;
+	int *label = Malloc(int,max_nr_class);
+	int *count = Malloc(int,max_nr_class);
+	int *data_label = Malloc(int,l);	
+	int i;
+
+	for(i=0;i<l;i++)
+	{
+		int this_label = (int)prob->y[i];
+		int j;
+		for(j=0;j<nr_class;j++)
+		{
+			if(this_label == label[j])
+			{
+				++count[j];
+				break;
+			}
+		}
+		data_label[i] = j;
+		if(j == nr_class)
+		{
+			if(nr_class == max_nr_class)
+			{
+				max_nr_class *= 2;
+				label = (int *)realloc(label,max_nr_class*sizeof(int));
+				count = (int *)realloc(count,max_nr_class*sizeof(int));
+			}
+			label[nr_class] = this_label;
+			count[nr_class] = 1;
+			++nr_class;
+		}
+	}
+
+	int *start = Malloc(int,nr_class);
+	start[0] = 0;
+	for(i=1;i<nr_class;i++)
+		start[i] = start[i-1]+count[i-1];
+	for(i=0;i<l;i++)
+	{
+		perm[start[data_label[i]]] = i;
+		++start[data_label[i]];
+	}
+	start[0] = 0;
+	for(i=1;i<nr_class;i++)
+		start[i] = start[i-1]+count[i-1];
+
+	*nr_class_ret = nr_class;
+	*label_ret = label;
+	*start_ret = start;
+	*count_ret = count;
+	free(data_label);
+}
+
+//
+// Interface functions
+//
+svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
+{
+	svm_model *model = Malloc(svm_model,1);
+	model->param = *param;
+	model->free_sv = 0;	// XXX
+
+	if(param->svm_type == ONE_CLASS ||
+	   param->svm_type == EPSILON_SVR ||
+	   param->svm_type == NU_SVR)
+	{
+		// regression or one-class-svm
+		model->nr_class = 2;
+		model->label = NULL;
+		model->nSV = NULL;
+		model->probA = NULL; model->probB = NULL;
+		model->sv_coef = Malloc(double *,1);
+
+		if(param->probability && 
+		   (param->svm_type == EPSILON_SVR ||
+		    param->svm_type == NU_SVR))
+		{
+			model->probA = Malloc(double,1);
+			model->probA[0] = svm_svr_probability(prob,param);
+		}
+
+		decision_function f = svm_train_one(prob,param,0,0);
+		model->rho = Malloc(double,1);
+		model->rho[0] = f.rho;
+
+		int nSV = 0;
+		int i;
+		for(i=0;i<prob->l;i++)
+			if(fabs(f.alpha[i]) > 0) ++nSV;
+		model->l = nSV;
+		model->SV = Malloc(svm_node *,nSV);
+		model->sv_coef[0] = Malloc(double,nSV);
+		int j = 0;
+		for(i=0;i<prob->l;i++)
+			if(fabs(f.alpha[i]) > 0)
+			{
+				model->SV[j] = prob->x[i];
+				model->sv_coef[0][j] = f.alpha[i];
+				++j;
+			}		
+
+		free(f.alpha);
+	}
+	else
+	{
+		// classification
+		int l = prob->l;
+		int nr_class;
+		int *label = NULL;
+		int *start = NULL;
+		int *count = NULL;
+		int *perm = Malloc(int,l);
+
+		// group training data of the same class
+		svm_group_classes(prob,&nr_class,&label,&start,&count,perm);		
+		svm_node **x = Malloc(svm_node *,l);
+		double *W = NULL;
+		if (prob->W) W = Malloc(double, l);
+
+		int i;
+		for(i=0;i<l;i++){
+			x[i] = prob->x[perm[i]];
+			if (prob->W) W[i] = prob->W[perm[i]];
+		}
+
+		// calculate weighted C
+
+		double *weighted_C = Malloc(double, nr_class);
+		for(i=0;i<nr_class;i++)
+			weighted_C[i] = param->C;
+		for(i=0;i<param->nr_weight;i++)
+		{	
+			int j;
+			for(j=0;j<nr_class;j++)
+				if(param->weight_label[i] == label[j])
+					break;
+			if(j == nr_class)
+				fprintf(stderr,"warning: class label %d specified in weight is not found\n", param->weight_label[i]);
+			else
+				weighted_C[j] *= param->weight[i];
+		}
+
+		// train k*(k-1)/2 models
+		
+		bool *nonzero = Malloc(bool,l);
+		for(i=0;i<l;i++)
+			nonzero[i] = false;
+		decision_function *f = Malloc(decision_function,nr_class*(nr_class-1)/2);
+
+		double *probA=NULL,*probB=NULL;
+		if (param->probability)
+		{
+			probA=Malloc(double,nr_class*(nr_class-1)/2);
+			probB=Malloc(double,nr_class*(nr_class-1)/2);
+		}
+
+		int p = 0;
+		for(i=0;i<nr_class;i++)
+			for(int j=i+1;j<nr_class;j++)
+			{
+				svm_problem sub_prob;
+				int si = start[i], sj = start[j];
+				int ci = count[i], cj = count[j];
+				sub_prob.l = ci+cj;
+				sub_prob.x = Malloc(svm_node *,sub_prob.l);
+				sub_prob.y = Malloc(double,sub_prob.l);
+				if (W) sub_prob.W = Malloc(double, sub_prob.l);
+				else sub_prob.W = NULL;
+				int k;
+				for(k=0;k<ci;k++)
+				{
+					sub_prob.x[k] = x[si+k];
+					sub_prob.y[k] = +1;
+					if (sub_prob.W) sub_prob.W[k] = W[si+k];
+				}
+				for(k=0;k<cj;k++)
+				{
+					sub_prob.x[ci+k] = x[sj+k];
+					sub_prob.y[ci+k] = -1;
+					if (sub_prob.W) sub_prob.W[ci+k] = W[sj+k];
+				}
+
+				if(param->probability)
+					svm_binary_svc_probability(&sub_prob,param,weighted_C[i],weighted_C[j],probA[p],probB[p]);
+
+				f[p] = svm_train_one(&sub_prob,param,weighted_C[i],weighted_C[j]);
+				for(k=0;k<ci;k++)
+					if(!nonzero[si+k] && fabs(f[p].alpha[k]) > 0)
+						nonzero[si+k] = true;
+				for(k=0;k<cj;k++)
+					if(!nonzero[sj+k] && fabs(f[p].alpha[ci+k]) > 0)
+						nonzero[sj+k] = true;
+				free(sub_prob.x);
+				free(sub_prob.y);
+				if (sub_prob.W) free(sub_prob.W);
+				++p;
+			}
+
+		// build output
+
+		model->nr_class = nr_class;
+		
+		model->label = Malloc(int,nr_class);
+		for(i=0;i<nr_class;i++)
+			model->label[i] = label[i];
+		
+		model->rho = Malloc(double,nr_class*(nr_class-1)/2);
+		for(i=0;i<nr_class*(nr_class-1)/2;i++)
+			model->rho[i] = f[i].rho;
+
+		if(param->probability)
+		{
+			model->probA = Malloc(double,nr_class*(nr_class-1)/2);
+			model->probB = Malloc(double,nr_class*(nr_class-1)/2);
+			for(i=0;i<nr_class*(nr_class-1)/2;i++)
+			{
+				model->probA[i] = probA[i];
+				model->probB[i] = probB[i];
+			}
+		}
+		else
+		{
+			model->probA=NULL;
+			model->probB=NULL;
+		}
+
+		int total_sv = 0;
+		int *nz_count = Malloc(int,nr_class);
+		model->nSV = Malloc(int,nr_class);
+		for(i=0;i<nr_class;i++)
+		{
+			int nSV = 0;
+			for(int j=0;j<count[i];j++)
+				if(nonzero[start[i]+j])
+				{	
+					++nSV;
+					++total_sv;
+				}
+			model->nSV[i] = nSV;
+			nz_count[i] = nSV;
+		}
+		
+		info("Total nSV = %d\n",total_sv);
+
+		model->l = total_sv;
+		model->SV = Malloc(svm_node *,total_sv);
+		p = 0;
+		for(i=0;i<l;i++)
+			if(nonzero[i]) model->SV[p++] = x[i];
+
+		int *nz_start = Malloc(int,nr_class);
+		nz_start[0] = 0;
+		for(i=1;i<nr_class;i++)
+			nz_start[i] = nz_start[i-1]+nz_count[i-1];
+
+		model->sv_coef = Malloc(double *,nr_class-1);
+		for(i=0;i<nr_class-1;i++)
+			model->sv_coef[i] = Malloc(double,total_sv);
+
+		p = 0;
+		for(i=0;i<nr_class;i++)
+			for(int j=i+1;j<nr_class;j++)
+			{
+				// classifier (i,j): coefficients with
+				// i are in sv_coef[j-1][nz_start[i]...],
+				// j are in sv_coef[i][nz_start[j]...]
+
+				int si = start[i];
+				int sj = start[j];
+				int ci = count[i];
+				int cj = count[j];
+				
+				int q = nz_start[i];
+				int k;
+				for(k=0;k<ci;k++)
+					if(nonzero[si+k])
+						model->sv_coef[j-1][q++] = f[p].alpha[k];
+				q = nz_start[j];
+				for(k=0;k<cj;k++)
+					if(nonzero[sj+k])
+						model->sv_coef[i][q++] = f[p].alpha[ci+k];
+				++p;
+			}
+		
+		free(label);
+		free(probA);
+		free(probB);
+		free(count);
+		free(perm);
+		free(start);
+		if (W) free(W);
+		free(x);
+		free(weighted_C);
+		free(nonzero);
+		for(i=0;i<nr_class*(nr_class-1)/2;i++)
+			free(f[i].alpha);
+		free(f);
+		free(nz_count);
+		free(nz_start);
+	}
+	return model;
+}
+
+// Stratified cross validation
+void svm_cross_validation(const svm_problem *prob, const svm_parameter *param, int nr_fold, double *target)
+{
+	int i;
+	int *fold_start = Malloc(int,nr_fold+1);
+	int l = prob->l;
+	int *perm = Malloc(int,l);
+	int nr_class;
+
+	// stratified cv may not give leave-one-out rate
+	// Each class to l folds -> some folds may have zero elements
+	if((param->svm_type == C_SVC ||
+	    param->svm_type == NU_SVC) && nr_fold < l)
+	{
+		int *start = NULL;
+		int *label = NULL;
+		int *count = NULL;
+		svm_group_classes(prob,&nr_class,&label,&start,&count,perm);
+
+		// random shuffle and then data grouped by fold using the array perm
+		int *fold_count = Malloc(int,nr_fold);
+		int c;
+		int *index = Malloc(int,l);
+		for(i=0;i<l;i++)
+			index[i]=perm[i];
+		for (c=0; c<nr_class; c++) 
+			for(i=0;i<count[c];i++)
+			{
+				int j = i+rand()%(count[c]-i);
+				swap(index[start[c]+j],index[start[c]+i]);
+			}
+		for(i=0;i<nr_fold;i++)
+		{
+			fold_count[i] = 0;
+			for (c=0; c<nr_class;c++)
+				fold_count[i]+=(i+1)*count[c]/nr_fold-i*count[c]/nr_fold;
+		}
+		fold_start[0]=0;
+		for (i=1;i<=nr_fold;i++)
+			fold_start[i] = fold_start[i-1]+fold_count[i-1];
+		for (c=0; c<nr_class;c++)
+			for(i=0;i<nr_fold;i++)
+			{
+				int begin = start[c]+i*count[c]/nr_fold;
+				int end = start[c]+(i+1)*count[c]/nr_fold;
+				for(int j=begin;j<end;j++)
+				{
+					perm[fold_start[i]] = index[j];
+					fold_start[i]++;
+				}
+			}
+		fold_start[0]=0;
+		for (i=1;i<=nr_fold;i++)
+			fold_start[i] = fold_start[i-1]+fold_count[i-1];
+		free(start);	
+		free(label);
+		free(count);	
+		free(index);
+		free(fold_count);
+	}
+	else
+	{
+		for(i=0;i<l;i++) perm[i]=i;
+		for(i=0;i<l;i++)
+		{
+			int j = i+rand()%(l-i);
+			swap(perm[i],perm[j]);
+		}
+		for(i=0;i<=nr_fold;i++)
+			fold_start[i]=i*l/nr_fold;
+	}
+
+	for(i=0;i<nr_fold;i++)
+	{
+		int begin = fold_start[i];
+		int end = fold_start[i+1];
+		int j,k;
+		struct svm_problem subprob;
+
+		subprob.l = l-(end-begin);
+		subprob.x = Malloc(struct svm_node*,subprob.l);
+		subprob.y = Malloc(double,subprob.l);
+		if (prob->W) subprob.W = Malloc(double,subprob.l);
+		else subprob.W = NULL;
+		k=0;
+		for(j=0;j<begin;j++)
+		{
+			subprob.x[k] = prob->x[perm[j]];
+			subprob.y[k] = prob->y[perm[j]];
+			if (subprob.W) subprob.W[k] = prob->W[perm[j]];
+			++k;
+		}
+		for(j=end;j<l;j++)
+		{
+			subprob.x[k] = prob->x[perm[j]];
+			subprob.y[k] = prob->y[perm[j]];
+			if (subprob.W) subprob.W[k] = prob->W[perm[j]];
+			++k;
+		}
+		struct svm_model *submodel = svm_train(&subprob,param);
+		if(param->probability && 
+		   (param->svm_type == C_SVC || param->svm_type == NU_SVC))
+		{
+			double *prob_estimates=Malloc(double,svm_get_nr_class(submodel));
+			for(j=begin;j<end;j++)
+				target[perm[j]] = svm_predict_probability(submodel,prob->x[perm[j]],prob_estimates);
+			free(prob_estimates);			
+		}
+		else
+			for(j=begin;j<end;j++)
+				target[perm[j]] = svm_predict(submodel,prob->x[perm[j]]);
+		svm_destroy_model(submodel);
+		free(subprob.x);
+		free(subprob.y);
+		if (subprob.W) free(subprob.W);
+	}		
+	free(fold_start);
+	free(perm);	
+}
+
+
+int svm_get_svm_type(const svm_model *model)
+{
+	return model->param.svm_type;
+}
+
+int svm_get_nr_class(const svm_model *model)
+{
+	return model->nr_class;
+}
+
+void svm_get_labels(const svm_model *model, int* label)
+{
+	if (model->label != NULL)
+		for(int i=0;i<model->nr_class;i++)
+			label[i] = model->label[i];
+}
+
+double svm_get_svr_probability(const svm_model *model)
+{
+	if ((model->param.svm_type == EPSILON_SVR || model->param.svm_type == NU_SVR) &&
+	    model->probA!=NULL)
+		return model->probA[0];
+	else
+	{
+		info("Model doesn't contain information for SVR probability inference\n");
+		return 0;
+	}
+}
+
+void svm_predict_values(const svm_model *model, const svm_node *x, double* dec_values)
+{
+	if(model->param.svm_type == ONE_CLASS ||
+	   model->param.svm_type == EPSILON_SVR ||
+	   model->param.svm_type == NU_SVR)
+	{
+		double *sv_coef = model->sv_coef[0];
+		double sum = 0;
+		for(int i=0;i<model->l;i++)
+			sum += sv_coef[i] * Kernel::k_function(x,model->SV[i],model->param);
+		sum -= model->rho[0];
+		*dec_values = sum;
+	}
+	else
+	{
+		int i;
+		int nr_class = model->nr_class;
+		int l = model->l;
+		
+		double *kvalue = Malloc(double,l);
+		for(i=0;i<l;i++)
+			kvalue[i] = Kernel::k_function(x,model->SV[i],model->param);
+
+		int *start = Malloc(int,nr_class);
+		start[0] = 0;
+		for(i=1;i<nr_class;i++)
+			start[i] = start[i-1]+model->nSV[i-1];
+
+		int p=0;
+		int pos=0;
+		for(i=0;i<nr_class;i++)
+			for(int j=i+1;j<nr_class;j++)
+			{
+				double sum = 0;
+				int si = start[i];
+				int sj = start[j];
+				int ci = model->nSV[i];
+				int cj = model->nSV[j];
+				
+				int k;
+				double *coef1 = model->sv_coef[j-1];
+				double *coef2 = model->sv_coef[i];
+				for(k=0;k<ci;k++)
+					sum += coef1[si+k] * kvalue[si+k];
+				for(k=0;k<cj;k++)
+					sum += coef2[sj+k] * kvalue[sj+k];
+				sum -= model->rho[p++];
+				dec_values[pos++] = sum;
+			}
+
+		free(kvalue);
+		free(start);
+	}
+}
+
+double svm_predict(const svm_model *model, const svm_node *x)
+{
+	if(model->param.svm_type == ONE_CLASS ||
+	   model->param.svm_type == EPSILON_SVR ||
+	   model->param.svm_type == NU_SVR)
+	{
+		double res;
+		svm_predict_values(model, x, &res);
+		
+		if(model->param.svm_type == ONE_CLASS)
+			return (res>0)?1:-1;
+		else
+			return res;
+	}
+	else
+	{
+		int i;
+		int nr_class = model->nr_class;
+		double *dec_values = Malloc(double, nr_class*(nr_class-1)/2);
+		svm_predict_values(model, x, dec_values);
+
+		int *vote = Malloc(int,nr_class);
+		for(i=0;i<nr_class;i++)
+			vote[i] = 0;
+		int pos=0;
+		for(i=0;i<nr_class;i++)
+			for(int j=i+1;j<nr_class;j++)
+			{
+				if(dec_values[pos++] > 0)
+					++vote[i];
+				else
+					++vote[j];
+			}
+
+		int vote_max_idx = 0;
+		for(i=1;i<nr_class;i++)
+			if(vote[i] > vote[vote_max_idx])
+				vote_max_idx = i;
+		free(vote);
+		free(dec_values);
+		return model->label[vote_max_idx];
+	}
+}
+
+double svm_predict_probability(
+	const svm_model *model, const svm_node *x, double *prob_estimates)
+{
+	if ((model->param.svm_type == C_SVC || model->param.svm_type == NU_SVC) &&
+	    model->probA!=NULL && model->probB!=NULL)
+	{
+		int i;
+		int nr_class = model->nr_class;
+		double *dec_values = Malloc(double, nr_class*(nr_class-1)/2);
+		svm_predict_values(model, x, dec_values);
+
+		double min_prob=1e-7;
+		double **pairwise_prob=Malloc(double *,nr_class);
+		for(i=0;i<nr_class;i++)
+			pairwise_prob[i]=Malloc(double,nr_class);
+		int k=0;
+		for(i=0;i<nr_class;i++)
+			for(int j=i+1;j<nr_class;j++)
+			{
+				pairwise_prob[i][j]=min(max(sigmoid_predict(dec_values[k],model->probA[k],model->probB[k]),min_prob),1-min_prob);
+				pairwise_prob[j][i]=1-pairwise_prob[i][j];
+				k++;
+			}
+		multiclass_probability(nr_class,pairwise_prob,prob_estimates);
+
+		int prob_max_idx = 0;
+		for(i=1;i<nr_class;i++)
+			if(prob_estimates[i] > prob_estimates[prob_max_idx])
+				prob_max_idx = i;
+		for(i=0;i<nr_class;i++)
+			free(pairwise_prob[i]);
+		free(dec_values);
+                free(pairwise_prob);	     
+		return model->label[prob_max_idx];
+	}
+	else 
+		return svm_predict(model, x);
+}
+
+const char *svm_type_table[] =
+{
+	"c_svc","nu_svc","one_class","epsilon_svr","nu_svr",NULL
+};
+
+const char *kernel_type_table[]=
+{
+	"linear","polynomial","rbf","sigmoid","stump","perceptron",NULL
+};
+
+int svm_save_model(const char *model_file_name, const svm_model *model)
+{
+	FILE *fp = fopen(model_file_name,"w");
+	if(fp==NULL) return -1;
+
+	const svm_parameter& param = model->param;
+
+	fprintf(fp,"svm_type %s\n", svm_type_table[param.svm_type]);
+	fprintf(fp,"kernel_type %s\n", kernel_type_table[param.kernel_type]);
+
+	if(param.kernel_type == POLY)
+		fprintf(fp,"degree %g\n", param.degree);
+
+	if(param.kernel_type == POLY || param.kernel_type == RBF || param.kernel_type == SIGMOID)
+		fprintf(fp,"gamma %g\n", param.gamma);
+
+	if(param.kernel_type == POLY || param.kernel_type == SIGMOID)
+		fprintf(fp,"coef0 %g\n", param.coef0);
+
+	int nr_class = model->nr_class;
+	int l = model->l;
+	fprintf(fp, "nr_class %d\n", nr_class);
+	fprintf(fp, "total_sv %d\n",l);
+	
+	{
+		fprintf(fp, "rho");
+		for(int i=0;i<nr_class*(nr_class-1)/2;i++)
+			fprintf(fp," %g",model->rho[i]);
+		fprintf(fp, "\n");
+	}
+	
+	if(model->label)
+	{
+		fprintf(fp, "label");
+		for(int i=0;i<nr_class;i++)
+			fprintf(fp," %d",model->label[i]);
+		fprintf(fp, "\n");
+	}
+
+	if(model->probA) // regression has probA only
+	{
+		fprintf(fp, "probA");
+		for(int i=0;i<nr_class*(nr_class-1)/2;i++)
+			fprintf(fp," %g",model->probA[i]);
+		fprintf(fp, "\n");
+	}
+	if(model->probB)
+	{
+		fprintf(fp, "probB");
+		for(int i=0;i<nr_class*(nr_class-1)/2;i++)
+			fprintf(fp," %g",model->probB[i]);
+		fprintf(fp, "\n");
+	}
+
+	if(model->nSV)
+	{
+		fprintf(fp, "nr_sv");
+		for(int i=0;i<nr_class;i++)
+			fprintf(fp," %d",model->nSV[i]);
+		fprintf(fp, "\n");
+	}
+
+	fprintf(fp, "SV\n");
+	const double * const *sv_coef = model->sv_coef;
+	const svm_node * const *SV = model->SV;
+
+	for(int i=0;i<l;i++)
+	{
+		for(int j=0;j<nr_class-1;j++)
+			fprintf(fp, "%.16g ",sv_coef[j][i]);
+
+		const svm_node *p = SV[i];
+		while(p->index != -1)
+		{
+			fprintf(fp,"%d:%.8g ",p->index,p->value);
+			p++;
+		}
+		fprintf(fp, "\n");
+	}
+
+	fclose(fp);
+	return 0;
+}
+
+svm_model *svm_load_model(const char *model_file_name)
+{
+	FILE *fp = fopen(model_file_name,"rb");
+	if(fp==NULL) return NULL;
+	
+	// read parameters
+
+	svm_model *model = Malloc(svm_model,1);
+	svm_parameter& param = model->param;
+	model->rho = NULL;
+	model->probA = NULL;
+	model->probB = NULL;
+	model->label = NULL;
+	model->nSV = NULL;
+
+	char cmd[81];
+	while(1)
+	{
+		fscanf(fp,"%80s",cmd);
+
+		if(strcmp(cmd,"svm_type")==0)
+		{
+			fscanf(fp,"%80s",cmd);
+			int i;
+			for(i=0;svm_type_table[i];i++)
+			{
+				if(strcmp(svm_type_table[i],cmd)==0)
+				{
+					param.svm_type=i;
+					break;
+				}
+			}
+			if(svm_type_table[i] == NULL)
+			{
+				fprintf(stderr,"unknown svm type.\n");
+				free(model->rho);
+				free(model->label);
+				free(model->nSV);
+				free(model);
+				return NULL;
+			}
+		}
+		else if(strcmp(cmd,"kernel_type")==0)
+		{		
+			fscanf(fp,"%80s",cmd);
+			int i;
+			for(i=0;kernel_type_table[i];i++)
+			{
+				if(strcmp(kernel_type_table[i],cmd)==0)
+				{
+					param.kernel_type=i;
+					break;
+				}
+			}
+			if(kernel_type_table[i] == NULL)
+			{
+				fprintf(stderr,"unknown kernel function.\n");
+				free(model->rho);
+				free(model->label);
+				free(model->nSV);
+				free(model);
+				return NULL;
+			}
+		}
+		else if(strcmp(cmd,"degree")==0)
+			fscanf(fp,"%lf",&param.degree);
+		else if(strcmp(cmd,"gamma")==0)
+			fscanf(fp,"%lf",&param.gamma);
+		else if(strcmp(cmd,"coef0")==0)
+			fscanf(fp,"%lf",&param.coef0);
+		else if(strcmp(cmd,"nr_class")==0)
+			fscanf(fp,"%d",&model->nr_class);
+		else if(strcmp(cmd,"total_sv")==0)
+			fscanf(fp,"%d",&model->l);
+		else if(strcmp(cmd,"rho")==0)
+		{
+			int n = model->nr_class * (model->nr_class-1)/2;
+			model->rho = Malloc(double,n);
+			for(int i=0;i<n;i++)
+				fscanf(fp,"%lf",&model->rho[i]);
+		}
+		else if(strcmp(cmd,"label")==0)
+		{
+			int n = model->nr_class;
+			model->label = Malloc(int,n);
+			for(int i=0;i<n;i++)
+				fscanf(fp,"%d",&model->label[i]);
+		}
+		else if(strcmp(cmd,"probA")==0)
+		{
+			int n = model->nr_class * (model->nr_class-1)/2;
+			model->probA = Malloc(double,n);
+			for(int i=0;i<n;i++)
+				fscanf(fp,"%lf",&model->probA[i]);
+		}
+		else if(strcmp(cmd,"probB")==0)
+		{
+			int n = model->nr_class * (model->nr_class-1)/2;
+			model->probB = Malloc(double,n);
+			for(int i=0;i<n;i++)
+				fscanf(fp,"%lf",&model->probB[i]);
+		}
+		else if(strcmp(cmd,"nr_sv")==0)
+		{
+			int n = model->nr_class;
+			model->nSV = Malloc(int,n);
+			for(int i=0;i<n;i++)
+				fscanf(fp,"%d",&model->nSV[i]);
+		}
+		else if(strcmp(cmd,"SV")==0)
+		{
+			while(1)
+			{
+				int c = getc(fp);
+				if(c==EOF || c=='\n') break;	
+			}
+			break;
+		}
+		else
+		{
+			fprintf(stderr,"unknown text in model file\n");
+			free(model->rho);
+			free(model->label);
+			free(model->nSV);
+			free(model);
+			return NULL;
+		}
+	}
+
+	// read sv_coef and SV
+
+	int elements = 0;
+	long pos = ftell(fp);
+
+	while(1)
+	{
+		int c = fgetc(fp);
+		switch(c)
+		{
+			case '\n':
+				// count the '-1' element
+			case ':':
+				++elements;
+				break;
+			case EOF:
+				goto out;
+			default:
+				;
+		}
+	}
+out:
+	fseek(fp,pos,SEEK_SET);
+
+	int m = model->nr_class - 1;
+	int l = model->l;
+	model->sv_coef = Malloc(double *,m);
+	int i;
+	for(i=0;i<m;i++)
+		model->sv_coef[i] = Malloc(double,l);
+	model->SV = Malloc(svm_node*,l);
+	svm_node *x_space=NULL;
+	if(l>0) x_space = Malloc(svm_node,elements);
+
+	int j=0;
+	for(i=0;i<l;i++)
+	{
+		model->SV[i] = &x_space[j];
+		for(int k=0;k<m;k++)
+			fscanf(fp,"%lf",&model->sv_coef[k][i]);
+		while(1)
+		{
+			int c;
+			do {
+				c = getc(fp);
+				if(c=='\n') goto out2;
+			} while(isspace(c));
+			ungetc(c,fp);
+			fscanf(fp,"%d:%lf",&(x_space[j].index),&(x_space[j].value));
+			++j;
+		}	
+out2:
+		x_space[j++].index = -1;
+	}
+
+	fclose(fp);
+
+	model->free_sv = 1;	// XXX
+	return model;
+}
+
+void svm_destroy_model(svm_model* model)
+{
+	if(model->free_sv && model->l > 0)
+		free((void *)(model->SV[0]));
+	for(int i=0;i<model->nr_class-1;i++)
+		free(model->sv_coef[i]);
+	free(model->SV);
+	free(model->sv_coef);
+	free(model->rho);
+	free(model->label);
+	free(model->probA);
+	free(model->probB);
+	free(model->nSV);
+	free(model);
+}
+
+void svm_destroy_param(svm_parameter* param)
+{
+	free(param->weight_label);
+	free(param->weight);
+}
+
+const char *svm_check_parameter(const svm_problem *prob, const svm_parameter *param)
+{
+	// svm_type
+
+	int svm_type = param->svm_type;
+	if(svm_type != C_SVC &&
+	   svm_type != NU_SVC &&
+	   svm_type != ONE_CLASS &&
+	   svm_type != EPSILON_SVR &&
+	   svm_type != NU_SVR)
+		return "unknown svm type";
+	
+	// kernel_type
+	
+	int kernel_type = param->kernel_type;
+	if(kernel_type != LINEAR &&
+	   kernel_type != POLY &&
+	   kernel_type != RBF &&
+	   kernel_type != SIGMOID &&
+	   kernel_type != STUMP &&
+	   kernel_type != PERCEPTRON)
+		return "unknown kernel type";
+
+	// cache_size,eps,C,nu,p,shrinking
+
+	if(param->cache_size <= 0)
+		return "cache_size <= 0";
+
+	if(param->eps <= 0)
+		return "eps <= 0";
+
+	if(svm_type == C_SVC ||
+	   svm_type == EPSILON_SVR ||
+	   svm_type == NU_SVR)
+		if(param->C <= 0)
+			return "C <= 0";
+
+	if(svm_type == NU_SVC ||
+	   svm_type == ONE_CLASS ||
+	   svm_type == NU_SVR)
+		if(param->nu <= 0 || param->nu > 1)
+			return "nu <= 0 or nu > 1";
+
+	if(svm_type == EPSILON_SVR)
+		if(param->p < 0)
+			return "p < 0";
+
+	if(param->shrinking != 0 &&
+	   param->shrinking != 1)
+		return "shrinking != 0 and shrinking != 1";
+
+	if(param->probability != 0 &&
+	   param->probability != 1)
+		return "probability != 0 and probability != 1";
+
+	if(param->probability == 1 &&
+	   svm_type == ONE_CLASS)
+		return "one-class SVM probability output not supported yet";
+
+
+	// check whether nu-svc is feasible
+	
+	if(svm_type == NU_SVC)
+	{
+		int l = prob->l;
+		int max_nr_class = 16;
+		int nr_class = 0;
+		int *label = Malloc(int,max_nr_class);
+		int *count = Malloc(int,max_nr_class);
+
+		int i;
+		for(i=0;i<l;i++)
+		{
+			int this_label = (int)prob->y[i];
+			int j;
+			for(j=0;j<nr_class;j++)
+				if(this_label == label[j])
+				{
+					++count[j];
+					break;
+				}
+			if(j == nr_class)
+			{
+				if(nr_class == max_nr_class)
+				{
+					max_nr_class *= 2;
+					label = (int *)realloc(label,max_nr_class*sizeof(int));
+					count = (int *)realloc(count,max_nr_class*sizeof(int));
+				}
+				label[nr_class] = this_label;
+				count[nr_class] = 1;
+				++nr_class;
+			}
+		}
+	
+		for(i=0;i<nr_class;i++)
+		{
+			int n1 = count[i];
+			for(int j=i+1;j<nr_class;j++)
+			{
+				int n2 = count[j];
+				if(param->nu*(n1+n2)/2 > min(n1,n2))
+				{
+					free(label);
+					free(count);
+					return "specified nu is infeasible";
+				}
+			}
+		}
+		free(label);
+		free(count);
+	}
+
+	return NULL;
+}
+
+int svm_check_probability_model(const svm_model *model)
+{
+	return ((model->param.svm_type == C_SVC || model->param.svm_type == NU_SVC) &&
+		model->probA!=NULL && model->probB!=NULL) ||
+		((model->param.svm_type == EPSILON_SVR || model->param.svm_type == NU_SVR) &&
+		 model->probA!=NULL);
+}

--- a/skordinal/classifiers/src/orensemble/python/libsvm-2.81/svm.h
+++ b/skordinal/classifiers/src/orensemble/python/libsvm-2.81/svm.h
@@ -1,0 +1,73 @@
+#ifndef _LIBSVM_H
+#define _LIBSVM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct svm_node
+{
+	int index;
+	double value;
+};
+
+struct svm_problem
+{
+	int l;
+	double *y;
+	struct svm_node **x;
+	double *W;
+};
+
+enum { C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR };	/* svm_type */
+enum { LINEAR, POLY, RBF, SIGMOID, STUMP, PERCEPTRON };	/* kernel_type */
+
+struct svm_parameter
+{
+	int svm_type;
+	int kernel_type;
+	double degree;	/* for poly */
+	double gamma;	/* for poly/rbf/sigmoid */
+	double coef0;	/* for poly/sigmoid */
+
+	/* these are for training only */
+	double cache_size; /* in MB */
+	double eps;	/* stopping criteria */
+	double C;	/* for C_SVC, EPSILON_SVR and NU_SVR */
+	int nr_weight;		/* for C_SVC */
+	int *weight_label;	/* for C_SVC */
+	double* weight;		/* for C_SVC */
+	double nu;	/* for NU_SVC, ONE_CLASS, and NU_SVR */
+	double p;	/* for EPSILON_SVR */
+	int shrinking;	/* use the shrinking heuristics */
+	int probability; /* do probability estimates */
+};
+
+struct svm_model *svm_train(const struct svm_problem *prob, const struct svm_parameter *param);
+void svm_cross_validation(const struct svm_problem *prob, const struct svm_parameter *param, int nr_fold, double *target);
+
+int svm_save_model(const char *model_file_name, const struct svm_model *model);
+struct svm_model *svm_load_model(const char *model_file_name);
+
+int svm_get_svm_type(const struct svm_model *model);
+int svm_get_nr_class(const struct svm_model *model);
+void svm_get_labels(const struct svm_model *model, int *label);
+double svm_get_svr_probability(const struct svm_model *model);
+
+void svm_predict_values(const struct svm_model *model, const struct svm_node *x, double* dec_values);
+double svm_predict(const struct svm_model *model, const struct svm_node *x);
+double svm_predict_probability(const struct svm_model *model, const struct svm_node *x, double* prob_estimates);
+
+void svm_destroy_model(struct svm_model *model);
+void svm_destroy_param(struct svm_parameter *param);
+
+const char *svm_check_parameter(const struct svm_problem *prob, const struct svm_parameter *param);
+int svm_check_probability_model(const struct svm_model *model);
+
+double svm_kernel(const svm_node *, const svm_node *, const svm_parameter&);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _LIBSVM_H */

--- a/skordinal/classifiers/src/orensemble/python/orensemble-model-python.cpp
+++ b/skordinal/classifiers/src/orensemble/python/orensemble-model-python.cpp
@@ -24,8 +24,12 @@ PyObject *paramsToPython(const boostrankParams &params)
 
 lemga::AggRank *pythonToModel(PyObject *modelPython)
 {
+    PyObject *bytes = PyUnicode_AsEncodedString(modelPython, "utf-8", "strict");
+    if (NULL == bytes)
+        return NULL;
     std::stringstream ss;
-    ss << PyBytes_AsString(PyUnicode_AsEncodedString(modelPython, "utf-8", "strict"));
+    ss << PyBytes_AsString(bytes);
+    Py_DECREF(bytes);
     return (lemga::AggRank *)Object::create(ss);
 }
 
@@ -73,8 +77,8 @@ boostrankModelParams *pythonToModelAndParams(PyObject *modelParamsPython)
     PyObject *pyParams = PyDict_GetItemString(modelParamsPython, "params");
 
     boostrankModelParams *ret = new boostrankModelParams();
-    ret->model = pythonToModel(pyModel);
-    ret->params = pythonToParams(pyParams);
+    ret->model = pyModel ? pythonToModel(pyModel) : NULL;
+    ret->params = pyParams ? pythonToParams(pyParams) : NULL;
 
     return ret;
 }

--- a/skordinal/classifiers/src/orensemble/python/orensemble-model-python.cpp
+++ b/skordinal/classifiers/src/orensemble/python/orensemble-model-python.cpp
@@ -1,0 +1,80 @@
+#include "orensemble-model-python.h"
+#include "common.h"
+#include <iostream>
+#include <sstream>
+#include <string>
+
+PyObject *modelToPython(const lemga::AggRank *model)
+{
+    std::ostringstream oss;
+    oss << *model;
+    std::string modelStr = oss.str();
+    PyObject *retval = Py_BuildValue("s", modelStr.c_str());
+    return retval;
+}
+
+PyObject *paramsToPython(const boostrankParams &params)
+{
+    return Py_BuildValue(
+        "kkkkkk",
+        params.bag, params.base, params.n_rank,
+        params.n_iter, params.n_in, params.n_out
+    );
+}
+
+lemga::AggRank *pythonToModel(PyObject *modelPython)
+{
+    std::stringstream ss;
+    ss << PyBytes_AsString(PyUnicode_AsEncodedString(modelPython, "utf-8", "strict"));
+    return (lemga::AggRank *)Object::create(ss);
+}
+
+boostrankParams *pythonToParams(PyObject *paramsPyton)
+{
+    UINT bag, base, n_rank, n_iter, n_in, n_out;
+    if (!PyArg_ParseTuple(paramsPyton, "kkkkkk", &bag, &base, &n_rank, &n_iter, &n_in, &n_out))
+    {
+        PyErr_SetString(PyExc_ValueError, "Couldn't parse parameters");
+        return NULL;
+    }
+    boostrankParams *ret = new boostrankParams();
+    ret->bag = bag;
+    ret->base = base;
+    ret->n_rank = n_rank;
+    ret->n_iter = n_iter;
+    ret->n_in = n_in;
+    ret->n_out = n_out;
+
+    return ret;
+}
+
+PyObject *modelAndParamsToPython(const lemga::AggRank *model, const boostrankParams &params)
+{
+
+    PyObject *modelPython = modelToPython(model);
+
+    PyObject *paramsPython = paramsToPython(params);
+
+    PyObject *ret = Py_BuildValue(
+        "{s:O, s:O}",
+        "model", modelPython,
+        "params", paramsPython
+    );
+
+    Py_DECREF(modelPython);
+    Py_DECREF(paramsPython);
+
+    return ret;
+}
+
+boostrankModelParams *pythonToModelAndParams(PyObject *modelParamsPython)
+{
+    PyObject *pyModel = PyDict_GetItemString(modelParamsPython, "model");
+    PyObject *pyParams = PyDict_GetItemString(modelParamsPython, "params");
+
+    boostrankModelParams *ret = new boostrankModelParams();
+    ret->model = pythonToModel(pyModel);
+    ret->params = pythonToParams(pyParams);
+
+    return ret;
+}

--- a/skordinal/classifiers/src/orensemble/python/orensemble-model-python.h
+++ b/skordinal/classifiers/src/orensemble/python/orensemble-model-python.h
@@ -1,0 +1,16 @@
+#ifndef _ORENSEMBLE_MODEL_PYTHON_HPP_
+#define _ORENSEMBLE_MODEL_PYTHON_HPP_
+
+#include "Python.h"
+#include "aggrank.h"
+#include "common.h"
+
+PyObject *modelToPython(const lemga::AggRank *model);
+lemga::AggRank *pythonToModel(PyObject *modelPython);
+
+PyObject *paramsToPython(const boostrankParams &params);
+boostrankParams *pythonToParams(PyObject *paramsPyton);
+
+PyObject *modelAndParamsToPython(const lemga::AggRank *model, const boostrankParams &params);
+boostrankModelParams *pythonToModelAndParams(PyObject *modelParamsPython);
+#endif

--- a/skordinal/classifiers/src/orensemble/python/orensemble-module.cpp
+++ b/skordinal/classifiers/src/orensemble/python/orensemble-module.cpp
@@ -1,0 +1,51 @@
+#include "Python.h"
+
+#include "orensemble-module.h"
+
+/*Python module init*/
+#if PY_MAJOR_VERSION >= 3
+#define IS_PY3K
+#endif
+
+static PyMethodDef orensembleMethods[] = {
+    {"fit", fit, METH_VARARGS, "Fits a model"},
+    {"predict", predict, METH_VARARGS, "Predict labels"},
+    {NULL, NULL, 0, NULL}
+};
+
+#ifndef IS_PY3K /*For Python 2*/
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    DL_EXPORT(void)
+    initorensemble(void)
+    {
+        Py_InitModule("_orensemble", orensembleMethods);
+    }
+#ifdef __cplusplus
+}
+#endif
+#else /*For Python 3*/
+static struct PyModuleDef orensemblemodule = {
+    PyModuleDef_HEAD_INIT,
+    "_orensemble", /* name of module */
+    NULL,          /* module documentation, may be NULL */
+    -1,            /* size of per-interpreter state of the module,
+                   or -1 if the module keeps state in global variables. */
+    orensembleMethods
+};
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    PyMODINIT_FUNC
+    PyInit__orensemble(void)
+    {
+        return PyModule_Create(&orensemblemodule);
+    }
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/skordinal/classifiers/src/orensemble/python/orensemble-module.h
+++ b/skordinal/classifiers/src/orensemble/python/orensemble-module.h
@@ -1,0 +1,9 @@
+#ifndef __ORENSEMBLE_MODULE_H__
+#define __ORENSEMBLE_MODULE_H__
+
+#include "Python.h"
+
+PyObject *fit(PyObject *self, PyObject *args);
+PyObject *predict(PyObject *self, PyObject *args);
+
+#endif

--- a/skordinal/classifiers/src/orensemble/python/train-functions.cpp
+++ b/skordinal/classifiers/src/orensemble/python/train-functions.cpp
@@ -44,7 +44,7 @@ int parseArgumentsTrain(PyObject *args, PyObject **features, PyObject **labels, 
         params.n_rank = n_rank;
         params.n_iter = n_iter;
 
-        params.n_in = PyLong_AsUnsignedLong(PyLong_FromSsize_t(PyList_Size(PyList_GetItem(*features, 0))));
+        params.n_in = (UINT)PyList_Size(PyList_GetItem(*features, 0));
         params.n_out = 1;
         return 0;
     }
@@ -117,12 +117,13 @@ lemga::DataSet *loadData(PyObject *features, PyObject *labels, const boostrankPa
 {
     lemga::DataSet *pd = new lemga::DataSet();
 
-    ssize_t instance_number = PyLong_AsLong(PyLong_FromSsize_t(PyList_Size(features))); /*features rows*/
-    ssize_t label_number = PyLong_AsLong(PyLong_FromSsize_t(PyList_Size(labels)));
+    ssize_t instance_number = PyList_Size(features); /*features rows*/
+    ssize_t label_number = PyList_Size(labels);
 
     if (instance_number != label_number)
     {
         PyErr_SetString(PyExc_ValueError, "Number of labels is different to the number of instances");
+        delete pd;
         return NULL;
     }
 
@@ -131,9 +132,10 @@ lemga::DataSet *loadData(PyObject *features, PyObject *labels, const boostrankPa
         lemga::Input x(params.n_in);
         lemga::Output y(params.n_out);
 
-        if (PyLong_AsUnsignedLong(PyLong_FromSsize_t(PyList_Size(PyList_GetItem(features, i)))) < params.n_in)
+        if ((UINT)PyList_Size(PyList_GetItem(features, i)) < params.n_in)
         {
             PyErr_SetString(PyExc_ValueError, "Instance has less features than expected");
+            delete pd;
             return NULL;
         }
         for (UINT j = 0; j < params.n_in; ++j)
@@ -143,6 +145,7 @@ lemga::DataSet *loadData(PyObject *features, PyObject *labels, const boostrankPa
         if (out < 1)
         {
             PyErr_SetString(PyExc_ValueError, "Found invalid (0) label");
+            delete pd;
             return NULL;
         }
         y[0] = out;

--- a/skordinal/classifiers/src/orensemble/python/train-functions.cpp
+++ b/skordinal/classifiers/src/orensemble/python/train-functions.cpp
@@ -1,0 +1,209 @@
+#include "train-functions.h"
+#include "softperc.h"
+
+#include <feedforwardnn.h>
+#include <nnlayer.h>
+#include <perceptron.h>
+#include <stump.h>
+
+#include "aggrank.h"
+#include "orboost.h"
+#include "rankboost.h"
+
+void setInvalidArgsErrorTrain()
+{
+    PyErr_SetString(
+        PyExc_ValueError,
+        "Usage: model = orensemble.fit( training_labels training_instances bag base n_rank n_iter\n"
+        "bag : 10 = RankBoost, cla_thres, reg_param=0.0\n"
+        "      11 = RankBoost, cla_thres, reg_param=1e-32\n"
+        "      20 = RankBoost, abs_thres, reg_param=0.0\n"
+        "      21 = RankBoost, abs_thres, reg_param=1e-32\n"
+        "      30 = ORBoost, FORM_LR, ordered, sub_iter=1, reg_param=0.0\n"
+        "      31 = ORBoost, FORM_LR, ordered, sub_iter=1, reg_param=1e-32\n"
+        "      40 = ORBoost, FORM_FULL, ordered, sub_iter=1, reg_param=0.0\n"
+        "      41 = ORBoost, FORM_FULL, ordered, sub_iter=1, reg_param=1e-32\n"
+        "base: 100 = stump (without constant)\n"
+        "      200 = perc200 with special bias\n"
+        "      201 = perc200 with special bias, scale=1\n"
+        "      204 = perc200 with special bias, scale=4\n"
+        "      3HH = neural net, number of hidden neurons=HH\n"
+    );
+}
+
+int parseArgumentsTrain(PyObject *args, PyObject **features, PyObject **labels, boostrankParams &params)
+{
+    UINT bag, base, n_rank, n_iter;
+    try
+    {
+        if (!PyArg_ParseTuple(args, "OOkkkk", features, labels, &bag, &base, &n_rank, &n_iter))
+            return 1;
+
+        params.bag = bag;
+        params.base = base;
+        params.n_rank = n_rank;
+        params.n_iter = n_iter;
+
+        params.n_in = PyLong_AsUnsignedLong(PyLong_FromSsize_t(PyList_Size(PyList_GetItem(*features, 0))));
+        params.n_out = 1;
+        return 0;
+    }
+
+    catch (const std::exception &ex)
+    {
+        return 1;
+    }
+}
+lemga::LearnModel *setUpBaseLearner(const boostrankParams &params)
+{
+    lemga::LearnModel *pst = 0;
+
+    switch (params.base)
+    {
+    case 100:
+    {
+        lemga::Stump *p = new lemga::Stump(params.n_in);
+        pst = p;
+        break;
+    }
+    case 200:
+    {
+        lemga::Perceptron *p = new lemga::Perceptron(params.n_in);
+        p->set_parameter(0, 0, 200);
+        p->set_train_method(lemga::Perceptron::RAND_COOR_DESCENT_BIAS);
+        pst = p;
+        break;
+    }
+    case 201:
+    {
+        lemga::SoftPerc *p = new lemga::SoftPerc(params.n_in);
+        p->set_parameter(0, 0, 200);
+        p->set_train_method(lemga::Perceptron::RAND_COOR_DESCENT_BIAS);
+        p->set_scale(1);
+        pst = p;
+        break;
+    }
+    case 204:
+    {
+        lemga::SoftPerc *p = new lemga::SoftPerc(params.n_in);
+        p->set_parameter(0, 0, 200);
+        p->set_train_method(lemga::Perceptron::RAND_COOR_DESCENT_BIAS);
+        p->set_scale(4);
+        pst = p;
+        break;
+    }
+    default:
+        if (params.base / 300 != 1)
+        {
+            PyErr_SetString(PyExc_ValueError, "Invalid base learner\n");
+            return NULL;
+        }
+        lemga::FeedForwardNN *p = new lemga::FeedForwardNN();
+        lemga::NNLayer l(params.n_in, params.base % 300);
+        l.set_weight_range(-1, 1);
+        p->add_top(l);
+        lemga::NNLayer lout(params.base % 300, 1);
+        lout.set_weight_range(-1, 1);
+        p->add_top(lout);
+        p->set_train_method(lemga::FeedForwardNN::CONJUGATE_GRADIENT);
+        p->set_parameter(0.1, 1e-7, 200); // 1e-10, 2000
+        p->initialize();
+        pst = p;
+    }
+    return pst;
+}
+
+lemga::DataSet *loadData(PyObject *features, PyObject *labels, const boostrankParams &params)
+{
+    lemga::DataSet *pd = new lemga::DataSet();
+
+    ssize_t instance_number = PyLong_AsLong(PyLong_FromSsize_t(PyList_Size(features))); /*features rows*/
+    ssize_t label_number = PyLong_AsLong(PyLong_FromSsize_t(PyList_Size(labels)));
+
+    if (instance_number != label_number)
+    {
+        PyErr_SetString(PyExc_ValueError, "Number of labels is different to the number of instances");
+        return NULL;
+    }
+
+    for (ssize_t i = 0; i < instance_number; ++i)
+    {
+        lemga::Input x(params.n_in);
+        lemga::Output y(params.n_out);
+
+        if (PyLong_AsUnsignedLong(PyLong_FromSsize_t(PyList_Size(PyList_GetItem(features, i)))) < params.n_in)
+        {
+            PyErr_SetString(PyExc_ValueError, "Instance has less features than expected");
+            return NULL;
+        }
+        for (UINT j = 0; j < params.n_in; ++j)
+            x[j] = PyFloat_AsDouble(PyList_GetItem(PyList_GetItem(features, i), j));
+
+        REAL out = PyFloat_AsDouble(PyList_GetItem(labels, i));
+        if (out < 1)
+        {
+            PyErr_SetString(PyExc_ValueError, "Found invalid (0) label");
+            return NULL;
+        }
+        y[0] = out;
+        pd->append(x, y);
+    }
+
+    return pd;
+}
+
+lemga::AggRank *setUpModel(const boostrankParams &params)
+{
+    lemga::LearnModel *pst = setUpBaseLearner(params);
+
+    if (NULL == pst)
+        return NULL;
+    lemga::AggRank *pbag = 0;
+
+    switch (params.bag / 10)
+    {
+    case 1:
+    {
+        lemga::RankBoost *p = new lemga::RankBoost(params.n_rank);
+        p->set_thres_mode(lemga::AggRank::THRES_CLALOSS);
+        pbag = p;
+        break;
+    }
+    case 2:
+    {
+        lemga::RankBoost *p = new lemga::RankBoost(params.n_rank);
+        p->set_thres_mode(lemga::AggRank::THRES_ABSLOSS);
+        pbag = p;
+        break;
+    }
+    case 3:
+    {
+        lemga::ORBoost *p = new lemga::ORBoost(params.n_rank);
+        p->set_sub_iter(1);
+        p->set_ordered(true);
+        p->set_form(lemga::ORBoost::FORM_LR);
+        pbag = p;
+        break;
+    }
+    case 4:
+    {
+        lemga::ORBoost *p = new lemga::ORBoost(params.n_rank);
+        p->set_sub_iter(1);
+        p->set_ordered(true);
+        p->set_form(lemga::ORBoost::FORM_FULL);
+        pbag = p;
+        break;
+    }
+    }
+
+    if (params.bag % 10 == 1)
+        pbag->set_reg_param(1e-32);
+    else
+        pbag->set_reg_param(0.0);
+
+    pbag->set_base_model(*pst);
+    pbag->set_max_models(params.n_iter);
+    pbag->reset();
+
+    return pbag;
+}

--- a/skordinal/classifiers/src/orensemble/python/train-functions.h
+++ b/skordinal/classifiers/src/orensemble/python/train-functions.h
@@ -1,0 +1,13 @@
+#ifndef _ORENSEMBLE_TRAIN_COMMON
+#define _ORENSEMBLE_TRAIN_COMMON
+
+#include "Python.h"
+#include "common.h"
+
+void setInvalidArgsErrorTrain();
+int parseArgumentsTrain(PyObject *args, PyObject **features, PyObject **labels, boostrankParams &params);
+lemga::LearnModel *setUpBaseLearner(const boostrankParams &params);
+lemga::AggRank *setUpModel(const boostrankParams &params);
+lemga::DataSet *loadData(PyObject *features, PyObject *labels, const boostrankParams &params);
+
+#endif

--- a/skordinal/classifiers/tests/test_orboost.py
+++ b/skordinal/classifiers/tests/test_orboost.py
@@ -1,0 +1,247 @@
+"""Tests for the ORBoost classifier."""
+
+import inspect
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.exceptions import NotFittedError
+
+from skordinal.classifiers import ORBoost
+from skordinal.datasets import load_era, make_ordinal_classification
+
+
+@pytest.fixture
+def X():
+    """Create sample feature patterns for testing."""
+    return np.array([[0, 1], [1, 0], [1, 1], [0, 0], [1, 2]])
+
+
+@pytest.fixture
+def y():
+    """Create sample target variables for testing."""
+    return np.array([0, 1, 1, 0, 1])
+
+
+@pytest.fixture
+def ordinal_dataset():
+    """Create a synthetic, separable ordinal dataset for behavioral tests."""
+    return make_ordinal_classification(n_samples=120, random_state=0)
+
+
+def test_orboost_default_params():
+    """Test that ORBoost uses the documented default hyperparameters."""
+    classifier = ORBoost()
+
+    assert classifier.n_estimators == 200
+    assert classifier.loss_form == "lr"
+    assert classifier.base_learner == "stump"
+    assert classifier.weight_reg is True
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("n_estimators", 0),
+        ("loss_form", "unknown"),
+        ("base_learner", "svm"),
+    ],
+)
+def test_orboost_hyperparameter_value_validation(X, y, param_name, invalid_value):
+    """Test that ORBoost raises ValueError for invalid of hyperparameters."""
+    classifier = ORBoost(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("n_estimators", 2.5),
+        ("loss_form", 5),
+        ("base_learner", 5),
+        ("weight_reg", "yes"),
+    ],
+)
+def test_orboost_hyperparameter_type_validation(X, y, param_name, invalid_value):
+    """Test that ORBoost raises ValueError for invalid types of hyperparameters."""
+    classifier = ORBoost(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+def test_orboost_parameter_constraints_match_init_params():
+    """Test that _parameter_constraints keys match __init__ parameters."""
+    init_params = set(inspect.signature(ORBoost.__init__).parameters) - {"self"}
+    assert set(ORBoost._parameter_constraints) == init_params
+
+
+def test_orboost_fit_returns_self(X, y):
+    """fit should return self for sklearn compatibility."""
+    classifier = ORBoost(n_estimators=5)
+    model = classifier.fit(X, y)
+    assert model is classifier
+
+
+def test_orboost_fit_input_validation(X, y):
+    """Test that input data is validated."""
+    X_invalid = X[:-1, :-1]
+    y_invalid = y[:-1]
+
+    classifier = ORBoost(n_estimators=5)
+    with pytest.raises(ValueError, match="inconsistent numbers of samples"):
+        classifier.fit(X, y_invalid)
+
+    with pytest.raises(ValueError):
+        classifier.fit([], y)
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, [])
+
+    with pytest.raises(ValueError):
+        classifier.fit(X_invalid, y)
+
+
+def test_orboost_sets_classes_and_n_features_in_after_fit(X, y):
+    """Test that classes_ and n_features_in_ are set after fit."""
+    classifier = ORBoost(n_estimators=5).fit(X, y)
+
+    assert isinstance(classifier.classes_, np.ndarray)
+    np.testing.assert_array_equal(classifier.classes_, np.unique(y))
+    assert isinstance(classifier.n_features_in_, int)
+    assert classifier.n_features_in_ == X.shape[1]
+
+
+def test_orboost_model_dict_present_after_fit(X, y):
+    """Test that model_ is a dict with 'model' and 'params' keys after fit."""
+    classifier = ORBoost(n_estimators=5).fit(X, y)
+
+    assert isinstance(classifier.model_, dict)
+    assert "model" in classifier.model_
+    assert "params" in classifier.model_
+
+
+def test_orboost_predict_raises_if_not_fitted(X):
+    """Test that predict raises NotFittedError if called before fit."""
+    classifier = ORBoost()
+    with pytest.raises(NotFittedError):
+        classifier.predict(X)
+
+
+def test_orboost_feature_names_in_when_dataframe(X, y):
+    """Test that feature_names_in_ is set when X is a DataFrame."""
+    df = pd.DataFrame(X, columns=["f0", "f1"])
+    classifier = ORBoost(n_estimators=5).fit(df, y)
+
+    assert hasattr(classifier, "feature_names_in_")
+    np.testing.assert_array_equal(
+        classifier.feature_names_in_, np.array(["f0", "f1"], dtype=object)
+    )
+
+
+def test_orboost_predict_rejects_wrong_n_features(X, y):
+    """Test that predict rejects input with mismatched n_features."""
+    classifier = ORBoost(n_estimators=5).fit(X, y)
+    with pytest.raises(ValueError):
+        classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_orboost_label_roundtrip(labels):
+    """Test that ORBoost preserves arbitrary ordinal label sets through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = ORBoost(n_estimators=10)
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+@pytest.mark.parametrize("loss_form", ["lr", "full"])
+def test_orboost_loss_form_produces_valid_predictions(ordinal_dataset, loss_form):
+    """Test that both loss_form values produce predictions drawn from classes_."""
+    X, y = ordinal_dataset
+    classifier = ORBoost(n_estimators=20, loss_form=loss_form).fit(X, y)
+
+    preds = classifier.predict(X)
+    assert preds.shape == (len(X),)
+    assert set(preds).issubset(set(classifier.classes_))
+
+
+@pytest.mark.parametrize("base_learner", ["stump", "perceptron"])
+def test_orboost_base_learner_produces_valid_predictions(ordinal_dataset, base_learner):
+    """Test that both base_learner types produce predictions drawn from classes_."""
+    X, y = ordinal_dataset
+    classifier = ORBoost(n_estimators=20, base_learner=base_learner).fit(X, y)
+
+    preds = classifier.predict(X)
+    assert preds.shape == (len(X),)
+    assert set(preds).issubset(set(classifier.classes_))
+
+
+def test_orboost_weight_reg_false_fits_and_predicts(ordinal_dataset):
+    """Test that weight_reg=False fits and predicts without error."""
+    X, y = ordinal_dataset
+    classifier = ORBoost(n_estimators=20, weight_reg=False).fit(X, y)
+
+    preds = classifier.predict(X)
+    assert preds.shape == (len(X),)
+    assert set(preds).issubset(set(classifier.classes_))
+
+
+def test_orboost_full_loss_form_weight_reg_false_fits_and_predicts(ordinal_dataset):
+    """Test that loss_form='full' combined with weight_reg=False fits and predicts."""
+    X, y = ordinal_dataset
+    classifier = ORBoost(n_estimators=20, loss_form="full", weight_reg=False)
+    classifier.fit(X, y)
+
+    preds = classifier.predict(X)
+    assert preds.shape == (len(X),)
+    assert set(preds).issubset(set(classifier.classes_))
+
+
+def test_orboost_stump_predictions_are_deterministic(ordinal_dataset):
+    """Test that two default (stump) fits on the same data give equal predicts."""
+    X, y = ordinal_dataset
+    classifier_a = ORBoost(n_estimators=20).fit(X, y)
+    classifier_b = ORBoost(n_estimators=20).fit(X, y)
+
+    np.testing.assert_array_equal(classifier_a.predict(X), classifier_b.predict(X))
+
+
+def test_orboost_predictions_are_nontrivial(ordinal_dataset):
+    """Test that predictions use multiple classes and beat the majority baseline."""
+    X, y = ordinal_dataset
+    classifier = ORBoost(n_estimators=20).fit(X, y)
+
+    preds = classifier.predict(X)
+    assert len(np.unique(preds)) > 1
+
+    majority_baseline = np.unique(y, return_counts=True)[1].max() / len(y)
+    training_accuracy = np.mean(preds == y)
+    assert training_accuracy > majority_baseline
+
+
+def test_orboost_fits_on_era_dataset():
+    """Test that ORBoost fits and predicts on the real-world ERA dataset."""
+    X, y = load_era(return_X_y=True)
+    classifier = ORBoost(n_estimators=10).fit(X, y)
+
+    preds = classifier.predict(X)
+    assert preds.shape == (len(X),)
+    assert set(preds).issubset(set(classifier.classes_))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `ORBoost`, an ordinal boosting classifier that fits a thresholded ensemble of decision stumps or perceptrons by minimising an exponential loss over ordinal ranks. A new CPython extension, `_orensemble`, wraps the vendored `orensemble` C++ library, and `predict` returns hard class labels. The vendored library sources are unchanged from upstream apart from the edits below. One comments out a training message printed to stderr. One adds a missing `<cstring>` include. Twelve add explicit boolean casts where streams are returned from functions that return `bool`, required since C++11. The last three repair undefined behaviour in the stump learner, a past-the-end iterator increment and an uninitialised member, which crashed or corrupted the model on libc++.