### PR TITLE
MNT: Update LICENSE copyright holder to skordinal

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, The ORCA-python developer
+Copyright (c) 2025, The skordinal developers
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

The LICENSE named `The ORCA-python` as the copyright holder, referring to the predecessor project. This updates it to `The skordinal developers`, matching the project name and the authors listed in `pyproject.toml`.