### PR TITLE
ENH: Add shared ordinal math utilities

### DIFF
--- a/skordinal/classifiers/_cost_sensitive_wrapper.py
+++ b/skordinal/classifiers/_cost_sensitive_wrapper.py
@@ -18,6 +18,7 @@ from sklearn.utils._param_validation import HasMethods
 from sklearn.utils.validation import check_is_fitted
 
 from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.extmath import normalize_proba_rows
 from skordinal.utils.validation import check_ordinal_targets
 
 
@@ -216,12 +217,4 @@ class CostSensitiveWrapper(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
             idx = int(np.searchsorted(est_p.classes_, 1))
             P[:, p] = est_p.predict_proba(X)[:, idx]
 
-        # Replace all-zero rows with the uniform distribution
-        zero_rows = P.sum(axis=1) == 0.0
-        P[zero_rows] = 1.0 / K
-
-        # Clip to a tiny floor and renormalise each row to sum to one
-        np.clip(P, np.finfo(float).tiny, None, out=P)
-        P /= P.sum(axis=1, keepdims=True)
-
-        return P
+        return normalize_proba_rows(P)

--- a/skordinal/classifiers/_elmop.py
+++ b/skordinal/classifiers/_elmop.py
@@ -10,17 +10,8 @@ from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.validation import check_is_fitted
 
 from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.extmath import losses_to_proba, proba_to_cumproba
 from skordinal.utils.validation import check_ordinal_targets
-
-
-def _losses_to_proba(losses):
-    """Convert a per-sample loss matrix to row-normalised probabilities."""
-    eps = np.finfo(float).tiny
-    scores = 1.0 / (np.asarray(losses, dtype=np.float64) + eps)
-    scores -= scores.max(axis=1, keepdims=True)
-    proba = np.exp(scores)
-    proba /= proba.sum(axis=1, keepdims=True)
-    return proba
 
 
 class ELMOP(ClassifierMixin, BaseEstimator):
@@ -211,7 +202,7 @@ class ELMOP(ClassifierMixin, BaseEstimator):
 
     def _proba(self, X):
         """Compute class probabilities from pre-validated X."""
-        return _losses_to_proba(self._losses(X))
+        return losses_to_proba(self._losses(X))
 
     def predict(self, X):
         """Predict ordinal class labels for patterns in X.
@@ -243,9 +234,10 @@ class ELMOP(ClassifierMixin, BaseEstimator):
         """Return per-class probability estimates.
 
         Probabilities are derived from the per-class exponential decoding
-        losses through a monotone decreasing transform, so smaller loss
-        means higher probability and ``predict`` coincides with the
-        argmax of ``predict_proba``.
+        losses through a monotone decreasing transform, so smaller loss means
+        higher probability and, apart from floating-point ties in the
+        transformed scores, ``predict`` coincides with the argmax of
+        ``predict_proba``.
 
         Parameters
         ----------
@@ -269,8 +261,8 @@ class ELMOP(ClassifierMixin, BaseEstimator):
     def predict_cumproba(self, X):
         """Cumulative class probabilities for each sample.
 
-        Derived from ``predict_proba`` as
-        ``numpy.cumsum(predict_proba(X), axis=1)[:, :-1]``.
+        Derived from ``predict_proba`` as the row-wise cumulative sum of
+        all but the last column.
 
         Parameters
         ----------
@@ -290,4 +282,4 @@ class ELMOP(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False, dtype=np.float64)
-        return np.cumsum(self._proba(X), axis=1)[:, :-1]
+        return proba_to_cumproba(self._proba(X))

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -14,6 +14,7 @@ from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
 from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.extmath import params_to_thresholds, thresholds_grad
 from skordinal.utils.validation import check_ordinal_targets
 
 
@@ -221,7 +222,9 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         self.theta1_ = theta1
         self.theta2_ = theta2
-        self.thresholds_ = self._convert_thresholds(thresholds_param, n_classes)
+        self.thresholds_ = params_to_thresholds(thresholds_param.ravel()).reshape(
+            1, n_classes - 1
+        )
 
         # Scikit-learn compatibility
         self.n_layers_ = 3
@@ -359,51 +362,6 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         return W
 
-    def _convert_thresholds(
-        self,
-        thresholds_param: np.ndarray,
-        n_classes: int,
-    ) -> np.ndarray:
-        """Transform thresholds to perform unconstrained optimization.
-
-        thresholds(1) = thresholds_param(1)
-        thresholds(2) = thresholds_param(1) + thresholds_param(2)**2
-        thresholds(3) = thresholds_param(1) + thresholds_param(2)**2 +
-                        thresholds_param(3)**2
-
-        Parameters
-        ----------
-        thresholds_param : ndarray of shape (n_classes - 1, 1)
-            Contains the original value of the thresholds between classes
-
-        n_classes : int
-            Number of classes.
-
-        Returns
-        -------
-        thresholds : ndarray of shape (n_classes - 1, 1)
-            Thresholds of the line
-
-        """
-        # Threshold ^2 element by element
-        thresholds_pquad = thresholds_param**2
-
-        # Gets row-array containing the thresholds
-        thresholds = np.reshape(
-            np.multiply(
-                np.tile(
-                    np.concatenate(
-                        (thresholds_param[0:1], thresholds_pquad[1:]), axis=0
-                    ),
-                    (1, n_classes - 1),
-                ).T,
-                np.tril(np.ones((n_classes - 1, n_classes - 1))),
-            ).sum(axis=1),
-            (n_classes - 1, 1),
-        ).T
-
-        return thresholds
-
     def _nnpom_cost_function(
         self,
         nn_params: np.ndarray,
@@ -460,7 +418,9 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         )
 
         # Convert thresholds
-        thresholds = self._convert_thresholds(thresholds_param, n_classes)
+        thresholds = params_to_thresholds(thresholds_param.ravel()).reshape(
+            1, n_classes - 1
+        )
 
         # Setup some useful variables
         n_samples = np.size(X, 0)
@@ -524,33 +484,15 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         theta1_grad = delta_1 / n_samples + p1
         theta2_grad = delta_2 / n_samples + p2
 
-        # Threshold gradients
-        thresh_grad_matrix = np.multiply(
-            np.concatenate(
-                (
-                    np.triu(np.ones((n_classes - 1, n_classes - 1))),
-                    np.ones((n_classes - 1, 1)),
-                ),
-                axis=1,
-            ),
-            np.tile(g_gradients.sum(axis=0), (n_classes - 1, 1)),
-        )
-
-        original_shape = thresh_grad_matrix.shape
-        thresh_grad_matrix = thresh_grad_matrix.flatten(order="F")
-
-        thresh_grad_matrix[(n_classes)::n_classes] = thresh_grad_matrix.flatten(
-            order="F"
-        )[(n_classes)::n_classes] + np.multiply(
-            error_der[:, 1 : (n_classes - 1)], f_gradients[:, 0 : (n_classes - 2)]
-        ).sum(axis=0)
-
-        thresh_grad_matrix = np.reshape(
-            thresh_grad_matrix[:, np.newaxis], original_shape, order="F"
-        )
-
-        threshold_grad = thresh_grad_matrix.sum(axis=1)[:, np.newaxis] / n_samples
-        threshold_grad[1:] = 2 * np.multiply(threshold_grad[1:], thresholds_param[1:])
+        # Threshold gradients: dJ/d(threshold) for each of the n_classes - 1
+        # ordered thresholds, pushed back through the unconstrained
+        # parametrization via the chain rule
+        raw_threshold_grad = (
+            (error_der[:, : n_classes - 1] - error_der[:, 1:n_classes]) * f_gradients
+        ).sum(axis=0) / n_samples
+        threshold_grad = thresholds_grad(
+            thresholds_param.ravel(), raw_threshold_grad
+        ).reshape(-1, 1)
 
         # Unroll gradients
         grad = np.concatenate(

--- a/skordinal/classifiers/_ordinal_decomposition.py
+++ b/skordinal/classifiers/_ordinal_decomposition.py
@@ -12,6 +12,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from skordinal.model_selection import load_classifier
 from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.extmath import losses_to_proba
 from skordinal.utils.validation import check_ordinal_targets
 
 
@@ -294,11 +295,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
 
             # Transforming from binary problems to the original problem
             losses = self._exponential_loss(predictions).astype(float)
-            eps = np.finfo(float).tiny
-            scores = 1.0 / (losses + eps)
-            scores -= scores.max(axis=1, keepdims=True)
-            y_proba = np.exp(scores)
-            y_proba /= y_proba.sum(axis=1, keepdims=True)
+            y_proba = losses_to_proba(losses)
 
         elif decision_method == "hinge_loss":
             # Scaling predictions from [0,1] range to [-1,1]
@@ -306,11 +303,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
 
             # Transforming from binary problems to the original problem
             losses = self._hinge_loss(predictions).astype(float)
-            eps = np.finfo(float).tiny
-            scores = 1.0 / (losses + eps)
-            scores -= scores.max(axis=1, keepdims=True)
-            y_proba = np.exp(scores)
-            y_proba /= y_proba.sum(axis=1, keepdims=True)
+            y_proba = losses_to_proba(losses)
 
         elif decision_method == "logarithmic_loss":
             # Scaling predictions from [0,1] range to [-1,1]
@@ -318,11 +311,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
 
             # Transforming from binary problems to the original problem
             losses = self._logarithmic_loss(predictions).astype(float)
-            eps = np.finfo(float).tiny
-            scores = 1.0 / (losses + eps)
-            scores -= scores.max(axis=1, keepdims=True)
-            y_proba = np.exp(scores)
-            y_proba /= y_proba.sum(axis=1, keepdims=True)
+            y_proba = losses_to_proba(losses)
 
         elif decision_method == "frank_hall":
             # Transforming from binary problems to the original problem

--- a/skordinal/classifiers/tests/test_cost_sensitive_wrapper.py
+++ b/skordinal/classifiers/tests/test_cost_sensitive_wrapper.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
+from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.neighbors import KNeighborsClassifier
 
@@ -80,6 +81,16 @@ def test_cost_sensitive_wrapper_predict_proba_sums_to_one(X, y):
     assert proba.shape == (X.shape[0], classifier.classes_.size)
     npt.assert_allclose(proba.sum(axis=1), np.ones(X.shape[0]))
     assert np.all(proba >= 0.0)
+
+
+def test_cost_sensitive_wrapper_predict_proba_all_zero_row_falls_back_to_uniform(X, y):
+    """An all-zero per-class score row falls back to a uniform distribution."""
+    base = DummyClassifier(strategy="constant", constant=0)
+    classifier = CostSensitiveWrapper(base).fit(X, y)
+    proba = classifier.predict_proba(X)
+
+    K = classifier.classes_.size
+    npt.assert_allclose(proba, np.full((X.shape[0], K), 1.0 / K))
 
 
 def test_cost_sensitive_wrapper_sets_classes_and_n_features_in_after_fit(X, y):

--- a/skordinal/classifiers/tests/test_nnpom.py
+++ b/skordinal/classifiers/tests/test_nnpom.py
@@ -5,6 +5,7 @@ import inspect
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.optimize import check_grad
 from sklearn.exceptions import NotFittedError
 
 from skordinal.classifiers import NNPOM
@@ -216,3 +217,34 @@ def test_fit_no_nan_with_near_zero_probabilities():
     assert np.isfinite(clf.theta2_).all()
     assert np.isfinite(clf.thresholds_).all()
     assert set(clf.predict(X_reg)).issubset(set(clf.classes_))
+
+
+def test_nnpom_cost_function_gradient_matches_finite_difference():
+    """The analytic cost gradient matches a finite-difference approximation."""
+    rng = np.random.default_rng(0)
+    n_samples, n_features, n_hidden, n_classes = 30, 4, 3, 3
+    X_data = rng.standard_normal((n_samples, n_features))
+    y_encoded = rng.integers(0, n_classes, size=n_samples)
+    Y = np.eye(n_classes)[y_encoded]
+
+    n_theta1 = n_hidden * (n_features + 1)
+    n_theta2 = n_hidden
+    n_thresholds = n_classes - 1
+    x0 = rng.standard_normal(n_theta1 + n_theta2 + n_thresholds) * 0.1
+
+    clf = NNPOM()
+
+    def cost(nn_params):
+        J, _ = clf._nnpom_cost_function(
+            nn_params, n_features, n_hidden, n_classes, X_data, Y, 0.01
+        )
+        return J
+
+    def grad(nn_params):
+        _, g = clf._nnpom_cost_function(
+            nn_params, n_features, n_hidden, n_classes, X_data, Y, 0.01
+        )
+        return g
+
+    err = check_grad(cost, grad, x0)
+    assert err < 1e-4

--- a/skordinal/preprocessing/_coding.py
+++ b/skordinal/preprocessing/_coding.py
@@ -78,9 +78,8 @@ def binary_cumulative_to_ordinal(
     per-row count of crossed thresholds, which indexes into
     ``classes``.
 
-    This routine does NOT correct monotonicity violations — call
-    :func:`skordinal.utils.validation.check_monotonic_probabilities`
-    beforehand if the binary predictions may be non-monotone.
+    This routine does not correct monotonicity violations; rows are
+    decoded as given.
 
     Parameters
     ----------

--- a/skordinal/utils/__init__.py
+++ b/skordinal/utils/__init__.py
@@ -1,13 +1,11 @@
 """Utilities for ordinal classification."""
 
-from skordinal.utils.validation import (
-    check_monotonic_probabilities,
-    check_ordinal_targets,
-    validate_thresholds,
-)
+from skordinal.utils.extmath import cumproba_to_proba, repair_cumproba
+from skordinal.utils.validation import check_ordinal_targets, validate_thresholds
 
 __all__ = [
-    "check_monotonic_probabilities",
     "check_ordinal_targets",
+    "cumproba_to_proba",
+    "repair_cumproba",
     "validate_thresholds",
 ]

--- a/skordinal/utils/extmath.py
+++ b/skordinal/utils/extmath.py
@@ -1,0 +1,504 @@
+"""Mathematical utilities shared across ordinal classifiers."""
+
+import numpy as np
+from sklearn.isotonic import isotonic_regression
+from sklearn.utils import check_array
+
+
+def params_to_thresholds(params):
+    """Map unconstrained threshold parameters to ordered thresholds.
+
+    Applies the cumsum-of-squares transform:
+
+        b[0] = params[0]
+        b[k] = params[0] + sum_{j=1..k} params[j]^2   for k >= 1
+
+    This guarantees ``b[0] <= b[1] <= ... <= b[K-2]`` for any unconstrained
+    ``params``, enabling gradient-based optimisation without explicit
+    ordering constraints.
+
+    Parameters
+    ----------
+    params : ndarray of shape (K-1,)
+        Unconstrained parameter vector. The first element is free; the
+        remaining elements are squared to form non-negative increments.
+
+    Returns
+    -------
+    b : ndarray of shape (K-1,)
+        Non-decreasing threshold vector.
+
+    Raises
+    ------
+    ValueError
+        If ``params`` is empty.
+
+    Notes
+    -----
+    A zero entry in ``params[1:]`` ties two thresholds and is also a
+    stationary point of any pulled-back gradient, since the
+    ``2 * params[j]`` chain-rule factor in ``thresholds_grad`` vanishes
+    there. Gradient-based optimisers therefore cannot separate
+    thresholds initialised exactly tied; initialise with strictly
+    increasing thresholds instead.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.extmath import params_to_thresholds
+    >>> params_to_thresholds(np.array([1.0, 2.0, -3.0]))
+    array([ 1.,  5., 14.])
+    """
+    params = np.asarray(params, dtype=float).ravel()
+    if params.size == 0:
+        raise ValueError("params must contain at least one element")
+
+    t_sq = np.empty_like(params)
+    t_sq[0] = params[0]
+    t_sq[1:] = params[1:] ** 2
+    return np.cumsum(t_sq)
+
+
+def thresholds_to_params(thresholds):
+    """Invert ``params_to_thresholds`` to recover unconstrained parameters.
+
+    Returns ``params`` such that
+    ``params_to_thresholds(params) == thresholds`` (up to floating-point
+    error) for an ordered ``thresholds``.
+
+    Parameters
+    ----------
+    thresholds : ndarray of shape (K-1,)
+        Ordered threshold values.
+
+    Returns
+    -------
+    params : ndarray of shape (K-1,)
+        Unconstrained parameter vector. ``params[0] = thresholds[0]`` and
+        ``params[j] = sqrt(max(thresholds[j] - thresholds[j-1], 0))`` for
+        ``j >= 1``.
+
+    Raises
+    ------
+    ValueError
+        If ``thresholds`` is empty.
+
+    Notes
+    -----
+    Tied input thresholds produce an exactly-zero ``params`` entry,
+    which is a stationary point of the pulled-back gradient; see the
+    ``Notes`` section of ``params_to_thresholds``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.extmath import (
+    ...     thresholds_to_params, params_to_thresholds
+    ... )
+    >>> b = np.array([1., 5., 14.])
+    >>> t = thresholds_to_params(b)
+    >>> np.allclose(params_to_thresholds(t), b)
+    True
+    """
+    thresholds = np.asarray(thresholds, dtype=float).ravel()
+    if thresholds.size == 0:
+        raise ValueError("thresholds must contain at least one element")
+
+    params = np.empty_like(thresholds)
+    params[0] = thresholds[0]
+    if params.size > 1:
+        params[1:] = np.sqrt(np.maximum(np.diff(thresholds), 0.0))
+    return params
+
+
+def thresholds_grad(params, grad_thresholds):
+    """Push a threshold-space gradient back through the parameter map.
+
+    Applies the chain rule through the cumsum-of-squares transform used
+    by ``params_to_thresholds``: given the gradient of a loss with
+    respect to the ordered thresholds, returns the gradient with respect
+    to the unconstrained parameters.
+
+    Parameters
+    ----------
+    params : ndarray of shape (K-1,)
+        Unconstrained parameter vector, as passed to
+        ``params_to_thresholds``.
+
+    grad_thresholds : ndarray of shape (K-1,)
+        Gradient of the loss with respect to the ordered thresholds
+        ``b = params_to_thresholds(params)``.
+
+    Returns
+    -------
+    grad_params : ndarray of shape (K-1,)
+        Gradient of the loss with respect to ``params``.
+
+    Raises
+    ------
+    ValueError
+        If ``params`` is empty, or if ``grad_thresholds`` does not have
+        the same number of elements as ``params``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.extmath import (
+    ...     thresholds_grad, params_to_thresholds
+    ... )
+    >>> t = np.array([1.0, 2.0, -3.0])
+    >>> grad_b = np.array([1.0, 0.5, -2.0])
+    >>> analytic = thresholds_grad(t, grad_b)
+    >>> eps = 1e-6
+    >>> numeric = np.array([
+    ...     (grad_b @ params_to_thresholds(t + eps * e)
+    ...      - grad_b @ params_to_thresholds(t - eps * e)) / (2 * eps)
+    ...     for e in np.eye(t.size)
+    ... ])
+    >>> np.allclose(analytic, numeric, atol=1e-4)
+    True
+    """
+    params = np.asarray(params, dtype=float).ravel()
+    if params.size == 0:
+        raise ValueError("params must contain at least one element")
+
+    grad_thresholds = np.asarray(grad_thresholds, dtype=float).ravel()
+    if grad_thresholds.size != params.size:
+        raise ValueError(
+            "params and grad_thresholds must have the same shape "
+            "(number of elements), got sizes "
+            f"{params.size} and {grad_thresholds.size}"
+        )
+
+    n_params = params.size
+    grad_params = np.empty(n_params)
+    # Take suffix sums via a reversed cumsum, then restore the order
+    cumsum_grad = np.cumsum(grad_thresholds[::-1])[::-1]
+    grad_params[0] = cumsum_grad[0]
+    if n_params > 1:
+        grad_params[1:] = 2.0 * params[1:] * cumsum_grad[1:]
+    return grad_params
+
+
+def _check_cumproba(cumproba):
+    """Validate a cumulative-probability matrix and cast it to float64."""
+    cumproba = check_array(
+        cumproba, ensure_2d=True, dtype=np.float64, input_name="cumproba"
+    )
+
+    if cumproba.min() < 0.0 or cumproba.max() > 1.0:
+        raise ValueError(
+            f"cumproba entries must lie in [0, 1], got range "
+            f"[{cumproba.min():.4g}, {cumproba.max():.4g}]"
+        )
+
+    return cumproba
+
+
+def _isotonic_repair(cumproba):
+    """Repair non-monotonic rows of an already validated cumproba matrix."""
+    repaired = cumproba.copy()
+    # Refit only violating rows; isotonic regression leaves monotone
+    # in-range rows unchanged
+    violating = np.flatnonzero((np.diff(cumproba, axis=1) < 0.0).any(axis=1))
+    for i in violating:
+        repaired[i] = isotonic_regression(
+            cumproba[i], y_min=0.0, y_max=1.0, increasing=True
+        )
+    return repaired
+
+
+def repair_cumproba(cumproba):
+    """Apply row-wise isotonic regression to enforce monotonicity in [0, 1].
+
+    Each row of ``cumproba`` is independently fitted with isotonic regression
+    bounded to ``[0, 1]`` and required to be non-decreasing. The returned
+    array has the same shape as the input.
+
+    This is the canonical primitive for repairing cumulative probability
+    outputs produced by ordinal classifiers whose backends (e.g. raw sigmoid,
+    independent binary boosters) do not guarantee monotonicity.
+
+    Parameters
+    ----------
+    cumproba : array-like of shape (n_samples, n_thresholds)
+        Cumulative probabilities. Each entry should lie in ``[0, 1]``.
+
+    Returns
+    -------
+    repaired : ndarray of shape (n_samples, n_thresholds), dtype np.float64
+        Each row is non-decreasing with values in ``[0, 1]``.
+
+    Raises
+    ------
+    ValueError
+        If ``cumproba`` is not 2-D, has zero columns, contains NaN /
+        inf values, or has any entry outside ``[0, 1]``. Upstream
+        ``ValueError`` from ``check_array`` (e.g. NaN inputs) is
+        propagated unchanged.
+
+    TypeError
+        If ``cumproba`` is a sparse matrix.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.extmath import repair_cumproba
+    >>> raw = np.array([[0.4, 0.2, 0.7]])  # column 1 violates monotonicity
+    >>> repair_cumproba(raw)
+    array([[0.3, 0.3, 0.7]])
+    """
+    cumproba = _check_cumproba(cumproba)
+    return _isotonic_repair(cumproba)
+
+
+def proba_to_cumproba(proba):
+    """Convert class-wise ``P(Y = k)`` to cumulative ``P(Y <= k)``.
+
+    Takes a matrix of class-wise probabilities ``P(Y = k | x)`` for
+    ``k = 1, ..., n_classes`` and returns the cumulative probabilities
+    ``P(Y <= k | x)`` for ``k = 1, ..., n_classes - 1``, i.e. all
+    partial row sums except the last (which is always 1).
+
+    This is the inverse of ``cumproba_to_proba``: for valid ``proba``
+    (non-negative rows summing to ~1),
+    ``cumproba_to_proba(proba_to_cumproba(proba))`` recovers ``proba``
+    up to floating-point error. The result is clipped to ``[0, 1]`` (a
+    cumulative sum can drift a few ulps above 1) so it stays valid
+    input for ``repair_cumproba`` and ``cumproba_to_proba``.
+
+    It does not validate its input; callers must pass valid
+    probability rows.
+
+    Parameters
+    ----------
+    proba : array-like of shape (n_samples, n_classes), dtype float
+        Class-wise probabilities. Each row should be non-negative and
+        sum to ~1.
+
+    Returns
+    -------
+    cumproba : ndarray of shape (n_samples, n_classes - 1), dtype np.float64
+        Cumulative probabilities. Each row is non-decreasing with
+        values in ``[0, 1]`` for valid input.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.extmath import (
+    ...     proba_to_cumproba, cumproba_to_proba
+    ... )
+    >>> P = np.array([[0.2, 0.3, 0.4, 0.1]])
+    >>> proba_to_cumproba(P)
+    array([[0.2, 0.5, 0.9]])
+    >>> np.allclose(cumproba_to_proba(proba_to_cumproba(P)), P)
+    True
+    """
+    proba = np.asarray(proba, dtype=np.float64)
+    cumproba = np.cumsum(proba, axis=1)[:, :-1]
+    np.clip(cumproba, 0.0, 1.0, out=cumproba)
+    return cumproba
+
+
+def cumproba_to_proba(cumproba, repair=True):
+    """Convert cumulative ``P(Y <= k)`` to class-wise ``P(Y = k)``.
+
+    Takes a matrix of cumulative probabilities ``P(Y <= k | x)`` for
+    ``k = 1, ..., n_classes - 1`` and returns a matrix of class-wise
+    probabilities ``P(Y = k | x)`` for ``k = 1, ..., n_classes``.
+
+    When ``repair=True``, monotonicity violations in each row are
+    silently fixed via isotonic regression before differencing. When
+    ``repair=False``, any non-monotonic row triggers a ``ValueError``.
+
+    Special row behaviours:
+
+    - An all-zero row becomes ``[0, 0, ..., 1]``; the final class absorbs
+      all probability mass.
+    - An all-one row becomes ``[1, 0, ..., 0]``; the first class absorbs
+      all probability mass.
+
+    Parameters
+    ----------
+    cumproba : array-like of shape (n_samples, n_classes - 1)
+        Cumulative probabilities. Each row should be a non-decreasing
+        sequence of values in ``[0, 1]``.
+
+    repair : bool, default=True
+        If ``True``, apply isotonic regression row-wise to enforce
+        monotonicity before differencing, then clip and renormalise.
+        If ``False``, raise ``ValueError`` when any row is non-monotonic.
+
+    Returns
+    -------
+    class_proba : ndarray of shape (n_samples, n_classes), dtype np.float64
+        Class-wise probabilities. Each row is non-negative and sums to
+        ``1.0`` up to floating-point rounding, in both the
+        ``repair=True`` and ``repair=False`` branches.
+
+    Raises
+    ------
+    ValueError
+        If ``cumproba`` is not 2-D, has zero columns, contains NaN / inf
+        values, contains values outside ``[0, 1]``, or — when
+        ``repair=False`` — has any row whose entries are not
+        non-decreasing. Upstream ``ValueError`` from ``check_array``
+        (e.g. NaN inputs) is propagated unchanged.
+
+    TypeError
+        If ``cumproba`` is a sparse matrix.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.extmath import cumproba_to_proba
+    >>> cumproba = np.array([[0.2, 0.5, 0.9]])
+    >>> cumproba_to_proba(cumproba)
+    array([[0.2, 0.3, 0.4, 0.1]])
+    """
+    cumproba = _check_cumproba(cumproba)
+
+    n_samples, n_thresholds = cumproba.shape
+    class_proba = np.empty((n_samples, n_thresholds + 1), dtype=np.float64)
+
+    if not repair:
+        diffs = np.diff(cumproba, axis=1)
+        if (diffs < 0.0).any():
+            raise ValueError(
+                f"cumproba rows must be non-decreasing, got minimum diff "
+                f"{diffs.min():.4g}"
+            )
+        class_proba[:, 0] = cumproba[:, 0]
+        class_proba[:, 1:-1] = diffs
+        class_proba[:, -1] = 1.0 - cumproba[:, -1]
+        return class_proba
+
+    repaired = _isotonic_repair(cumproba)
+    class_proba[:, 0] = repaired[:, 0]
+    class_proba[:, 1:-1] = np.diff(repaired, axis=1)
+    class_proba[:, -1] = 1.0 - repaired[:, -1]
+
+    np.clip(class_proba, 0.0, None, out=class_proba)
+    row_sums = class_proba.sum(axis=1, keepdims=True)
+    # Guard against division by zero on an all-zero row, though y_min=0
+    # already rules this out
+    row_sums = np.where(row_sums == 0.0, 1.0, row_sums)
+    class_proba /= row_sums
+    return class_proba
+
+
+def normalize_proba_rows(scores, *, floor=np.finfo(np.float64).tiny):
+    """Clip a score matrix to a positive floor and row-normalise to sum to 1.
+
+    Each entry is clipped to ``>= floor`` and each row is divided by its
+    sum; a second clip-and-renormalise keeps every output entry strictly
+    positive even when the first division underflows a tiny entry to
+    zero. Callers must pass finite ``scores`` — non-finite input or an
+    overflowing row sum raises.
+
+    This is the shared primitive used by ensemble meta-estimators that fuse
+    sub-classifier scores via a product or sum combiner, where underflow to
+    zero would otherwise produce degenerate rows.
+
+    Parameters
+    ----------
+    scores : ndarray of shape (n_samples, n_classes), dtype float
+        Raw (non-negative) score matrix. Negative values are clipped up to
+        ``floor``.
+
+    floor : float, default=numpy.finfo(numpy.float64).tiny
+        Minimum value every entry is clipped to before normalisation. Must
+        be strictly positive and finite.
+
+    Returns
+    -------
+    proba : ndarray of shape (n_samples, n_classes), dtype float64
+        Row-normalised probability matrix. Every entry is strictly
+        positive, though an entry may fall below ``floor`` after
+        normalisation. Each row sums to 1.0 up to floating-point
+        rounding.
+
+    Raises
+    ------
+    ValueError
+        If ``floor`` is not strictly positive and finite (this also
+        rejects ``NaN``), or if ``scores`` contains NaN or positive
+        infinity, or if any row sum overflows to infinity.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.extmath import normalize_proba_rows
+    >>> S = np.array([[0.0, 0.5, 0.5], [1.0, 0.0, 0.0]])
+    >>> P = normalize_proba_rows(S)
+    >>> np.allclose(P.sum(axis=1), 1.0)
+    True
+    >>> bool((P > 0).all())
+    True
+    """
+    if not 0.0 < floor < np.inf:
+        raise ValueError(f"floor must be strictly positive and finite, got {floor!r}")
+
+    scores = np.array(scores, dtype=np.float64)
+    np.clip(scores, floor, None, out=scores)
+    row_sums = scores.sum(axis=1, keepdims=True)
+    if not np.isfinite(row_sums).all():
+        raise ValueError("scores must be finite and row sums must not overflow")
+    scores /= row_sums
+
+    # Clip to the smallest positive float64 and re-normalise; the first
+    # division can underflow an entry to exactly zero
+    tiny = np.finfo(np.float64).tiny
+    np.clip(scores, tiny, None, out=scores)
+    scores /= scores.sum(axis=1, keepdims=True)
+    return scores
+
+
+def losses_to_proba(losses):
+    """Convert a per-class loss matrix to row-normalised probabilities.
+
+    The conversion is ``softmax(1 / (losses + tiny))``: each row is first
+    inverted (so that smaller losses become larger scores), then shifted by
+    the row max for numerical stability before exponentiation, then divided
+    by its row sum. Infinite losses are accepted, mapping to a zero
+    score for that class. The mapping is a heuristic kept for backward
+    compatibility: its argmax always matches the loss argmin, but the
+    probabilities are scale-sensitive — saturating toward the uniform
+    distribution for losses much larger than 1 — and should not be read
+    as calibrated.
+
+    Parameters
+    ----------
+    losses : ndarray of shape (n_samples, n_classes), dtype float
+        Per-class non-negative loss values.
+
+    Returns
+    -------
+    proba : ndarray of shape (n_samples, n_classes), dtype float64
+        Row-normalised probability matrix. Each row is non-negative and
+        sums to 1.0 up to floating-point rounding.
+
+    Raises
+    ------
+    ValueError
+        If ``losses`` contains any negative value or NaN.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.utils.extmath import losses_to_proba
+    >>> L = np.array([[0.1, 0.2, 0.3], [0.3, 0.2, 0.1]])
+    >>> np.round(losses_to_proba(L), 4)
+    array([[0.9921, 0.0067, 0.0013],
+           [0.0013, 0.0067, 0.9921]])
+    """
+    losses = np.asarray(losses, dtype=np.float64)
+    if not (losses >= 0.0).all():
+        raise ValueError("losses must be non-negative and not NaN")
+
+    tiny = np.finfo(np.float64).tiny
+    scores = 1.0 / (losses + tiny)
+    scores -= scores.max(axis=1, keepdims=True)
+    proba = np.exp(scores)
+    proba /= proba.sum(axis=1, keepdims=True)
+    return proba

--- a/skordinal/utils/tests/test_extmath.py
+++ b/skordinal/utils/tests/test_extmath.py
@@ -1,0 +1,537 @@
+"""Tests for skordinal.utils.extmath mathematical helpers."""
+
+import inspect
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from skordinal.utils.extmath import (
+    cumproba_to_proba,
+    losses_to_proba,
+    normalize_proba_rows,
+    params_to_thresholds,
+    proba_to_cumproba,
+    repair_cumproba,
+    thresholds_grad,
+    thresholds_to_params,
+)
+
+_EXTMATH_HELPERS = [
+    params_to_thresholds,
+    thresholds_to_params,
+    thresholds_grad,
+    proba_to_cumproba,
+    cumproba_to_proba,
+    repair_cumproba,
+    losses_to_proba,
+    normalize_proba_rows,
+]
+_EXTMATH_NAMES = [f.__name__ for f in _EXTMATH_HELPERS]
+
+
+@pytest.mark.parametrize("func", _EXTMATH_HELPERS, ids=_EXTMATH_NAMES)
+def test_api_no_mutable_defaults(func):
+    """No extmath helper has a mutable default argument."""
+    for default in func.__defaults__ or ():
+        assert not isinstance(default, (list, dict, np.ndarray)), (
+            f"{func.__name__} has a mutable default: {default!r}"
+        )
+
+
+def test_api_cumproba_to_proba_default_repair():
+    """cumproba_to_proba defaults repair=True."""
+    sig = inspect.signature(cumproba_to_proba)
+    assert sig.parameters["repair"].default is True
+
+
+def test_p2t_known_values():
+    """params_to_thresholds produces the expected non-decreasing vector."""
+    t = np.array([1.0, 2.0, -3.0])
+    result = params_to_thresholds(t)
+    # b[0] = 1.0; b[1] = 1.0 + 4.0 = 5.0; b[2] = 5.0 + 9.0 = 14.0
+    assert_allclose(result, [1.0, 5.0, 14.0], atol=1e-12)
+
+
+def test_p2t_output_is_non_decreasing():
+    """Output of params_to_thresholds is always non-decreasing."""
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        t = rng.standard_normal(5)
+        b = params_to_thresholds(t)
+        assert np.all(np.diff(b) >= 0.0)
+
+
+def test_p2t_single_element():
+    """Single-element parameter passes through unchanged."""
+    result = params_to_thresholds(np.array([3.0]))
+    assert_allclose(result, [3.0], atol=1e-12)
+
+
+def test_t2p_round_trip():
+    """params_to_thresholds(thresholds_to_params(b)) == b for ordered b."""
+    b = np.array([1.0, 5.0, 14.0])
+    t = thresholds_to_params(b)
+    assert_allclose(params_to_thresholds(t), b, atol=1e-10)
+
+
+@pytest.mark.parametrize(
+    "b",
+    [
+        np.array([-2.0, 0.0, 3.0]),
+        np.array([0.5]),
+        np.array([1.0, 1.0, 2.0]),  # non-strictly-increasing (flat segment OK)
+    ],
+    ids=["generic", "single", "flat-segment"],
+)
+def test_t2p_round_trip_parametrised(b):
+    """Round-trip holds for various ordered threshold vectors."""
+    t = thresholds_to_params(b)
+    assert_allclose(params_to_thresholds(t), b, atol=1e-10)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: params_to_thresholds(np.array([])),
+        lambda: thresholds_to_params(np.array([])),
+        lambda: thresholds_grad(np.array([]), np.array([])),
+    ],
+    ids=["params_to_thresholds", "thresholds_to_params", "thresholds_grad"],
+)
+def test_threshold_functions_empty_input_raises(call):
+    """Each threshold helper rejects an empty input vector."""
+    with pytest.raises(ValueError, match=r"must contain at least one element"):
+        call()
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_thresholds_grad_matches_finite_difference(seed):
+    """thresholds_grad matches a central-difference gradient check."""
+    rng = np.random.default_rng(seed)
+    t = rng.standard_normal(5)
+    grad_b = rng.standard_normal(5)
+    eps = 1e-6
+    grad_t = thresholds_grad(t, grad_b)
+    grad_t_fd = np.empty_like(t)
+    for i in range(len(t)):
+        t_plus, t_minus = t.copy(), t.copy()
+        t_plus[i] += eps
+        t_minus[i] -= eps
+        loss_plus = grad_b @ params_to_thresholds(t_plus)
+        loss_minus = grad_b @ params_to_thresholds(t_minus)
+        grad_t_fd[i] = (loss_plus - loss_minus) / (2 * eps)
+    assert_allclose(grad_t, grad_t_fd, atol=1e-5)
+
+
+def test_thresholds_grad_single_element():
+    """A single-parameter gradient passes through unchanged."""
+    grad_params = thresholds_grad(np.array([3.0]), np.array([5.0]))
+    assert_allclose(grad_params, [5.0], atol=1e-12)
+
+
+def test_thresholds_grad_shape_mismatch_raises():
+    """A grad_thresholds size differing from params size raises ValueError."""
+    with pytest.raises(ValueError, match=r"must have the same shape"):
+        thresholds_grad(np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0]))
+
+
+def test_thresholds_grad_ravels_2d_input():
+    """A 2-D grad_thresholds is ravelled to match its 1-D counterpart."""
+    t = np.array([1.0, 2.0, -3.0])
+    grad_b_1d = np.array([1.0, 0.5, -2.0])
+    grad_b_2d = grad_b_1d.reshape(3, 1)
+    assert_allclose(thresholds_grad(t, grad_b_2d), thresholds_grad(t, grad_b_1d))
+
+
+def test_repair_cumproba_already_monotone_unchanged():
+    """A monotone input row is returned bit-exact."""
+    cumproba = np.array([[0.1, 0.4, 0.8]])
+    result = repair_cumproba(cumproba)
+    assert_array_equal(result, cumproba)
+
+
+def test_repair_cumproba_fixes_violation():
+    """A non-monotone row is repaired to be non-decreasing."""
+    cumproba = np.array([[0.4, 0.2, 0.7]])
+    result = repair_cumproba(cumproba)
+    assert result.shape == cumproba.shape
+    assert np.all(np.diff(result, axis=1) >= 0.0)
+    assert np.all((result >= 0.0) & (result <= 1.0))
+
+
+def test_repair_cumproba_mixed_batch_preserves_monotone_row():
+    """Batching with a violating row does not affect a monotone row."""
+    cumproba = np.array([[0.1, 0.4, 0.8], [0.4, 0.2, 0.7]])
+    result = repair_cumproba(cumproba)
+    assert_array_equal(result[0], cumproba[0])
+    assert np.all(np.diff(result[1]) >= 0.0)
+
+
+def test_repair_cumproba_idempotent():
+    """Applying repair_cumproba twice equals applying it once."""
+    rng = np.random.default_rng(42)
+    cumproba = rng.uniform(0, 1, size=(10, 4))
+    once = repair_cumproba(cumproba)
+    twice = repair_cumproba(once)
+    assert_allclose(twice, once, atol=1e-12)
+
+
+def test_repair_cumproba_values_in_unit_interval():
+    """Repaired output entries stay in [0, 1]."""
+    rng = np.random.default_rng(7)
+    cumproba = rng.uniform(0, 1, size=(20, 5))
+    result = repair_cumproba(cumproba)
+    assert np.all(result >= 0.0)
+    assert np.all(result <= 1.0)
+
+
+@pytest.mark.parametrize(
+    "cumproba",
+    [np.array([[-0.1, 0.5]]), np.array([[0.5, 1.2]])],
+    ids=["negative-entry", "above-one-entry"],
+)
+def test_repair_cumproba_out_of_range_raises(cumproba):
+    """Entries outside [0, 1] raise ValueError."""
+    with pytest.raises(ValueError, match=r"cumproba entries must lie in \[0, 1\]"):
+        repair_cumproba(cumproba)
+
+
+def test_c2p_valid_input_output_values():
+    """Output values, row sums, and non-negativity for a monotonic input."""
+    cumproba = np.array([[0.2, 0.5, 0.9]])
+    class_proba = cumproba_to_proba(cumproba)
+    assert_allclose(class_proba, [[0.2, 0.3, 0.4, 0.1]], atol=1e-12)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+    assert np.all(class_proba >= 0.0)
+
+
+def test_c2p_repair_true_repairs_violation():
+    """Monotonicity violations are repaired silently when repair=True."""
+    cumproba = np.array([[0.5, 0.3, 0.9]])
+    class_proba = cumproba_to_proba(cumproba, repair=True)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+    assert np.all(class_proba >= 0.0)
+
+
+def test_c2p_repair_true_matches_hand_computed_repair():
+    """repair=True gives the exact PAVA-repaired class probabilities."""
+    cumproba = np.array([[0.5, 0.3, 0.9]])
+    class_proba = cumproba_to_proba(cumproba, repair=True)
+    # Pool the violating pair to their average via PAVA: [0.4, 0.4, 0.9]
+    assert_allclose(class_proba, [[0.4, 0.0, 0.5, 0.1]], atol=1e-12)
+
+
+def test_c2p_repair_false_valid_input():
+    """repair=False happy path with multiple rows."""
+    cumproba = np.array([[0.2, 0.5, 0.9], [0.1, 0.4, 0.8]])
+    class_proba = cumproba_to_proba(cumproba, repair=False)
+    assert class_proba.shape == (2, 4)
+    assert_allclose(class_proba[0], [0.2, 0.3, 0.4, 0.1], atol=1e-12)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+    assert np.all(class_proba >= 0.0)
+
+
+def test_c2p_repair_false_raises_on_violation():
+    """A non-monotonic row raises ValueError when repair=False."""
+    with pytest.raises(ValueError, match=r"cumproba rows must be non-decreasing"):
+        cumproba_to_proba(np.array([[0.5, 0.3]]), repair=False)
+
+
+@pytest.mark.parametrize("repair", [True, False])
+def test_c2p_k2_single_column(repair):
+    """K=2 single-column input produces 2-column output for both branches."""
+    cumproba = np.array([[0.3], [0.7]])
+    class_proba = cumproba_to_proba(cumproba, repair=repair)
+    assert class_proba.shape == (2, 2)
+    assert_allclose(class_proba[0], [0.3, 0.7], atol=1e-12)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "cumproba",
+    [np.array([[-0.1, 0.5]]), np.array([[0.5, 1.2]])],
+    ids=["negative-entry", "above-one-entry"],
+)
+def test_c2p_out_of_range_raises(cumproba):
+    """Entries outside [0, 1] raise ValueError."""
+    with pytest.raises(ValueError, match=r"cumproba entries must lie in \[0, 1\]"):
+        cumproba_to_proba(cumproba)
+
+
+def test_c2p_zero_columns_raises():
+    """A cumproba matrix with zero columns raises ValueError."""
+    with pytest.raises(ValueError, match=r"minimum of 1 is required"):
+        cumproba_to_proba(np.empty((3, 0)))
+
+
+@pytest.mark.parametrize(
+    "cumproba, mass_index",
+    [
+        (np.array([[0.0, 0.0, 0.0]]), -1),
+        (np.array([[1.0, 1.0, 1.0]]), 0),
+    ],
+    ids=["all-zero-row", "all-one-row"],
+)
+def test_c2p_special_rows_concentrate_mass(cumproba, mass_index):
+    """All-zero and all-one rows place all mass on a single class."""
+    class_proba = cumproba_to_proba(cumproba)
+    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
+    assert np.all(class_proba >= 0.0)
+    assert class_proba[0, mass_index] == pytest.approx(1.0)
+
+
+def test_c2p_output_shape():
+    """Output has n_classes = n_thresholds + 1 columns."""
+    rng = np.random.default_rng(11)
+    for n_thresholds in [1, 2, 5, 9]:
+        cumproba = np.sort(rng.uniform(0, 1, size=(8, n_thresholds)), axis=1)
+        result = cumproba_to_proba(cumproba)
+        assert result.shape == (8, n_thresholds + 1)
+
+
+def test_c2p_rows_sum_to_one_multirow():
+    """All rows of the output sum to 1.0 within floating-point tolerance."""
+    rng = np.random.default_rng(99)
+    cumproba = np.sort(rng.uniform(0, 1, size=(50, 6)), axis=1)
+    result = cumproba_to_proba(cumproba)
+    assert_allclose(result.sum(axis=1), np.ones(50), atol=1e-12)
+
+
+def test_p2c_known_values():
+    """proba_to_cumproba produces the expected cumulative sums."""
+    proba = np.array([[0.2, 0.3, 0.4, 0.1]])
+    result = proba_to_cumproba(proba)
+    assert_allclose(result, [[0.2, 0.5, 0.9]], atol=1e-12)
+
+
+def test_p2c_round_trip_random_dirichlet():
+    """cumproba_to_proba(proba_to_cumproba(P), repair=False) recovers P."""
+    rng = np.random.default_rng(21)
+    proba = rng.dirichlet(np.ones(5), size=30)
+    recovered = cumproba_to_proba(proba_to_cumproba(proba), repair=False)
+    assert_allclose(recovered, proba, atol=1e-10)
+
+
+def test_p2c_round_trip_matches_doctest_example():
+    """The doctest's round-trip direction holds under a tight tolerance."""
+    proba = np.array([[0.2, 0.3, 0.4, 0.1]])
+    recovered = cumproba_to_proba(proba_to_cumproba(proba))
+    assert_allclose(recovered, proba, atol=1e-12)
+
+
+def test_p2c_output_shape():
+    """Output has n_classes - 1 columns for K classes."""
+    rng = np.random.default_rng(11)
+    for n_classes in [2, 3, 5, 9]:
+        proba = rng.dirichlet(np.ones(n_classes), size=8)
+        result = proba_to_cumproba(proba)
+        assert result.shape == (8, n_classes - 1)
+
+
+def test_p2c_output_dtype_is_float64():
+    """Output dtype is float64 regardless of the input dtype."""
+    proba = np.array([[0.5, 0.5]], dtype=np.float32)
+    result = proba_to_cumproba(proba)
+    assert result.dtype == np.float64
+
+
+def test_p2c_k2_single_column():
+    """K=2 input produces a single-column cumulative output."""
+    proba = np.array([[0.3, 0.7], [0.6, 0.4]])
+    result = proba_to_cumproba(proba)
+    assert result.shape == (2, 1)
+    assert_allclose(result, [[0.3], [0.6]], atol=1e-12)
+
+
+def test_p2c_fp_overshoot_regression_clips_to_one():
+    """A row whose raw cumsum overshoots 1.0 by a few ulp is clipped."""
+    proba = np.append(np.full(100, 1.0 / 100), 0.0).reshape(1, -1)
+    # Confirm the row genuinely overshoots before proba_to_cumproba clips it
+    raw_partial = np.cumsum(proba, axis=1)[:, :-1]
+    assert raw_partial.max() > 1.0
+    cumproba = proba_to_cumproba(proba)
+    assert cumproba.max() <= 1.0
+    # The clipped output must remain valid input for downstream consumers
+    repair_cumproba(cumproba)
+    cumproba_to_proba(cumproba, repair=False)
+
+
+def test_p2c_output_is_non_decreasing():
+    """Output rows are non-decreasing for non-negative input."""
+    rng = np.random.default_rng(3)
+    proba = rng.uniform(0, 1, size=(20, 6))
+    result = proba_to_cumproba(proba)
+    assert np.all(np.diff(result, axis=1) >= 0.0)
+
+
+def test_p2c_does_not_mutate_input_array():
+    """proba_to_cumproba leaves its ndarray argument unchanged."""
+    rng = np.random.default_rng(13)
+    proba = rng.dirichlet(np.ones(4), size=10).astype(np.float64)
+    saved = proba.copy()
+    proba_to_cumproba(proba)
+    np.testing.assert_array_equal(proba, saved)
+
+
+def test_l2p_known_values():
+    """losses_to_proba produces expected probabilities for a known input."""
+    L = np.array([[0.1, 0.2, 0.3], [0.3, 0.2, 0.1]])
+    result = losses_to_proba(L)
+    assert_allclose(
+        result, [[0.9921, 0.0067, 0.0013], [0.0013, 0.0067, 0.9921]], atol=1e-4
+    )
+
+
+def test_l2p_rows_sum_to_one():
+    """Every row of losses_to_proba output sums to 1.0."""
+    rng = np.random.default_rng(5)
+    L = rng.uniform(0, 2, size=(30, 5))
+    result = losses_to_proba(L)
+    assert_allclose(result.sum(axis=1), np.ones(30), atol=1e-12)
+
+
+def test_l2p_all_entries_non_negative():
+    """All entries of losses_to_proba output are >= 0."""
+    rng = np.random.default_rng(6)
+    L = rng.uniform(0, 5, size=(20, 4))
+    result = losses_to_proba(L)
+    assert np.all(result >= 0.0)
+
+
+def test_l2p_minimum_loss_gets_maximum_probability():
+    """The class with the minimum loss receives the highest probability."""
+    L = np.array([[0.01, 1.0, 2.0]])
+    result = losses_to_proba(L)
+    assert result[0, 0] == result[0].max()
+
+
+def test_l2p_symmetric_input_gives_symmetric_output():
+    """Equal losses produce equal probabilities across classes."""
+    L = np.array([[1.0, 1.0, 1.0]])
+    result = losses_to_proba(L)
+    assert_allclose(result[0], [1 / 3, 1 / 3, 1 / 3], atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "L",
+    [np.array([[0.1, -0.2, 0.3]]), np.array([[0.1, np.nan, 0.3]])],
+    ids=["negative", "nan"],
+)
+def test_l2p_negative_or_nan_loss_raises(L):
+    """A negative or NaN loss entry raises ValueError."""
+    with pytest.raises(ValueError, match=r"losses must be non-negative"):
+        losses_to_proba(L)
+
+
+def test_npr_rows_sum_to_one():
+    """normalize_proba_rows output rows sum to 1.0 within atol=1e-12."""
+    rng = np.random.default_rng(42)
+    S = rng.uniform(0.0, 2.0, size=(30, 5))
+    P = normalize_proba_rows(S)
+    assert_allclose(P.sum(axis=1), np.ones(30), atol=1e-12)
+
+
+def test_npr_all_entries_positive():
+    """normalize_proba_rows guarantees all entries > 0 (clipped to floor)."""
+    S = np.array([[0.0, 0.5, 0.5], [1.0, 0.0, 0.0]])
+    P = normalize_proba_rows(S)
+    assert (P > 0.0).all(), "normalize_proba_rows should clip zeros to a positive floor"
+
+
+def test_npr_underflow_regression_all_entries_strictly_positive():
+    """An extreme-scale row no longer underflows to an exact zero entry."""
+    S = np.array([[0.0, 1e20]])
+    P = normalize_proba_rows(S)
+    assert (P > 0.0).all()
+    assert_allclose(P.sum(axis=1), 1.0, atol=1e-12)
+
+
+def test_npr_zero_row_becomes_valid():
+    """An all-zero row is clipped to floor and normalised to uniform."""
+    K = 4
+    S = np.zeros((1, K), dtype=float)
+    P = normalize_proba_rows(S)
+    assert P.shape == (1, K)
+    assert_allclose(P.sum(axis=1), 1.0, atol=1e-12)
+    # Clip every zero to the same tiny value, so the row becomes uniform
+    assert_allclose(P[0], np.full(K, 1.0 / K), atol=1e-12)
+
+
+def test_npr_shape_preserved():
+    """normalize_proba_rows preserves the input array shape."""
+    rng = np.random.default_rng(7)
+    for shape in [(1, 2), (10, 3), (50, 7)]:
+        S = rng.uniform(0.1, 1.0, size=shape)
+        P = normalize_proba_rows(S)
+        assert P.shape == shape, f"Shape changed: {shape} -> {P.shape}"
+
+
+def test_npr_custom_floor_respected():
+    """A custom floor clips input entries before normalisation."""
+    S = np.array([[0.0, 1.0, 0.0]])
+    floor = 0.1
+    P = normalize_proba_rows(S, floor=floor)
+    assert_allclose(P[0], [0.1 / 1.2, 1.0 / 1.2, 0.1 / 1.2], atol=1e-12)
+    assert_allclose(P.sum(axis=1), 1.0, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "floor",
+    [0.0, -5.0, float("nan"), np.inf],
+    ids=["zero", "negative", "nan", "inf"],
+)
+def test_npr_non_positive_floor_raises(floor):
+    """A non-positive, non-finite, or NaN floor raises ValueError."""
+    S = np.array([[1.0, 2.0]])
+    with pytest.raises(ValueError, match=r"floor must be strictly positive"):
+        normalize_proba_rows(S, floor=floor)
+
+
+def test_npr_nan_scores_raises():
+    """A NaN entry in scores raises ValueError."""
+    S = np.array([[np.nan, 1.0, 2.0]])
+    with pytest.raises(ValueError, match=r"scores must be finite"):
+        normalize_proba_rows(S)
+
+
+def test_npr_inf_scores_raises():
+    """An infinite entry in scores raises ValueError."""
+    S = np.array([[np.inf, 1.0, 2.0]])
+    with pytest.raises(ValueError, match=r"scores must be finite"):
+        normalize_proba_rows(S)
+
+
+def test_npr_finite_overflow_row_sum_raises():
+    """A finite row whose sum overflows to infinity raises ValueError."""
+    S = np.array([[1e308, 1e308]])
+    with pytest.raises(ValueError, match=r"scores must be finite"):
+        normalize_proba_rows(S)
+
+
+def test_npr_already_normalised_input_stays_close():
+    """A row summing to 1 with positive entries is approximately unchanged."""
+    rng = np.random.default_rng(11)
+    raw = rng.dirichlet(np.ones(5), size=20)
+    P = normalize_proba_rows(raw.copy())
+    assert_allclose(P, raw, atol=1e-12)
+
+
+def test_npr_does_not_mutate_input_array():
+    """normalize_proba_rows leaves its ndarray argument unchanged."""
+    rng = np.random.default_rng(11)
+    S = rng.uniform(0.1, 1.0, size=(20, 5)).astype(np.float64)
+    saved = S.copy()
+    normalize_proba_rows(S)
+    np.testing.assert_array_equal(S, saved)
+
+
+def test_npr_negative_scores_clipped_to_floor():
+    """Negative input entries are clipped up to the tiny floor, not to zero."""
+    S = np.array([[-1.0, 2.0, 3.0]])
+    P = normalize_proba_rows(S)
+    # -1.0 clips to tiny, so the row becomes [tiny, 2.0, 3.0] before dividing
+    # by its sum of approximately 5.0
+    assert 0.0 < P[0, 0] < 1e-300
+    assert_allclose(P[0, 1:], [0.4, 0.6], atol=1e-12)
+    assert_allclose(P.sum(axis=1), 1.0, atol=1e-12)

--- a/skordinal/utils/tests/test_validation.py
+++ b/skordinal/utils/tests/test_validation.py
@@ -1,22 +1,15 @@
 """Tests for the validation utilities."""
 
-import inspect
-
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing import assert_array_equal
 
 import skordinal.utils.validation as val_mod
-from skordinal.utils.validation import (
-    check_monotonic_probabilities,
-    check_ordinal_targets,
-    validate_thresholds,
-)
+from skordinal.utils.validation import check_ordinal_targets, validate_thresholds
 
 _ALL_HELPERS = [
     check_ordinal_targets,
     validate_thresholds,
-    check_monotonic_probabilities,
 ]
 _HELPER_NAMES = [f.__name__ for f in _ALL_HELPERS]
 
@@ -30,14 +23,8 @@ def test_api_no_mutable_defaults(func):
         )
 
 
-def test_api_check_monotonic_probabilities_default_repair():
-    """The default value of ``repair`` is True."""
-    sig = inspect.signature(check_monotonic_probabilities)
-    assert sig.parameters["repair"].default is True
-
-
 def test_integration_all_names_in_module_all():
-    """``__all__`` lists exactly the three public helpers and is re-exported."""
+    """``validation.__all__`` lists exactly the helpers, all re-exported."""
     import skordinal.utils as utils_pkg
 
     expected = set(_HELPER_NAMES)
@@ -45,8 +32,8 @@ def test_integration_all_names_in_module_all():
     assert set(val_mod.__all__) == expected
     for name in expected:
         assert callable(getattr(val_mod, name))
-    # Subpackage shortcut: skordinal.utils re-exports the same surface.
-    assert set(utils_pkg.__all__) == expected
+    # Subpackage shortcut: skordinal.utils re-exports these among others.
+    assert expected <= set(utils_pkg.__all__)
     for name in expected:
         assert getattr(utils_pkg, name) is getattr(val_mod, name)
 
@@ -125,73 +112,3 @@ def test_vt_invalid_raises(thresholds, match):
     """Each invalid threshold vector raises ValueError with a specific message."""
     with pytest.raises(ValueError, match=match):
         validate_thresholds(thresholds)
-
-
-def test_cmp_valid_input_output_values():
-    """Output values, row sums, and non-negativity for a valid monotonic input."""
-    cumproba = np.array([[0.2, 0.5, 0.9]])
-    class_proba = check_monotonic_probabilities(cumproba)
-    assert_allclose(class_proba, [[0.2, 0.3, 0.4, 0.1]], atol=1e-12)
-    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
-    assert np.all(class_proba >= 0.0)
-
-
-def test_cmp_repair_true_repairs_violation():
-    """Monotonicity violations are repaired silently when ``repair=True``."""
-    cumproba = np.array([[0.5, 0.3, 0.9]])
-    class_proba = check_monotonic_probabilities(cumproba, repair=True)
-    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
-    assert np.all(class_proba >= 0.0)
-
-
-def test_cmp_repair_false_valid_input():
-    """``repair=False`` happy path with multiple rows."""
-    cumproba = np.array([[0.2, 0.5, 0.9], [0.1, 0.4, 0.8]])
-    class_proba = check_monotonic_probabilities(cumproba, repair=False)
-    assert class_proba.shape == (2, 4)
-    assert_allclose(class_proba[0], [0.2, 0.3, 0.4, 0.1], atol=1e-12)
-    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
-    assert np.all(class_proba >= 0.0)
-
-
-def test_cmp_repair_false_raises_on_violation():
-    """A non-monotonic row raises ValueError when ``repair=False``."""
-    with pytest.raises(ValueError, match=r"cumproba rows must be non-decreasing"):
-        check_monotonic_probabilities(np.array([[0.5, 0.3]]), repair=False)
-
-
-@pytest.mark.parametrize("repair", [True, False])
-def test_cmp_k2_single_column(repair):
-    """K=2 (single input column) produces a 2-column output for both branches."""
-    cumproba = np.array([[0.3], [0.7]])
-    class_proba = check_monotonic_probabilities(cumproba, repair=repair)
-    assert class_proba.shape == (2, 2)
-    assert_allclose(class_proba[0], [0.3, 0.7], atol=1e-12)
-    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
-
-
-@pytest.mark.parametrize(
-    "cumproba",
-    [np.array([[-0.1, 0.5]]), np.array([[0.5, 1.2]])],
-    ids=["negative-entry", "above-one-entry"],
-)
-def test_cmp_out_of_range_raises(cumproba):
-    """Entries outside [0, 1] raise ValueError."""
-    with pytest.raises(ValueError, match=r"cumproba entries must lie in \[0, 1\]"):
-        check_monotonic_probabilities(cumproba)
-
-
-@pytest.mark.parametrize(
-    "cumproba, mass_index",
-    [
-        (np.array([[0.0, 0.0, 0.0]]), -1),
-        (np.array([[1.0, 1.0, 1.0]]), 0),
-    ],
-    ids=["all-zero-row", "all-one-row"],
-)
-def test_cmp_special_rows_concentrate_mass(cumproba, mass_index):
-    """All-zero and all-one rows place all mass on a single class."""
-    class_proba = check_monotonic_probabilities(cumproba)
-    assert_allclose(class_proba.sum(axis=1), 1.0, atol=1e-12)
-    assert np.all(class_proba >= 0.0)
-    assert class_proba[0, mass_index] == pytest.approx(1.0)

--- a/skordinal/utils/validation.py
+++ b/skordinal/utils/validation.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
-from sklearn.isotonic import isotonic_regression
 from sklearn.utils import check_array
 from sklearn.utils.multiclass import check_classification_targets
 
 __all__ = [
     "check_ordinal_targets",
     "validate_thresholds",
-    "check_monotonic_probabilities",
 ]
 
 
@@ -128,99 +126,3 @@ def validate_thresholds(thresholds: ArrayLike) -> None:
         raise ValueError(
             f"thresholds must be strictly increasing, got differences {diffs!r}"
         )
-
-
-def check_monotonic_probabilities(
-    cumproba: ArrayLike,
-    repair: bool = True,
-) -> NDArray[np.float64]:
-    """Convert cumulative class probabilities to class-wise probabilities.
-
-    Takes a matrix of cumulative probabilities ``P(Y <= k | x)`` for
-    ``k = 1, ..., n_classes - 1`` and returns a matrix of class-wise
-    probabilities ``P(Y = k | x)`` for ``k = 1, ..., n_classes``.
-
-    When ``repair=True``, monotonicity violations in each row are
-    silently fixed via isotonic regression before differencing. When
-    ``repair=False``, any non-monotonic row triggers a ``ValueError``.
-
-    Special row behaviors:
-
-    - An all-zero row becomes ``[0, 0, ..., 1]``; the final class absorbs
-      all probability mass.
-    - An all-one row becomes ``[1, 0, ..., 0]``; the first class absorbs
-      all probability mass.
-
-    Parameters
-    ----------
-    cumproba : array-like of shape (n_samples, n_classes - 1)
-        Cumulative probabilities. Each row should be a non-decreasing
-        sequence of values in ``[0, 1]``.
-
-    repair : bool, default=True
-        If ``True``, apply isotonic regression row-wise to enforce
-        monotonicity before differencing, then clip and renormalise.
-        If ``False``, raise ``ValueError`` when any row is non-monotonic.
-
-    Returns
-    -------
-    class_proba : ndarray of shape (n_samples, n_classes), dtype np.float64
-        Class-wise probabilities. Each row is non-negative and sums to
-        exactly ``1.0``.
-
-    Raises
-    ------
-    ValueError
-        If ``cumproba`` is not 2-D, has zero columns, contains NaN / inf
-        values, contains values outside ``[0, 1]``, or — when
-        ``repair=False`` — has any row whose entries are not
-        non-decreasing. Upstream ``ValueError`` from ``check_array``
-        (e.g. NaN inputs) is propagated unchanged.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from skordinal.utils.validation import check_monotonic_probabilities
-    >>> cumproba = np.array([[0.2, 0.5, 0.9]])
-    >>> check_monotonic_probabilities(cumproba)
-    array([[0.2, 0.3, 0.4, 0.1]])
-    """
-    cumproba = check_array(
-        cumproba, ensure_2d=True, dtype=np.float64, input_name="cumproba"
-    )
-
-    if cumproba.min() < 0.0 or cumproba.max() > 1.0:
-        raise ValueError(
-            f"cumproba entries must lie in [0, 1], got range "
-            f"[{cumproba.min():.4g}, {cumproba.max():.4g}]"
-        )
-
-    n_samples, n_thresholds = cumproba.shape
-    class_proba = np.empty((n_samples, n_thresholds + 1), dtype=np.float64)
-
-    if not repair:
-        diffs = np.diff(cumproba, axis=1)
-        if (diffs < 0.0).any():
-            raise ValueError(
-                f"cumproba rows must be non-decreasing, got minimum diff "
-                f"{diffs.min():.4g}"
-            )
-        class_proba[:, 0] = cumproba[:, 0]
-        class_proba[:, 1:-1] = diffs
-        class_proba[:, -1] = 1.0 - cumproba[:, -1]
-        return class_proba
-
-    for i in range(n_samples):
-        row_iso = isotonic_regression(
-            cumproba[i], y_min=0.0, y_max=1.0, increasing=True
-        )
-        class_proba[i, 0] = row_iso[0]
-        class_proba[i, 1:-1] = np.diff(row_iso)
-        class_proba[i, -1] = 1.0 - row_iso[-1]
-
-    np.clip(class_proba, 0.0, None, out=class_proba)
-    row_sums = class_proba.sum(axis=1, keepdims=True)
-    # Defensive: y_min=0 prevents all-zero rows; clip is a safety net.
-    row_sums = np.where(row_sums == 0.0, 1.0, row_sums)
-    class_proba /= row_sums
-    return class_proba


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `skordinal.utils.extmath`, a module of mathematical primitives shared across ordinal classifiers. `params_to_thresholds`, together with its inverse `thresholds_to_params` and `gradient thresholds_grad`, reparameterises ordered thresholds for unconstrained optimisation. `repair_cumproba` enforces monotonicity of cumulative probabilities via isotonic regression. `cumproba_to_proba` and `proba_to_cumproba` convert between cumulative `P(Y <= k)` and class probabilities. `normalize_proba_rows` and `losses_to_proba` turn raw scores or losses into valid probability rows. `skordinal.utils` re-exports `cumproba_to_proba` and `repair_cumproba`. `check_monotonic_probabilities` is removed from `skordinal.utils.validation` in favour of `cumproba_to_proba`, and the private or inline duplicates in `ELMOP`, `NNPOM`, `OrdinalDecomposition` and `CostSensitiveWrapper` now call the shared functions.