### PR TITLE
ENH: Add ELMOP ordinal extreme learning machine

### DIFF
--- a/skordinal/classifiers/__init__.py
+++ b/skordinal/classifiers/__init__.py
@@ -1,6 +1,7 @@
 """Ordinal classification classifiers module."""
 
 from ._cost_sensitive_wrapper import CostSensitiveWrapper
+from ._elmop import ELMOP
 from ._nnop import NNOP
 from ._nnpom import NNPOM
 from ._ordinal_decomposition import OrdinalDecomposition
@@ -10,6 +11,7 @@ from ._svorex import SVOREX
 
 __all__ = [
     "CostSensitiveWrapper",
+    "ELMOP",
     "NNOP",
     "NNPOM",
     "OrdinalDecomposition",

--- a/skordinal/classifiers/_elmop.py
+++ b/skordinal/classifiers/_elmop.py
@@ -1,0 +1,293 @@
+"""Extreme Learning Machine for Ordered Partitions (ELMOP)."""
+
+from numbers import Integral
+
+import numpy as np
+from scipy.special import expit
+from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.utils import check_random_state
+from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.utils.validation import check_is_fitted
+
+from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.validation import check_ordinal_targets
+
+
+def _losses_to_proba(losses):
+    """Convert a per-sample loss matrix to row-normalised probabilities."""
+    eps = np.finfo(float).tiny
+    scores = 1.0 / (np.asarray(losses, dtype=np.float64) + eps)
+    scores -= scores.max(axis=1, keepdims=True)
+    proba = np.exp(scores)
+    proba /= proba.sum(axis=1, keepdims=True)
+    return proba
+
+
+class ELMOP(ClassifierMixin, BaseEstimator):
+    """Extreme Learning Machine for Ordered Partitions.
+
+    ELMOP [1]_ combines a single-hidden-layer network, whose input weights
+    and biases are drawn randomly and then frozen, with the
+    ordered-partitions coding of ordinal targets. The output layer is
+    obtained in closed form via a single least-squares solve, so no
+    iterative optimisation is required.
+
+    Each of the ``K - 1`` output neurons solves one binary partition — the
+    classes with rank above ``j`` vs. the rest — in ``{-1, +1}`` regression
+    form. At prediction time the joint output is decoded to a single label
+    by minimising an exponential loss against the ``(K, K - 1)`` code
+    matrix.
+
+    Parameters
+    ----------
+    n_hidden : int, default=50
+        Number of neurons in the hidden layer. Must be >= 1.
+
+    activation : {"sigmoid", "hardlim"}, default="sigmoid"
+        Activation function applied to the pre-activation values.
+        ``"sigmoid"`` is the logistic sigmoid; ``"hardlim"`` is the
+        Heaviside step function (outputs 0 or 1).
+
+    random_state : int, RandomState instance or None, default=None
+        Controls the random initialisation of the input weights and biases.
+        Pass an int for reproducible results across multiple calls.
+
+    Attributes
+    ----------
+    classes_ : ndarray of shape (n_classes,)
+        Unique ordinal class labels seen during ``fit``, sorted in ascending
+        order.
+
+    n_features_in_ : int
+        Number of features seen during ``fit``.
+
+    feature_names_in_ : ndarray of shape (n_features_in_,), dtype object
+        Feature names seen during ``fit``. Defined only when ``X`` is a
+        ``pandas.DataFrame``.
+
+    input_weights_ : ndarray of shape (n_hidden, n_features_in_)
+        Random input-to-hidden weight matrix, drawn at ``fit`` and kept
+        fixed. Each entry is uniform on ``[-1, 1]``.
+
+    input_biases_ : ndarray of shape (n_hidden,)
+        Random hidden-unit biases, drawn at ``fit`` and kept fixed. Each
+        entry is uniform on ``[0, 1]``.
+
+    output_weights_ : ndarray of shape (n_hidden, n_classes - 1)
+        Output weights computed by least-squares regression of the hidden
+        activations onto the ordered-partitions target matrix.
+
+    Notes
+    -----
+    The random input biases are added to the pre-activations before either
+    activation function is applied.
+
+    When ``n_hidden`` exceeds the number of training samples the hidden
+    matrix is rank-deficient and ``numpy.linalg.lstsq`` returns the
+    minimum-norm solution.
+
+    The formulation in [1]_ uses ``K`` output neurons, the first of which
+    regresses a constant all-positive column. That column adds the same
+    term to the decoding loss of every candidate class, so it cannot
+    change the prediction; this implementation drops it and works with
+    ``K - 1`` partitions.
+
+    The input weights are drawn on ``[-1, 1]`` with no data-dependent
+    scaling, so results are sensitive to feature scale. Standardising
+    features (e.g. with ``sklearn.preprocessing.StandardScaler``) before
+    fitting is strongly recommended.
+
+    References
+    ----------
+    .. [1] W.-Y. Deng, Q.-H. Zheng, S. Lian, L. Chen, X. Wang,
+       "Ordinal extreme learning machine", Neurocomputing, vol. 74,
+       no. 1-3, pp. 447-456, 2010.
+       https://doi.org/10.1016/j.neucom.2010.08.022
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.classifiers import ELMOP
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((80, 4))
+    >>> y = np.repeat([1, 2, 3, 4], 20)
+    >>> clf = ELMOP(n_hidden=50, random_state=0).fit(X, y)
+    >>> clf.predict(X[:5])  # doctest: +SKIP
+    array([1, 2, 3, 4, ...])
+    """
+
+    _parameter_constraints: dict = {
+        "n_hidden": [Interval(Integral, 1, None, closed="left")],
+        "activation": [StrOptions({"sigmoid", "hardlim"})],
+        "random_state": ["random_state"],
+    }
+
+    def __init__(
+        self,
+        *,
+        n_hidden=50,
+        activation="sigmoid",
+        random_state=None,
+    ):
+        self.n_hidden = n_hidden
+        self.activation = activation
+        self.random_state = random_state
+
+    def _hidden(self, X):
+        """Compute hidden-layer activations for pre-validated input X."""
+        Z = X @ self.input_weights_.T + self.input_biases_
+        if self.activation == "sigmoid":
+            return expit(Z)
+        return (Z >= 0.0).astype(np.float64)
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y):
+        """Fit the ELMOP model to training data.
+
+        Draws random input weights and biases, computes the hidden-layer
+        activations, then solves for the output weights via least squares.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training patterns.
+
+        y : array-like of shape (n_samples,)
+            Ordinal target labels. Must contain at least 2 unique classes.
+
+        Returns
+        -------
+        self : ELMOP
+            Fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` contains fewer than 2 unique classes.
+        """
+        X, y = validate_data(self, X, y, dtype=np.float64)
+        self.classes_, y_enc = check_ordinal_targets(y)
+        rng = check_random_state(self.random_state)
+
+        d = X.shape[1]
+        K = len(self.classes_)
+
+        # Draw the frozen random feature map.
+        self.input_weights_ = rng.uniform(-1.0, 1.0, size=(self.n_hidden, d))
+        self.input_biases_ = rng.uniform(0.0, 1.0, size=(self.n_hidden,))
+
+        # Build the ordered-partitions target matrix in {-1, +1}:
+        # T[i, j] = +1 iff y_enc[i] >= j + 1.
+        T = np.where(
+            y_enc[:, np.newaxis] >= np.arange(1, K)[np.newaxis, :],
+            1.0,
+            -1.0,
+        )  # (n, K-1)
+
+        H = self._hidden(X)  # (n, n_hidden)
+        self.output_weights_, *_ = np.linalg.lstsq(H, T, rcond=None)  # (n_hidden, K-1)
+
+        return self
+
+    def _losses(self, X):
+        """Compute exponential decoding losses for pre-validated X."""
+        K = len(self.classes_)
+        H_test = self._hidden(X)  # (n_test, n_hidden)
+        TY = H_test @ self.output_weights_  # (n_test, K-1)
+
+        # Build the code matrix: C[k, j] = +1 if k >= j + 1 else -1.
+        C = np.where(
+            np.arange(K)[:, np.newaxis] >= np.arange(1, K)[np.newaxis, :],
+            1.0,
+            -1.0,
+        )  # (K, K-1)
+
+        # Sum the exponential loss of the outputs against each code row.
+        losses = np.exp(-TY[:, np.newaxis, :] * C[np.newaxis, :, :]).sum(
+            axis=2
+        )  # (n_test, K)
+
+        return losses
+
+    def _proba(self, X):
+        """Compute class probabilities from pre-validated X."""
+        return _losses_to_proba(self._losses(X))
+
+    def predict(self, X):
+        """Predict ordinal class labels for patterns in X.
+
+        The predicted label is the class whose ordered-partitions code
+        vector minimises the exponential decoding loss of the network
+        outputs. Ties are broken toward the lowest class.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted class labels drawn from ``self.classes_``.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return self.classes_[self._losses(X).argmin(axis=1)]
+
+    def predict_proba(self, X):
+        """Return per-class probability estimates.
+
+        Probabilities are derived from the per-class exponential decoding
+        losses through a monotone decreasing transform, so smaller loss
+        means higher probability and ``predict`` coincides with the
+        argmax of ``predict_proba``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Non-negative class probabilities; each row sums to 1.0.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return self._proba(X)
+
+    def predict_cumproba(self, X):
+        """Cumulative class probabilities for each sample.
+
+        Derived from ``predict_proba`` as
+        ``numpy.cumsum(predict_proba(X), axis=1)[:, :-1]``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input samples.
+
+        Returns
+        -------
+        cumproba : ndarray of shape (n_samples, n_classes - 1)
+            Entry ``[i, k]`` is the estimated probability that sample ``i``
+            belongs to class ``k`` or lower.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return np.cumsum(self._proba(X), axis=1)[:, :-1]

--- a/skordinal/classifiers/tests/test_elmop.py
+++ b/skordinal/classifiers/tests/test_elmop.py
@@ -1,0 +1,239 @@
+"""Tests for the ELMOP classifier."""
+
+import inspect
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.exceptions import NotFittedError
+
+from skordinal.classifiers import ELMOP
+
+
+@pytest.fixture
+def X():
+    """Create sample feature patterns for testing."""
+    return np.array([[0, 1], [1, 0], [1, 1], [0, 0], [1, 2]])
+
+
+@pytest.fixture
+def y():
+    """Create sample target variables for testing."""
+    return np.array([0, 1, 1, 0, 1])
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("n_hidden", 0),
+        ("n_hidden", -1),
+        ("activation", "relu"),
+    ],
+)
+def test_elmop_hyperparameter_value_validation(X, y, param_name, invalid_value):
+    """Test that ELMOP raises ValueError for invalid of hyperparameters."""
+    classifier = ELMOP(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("n_hidden", 5.5),
+        ("activation", 42),
+        ("random_state", "seed"),
+        ("random_state", 1.5),
+    ],
+)
+def test_elmop_hyperparameter_type_validation(X, y, param_name, invalid_value):
+    """Test that ELMOP raises ValueError for invalid types of hyperparameters."""
+    classifier = ELMOP(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+def test_elmop_fit_returns_self(X, y):
+    """fit should return self for sklearn compatibility."""
+    classifier = ELMOP()
+    model = classifier.fit(X, y)
+    assert model is classifier
+
+
+def test_elmop_fit_input_validation(X, y):
+    """Test that input data is validated."""
+    X_invalid = X[:-1, :-1]
+    y_invalid = y[:-1]
+
+    classifier = ELMOP()
+    with pytest.raises(ValueError):
+        classifier.fit(X, y_invalid)
+
+    with pytest.raises(ValueError):
+        classifier.fit([], y)
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, [])
+
+    with pytest.raises(ValueError):
+        classifier.fit(X_invalid, y)
+
+
+def test_elmop_sets_fitted_attributes_after_fit(X, y):
+    """Test than ELMOP exposes fitted attributes aligned con sklearn-style."""
+    clf = ELMOP(n_hidden=4)
+    clf.fit(X, y)
+
+    for attr in [
+        "classes_",
+        "n_features_in_",
+        "input_weights_",
+        "input_biases_",
+        "output_weights_",
+    ]:
+        assert hasattr(clf, attr), f"Missing fitted attribute: {attr}"
+
+    assert isinstance(clf.classes_, np.ndarray) and np.array_equal(
+        clf.classes_, np.unique(y)
+    )
+    assert isinstance(clf.n_features_in_, int) and clf.n_features_in_ == X.shape[1]
+    assert clf.input_weights_.shape == (4, X.shape[1])
+    assert clf.input_biases_.shape == (4,)
+    assert clf.output_weights_.shape == (4, len(np.unique(y)) - 1)
+    assert np.isfinite(clf.output_weights_).all()
+
+
+def test_elmop_predict_invalid_input_raises_error(X, y):
+    """Test that invalid input raises an error."""
+    classifier = ELMOP()
+    classifier.fit(X, y)
+
+    with pytest.raises(ValueError):
+        classifier.predict([])
+
+
+def test_elmop_predict_raises_if_not_fitted(X):
+    """Test that predict raises NotFittedError if called before fit."""
+    classifier = ELMOP()
+    with pytest.raises(NotFittedError):
+        classifier.predict(X)
+
+
+def test_elmop_feature_names_in_when_dataframe(X, y):
+    """Test that feature_names_in_ is set when X is a DataFrame."""
+    df = pd.DataFrame(X, columns=["f0", "f1"])
+    classifier = ELMOP(n_hidden=4).fit(df, y)
+
+    assert hasattr(classifier, "feature_names_in_")
+    np.testing.assert_array_equal(
+        classifier.feature_names_in_, np.array(["f0", "f1"], dtype=object)
+    )
+
+
+def test_elmop_parameter_constraints_match_init_params():
+    """Test that _parameter_constraints keys match __init__ parameters."""
+    init_params = set(inspect.signature(ELMOP.__init__).parameters) - {"self"}
+    assert set(ELMOP._parameter_constraints) == init_params
+
+
+def test_elmop_predict_rejects_wrong_n_features(X, y):
+    """Test that predict rejects input with mismatched n_features."""
+    classifier = ELMOP(n_hidden=4).fit(X, y)
+    with pytest.raises(ValueError):
+        classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_elmop_label_roundtrip(labels):
+    """Test that ELMOP preserves arbitrary ordinal label sets through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = ELMOP(n_hidden=4)
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_elmop_random_state_reproducibility(X, y):
+    """Two fits with the same seed produce identical weight matrices."""
+    clf_a = ELMOP(n_hidden=4, random_state=0).fit(X, y)
+    clf_b = ELMOP(n_hidden=4, random_state=0).fit(X, y)
+
+    np.testing.assert_array_equal(clf_a.input_weights_, clf_b.input_weights_)
+    np.testing.assert_array_equal(clf_a.input_biases_, clf_b.input_biases_)
+    np.testing.assert_array_equal(clf_a.output_weights_, clf_b.output_weights_)
+
+
+def test_elmop_random_state_different_seeds_differ(X, y):
+    """Different seeds produce different random input weights."""
+    clf_a = ELMOP(n_hidden=4, random_state=0).fit(X, y)
+    clf_b = ELMOP(n_hidden=4, random_state=1).fit(X, y)
+
+    assert not np.array_equal(clf_a.input_weights_, clf_b.input_weights_)
+
+
+def test_elmop_random_state_accepts_random_state_instance(X, y):
+    """RandomState instance gives the same result as the equivalent seed."""
+    rs_seed = ELMOP(n_hidden=4, random_state=42).fit(X, y)
+    rs_instance = ELMOP(n_hidden=4, random_state=np.random.RandomState(42)).fit(X, y)
+
+    np.testing.assert_array_equal(rs_seed.input_weights_, rs_instance.input_weights_)
+
+
+def test_elmop_predict_cumproba_shape_and_bounds(X, y):
+    """predict_cumproba has shape (n, n_classes - 1) with values in [0, 1]."""
+    classifier = ELMOP(n_hidden=4, random_state=0).fit(X, y)
+    cumproba = classifier.predict_cumproba(X)
+
+    n_classes = len(np.unique(y))
+    assert cumproba.shape == (X.shape[0], n_classes - 1)
+    assert np.all(cumproba >= 0.0) and np.all(cumproba <= 1.0)
+
+
+def test_elmop_activation_changes_output_weights(X, y):
+    """Different activation functions produce different output weights."""
+    clf_sigmoid = ELMOP(activation="sigmoid", random_state=0).fit(X, y)
+    clf_hardlim = ELMOP(activation="hardlim", random_state=0).fit(X, y)
+
+    assert not np.allclose(clf_sigmoid.output_weights_, clf_hardlim.output_weights_)
+
+
+def test_elmop_n_hidden_greater_than_n_samples_finite():
+    """Fitting with more hidden units than samples yields finite weights."""
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((20, 3))
+    y = np.tile(np.arange(3), 20 // 3 + 1)[:20]
+
+    classifier = ELMOP(n_hidden=100, random_state=0).fit(X, y)
+
+    n_classes = len(np.unique(y))
+    assert classifier.output_weights_.shape == (100, n_classes - 1)
+    assert np.isfinite(classifier.output_weights_).all()
+
+
+def test_elmop_large_magnitude_x_no_nan():
+    """Large-magnitude inputs still yield finite, normalised probabilities."""
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((60, 4)) * 1000.0
+    y = np.tile(np.arange(3), 20)
+
+    classifier = ELMOP(random_state=0).fit(X, y)
+    proba = classifier.predict_proba(X)
+
+    assert np.isfinite(proba).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-12)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `ELMOP`, an ordinal extreme learning machine. It combines a single hidden layer, whose input weights and biases are drawn at random and frozen, with an ordered-partitions coding of the target. The output layer is fitted in closed form with one least-squares solve, so no iterative optimisation is needed. It exposes `predict`, `predict_proba` and `predict_cumproba`, and `random_state` makes fitting reproducible.