### PR TITLE
ENH: Restructure experiment results into a per-seed layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,38 @@ RECIPE = {
 python examples/run_recipe.py my_experiment.py
 ```
 
-Results are saved in `results/` folder with performance metrics for each dataset-classifier combination. The framework automatically performs cross-validation, hyperparameter tuning, and evaluation on test sets.
+Results are saved in the `results/` folder with performance metrics for each
+dataset-classifier combination. The framework automatically performs
+cross-validation, hyperparameter tuning, and evaluation on test sets.
+
+Each classifier-dataset pair gets its own directory holding a `report.csv`
+with per-resample metrics, a `hyperparameter_configuration.csv` recording the
+best hyperparameters chosen for each seed, and a `predictions_by_seed/`
+folder grouping the outputs of every resample:
+
+```text
+results/
+└── <classifier>/
+    └── <dataset>/
+        ├── report.csv
+        ├── hyperparameter_configuration.csv
+        └── predictions_by_seed/
+            └── seed_<N>/
+                ├── train_predictions.csv
+                ├── test_predictions.csv
+                ├── train_confusion_matrix.txt
+                └── test_confusion_matrix.txt
+```
+
+Each predictions CSV lists the `Pattern ID`, the zero-based `Target` class
+index, a `Prediction probabilities` column with the per-class probabilities
+(for estimators that support `predict_proba`), and the zero-based
+`Prediction` class index — the argmax of the probabilities when they are
+present, or the estimator's own prediction otherwise. Confusion matrices are
+written alongside as plain-text `.txt` files, the fitted estimator for each
+seed is stored under a `models/` subfolder, and aggregated
+`train_summary.csv` and `test_summary.csv` files are produced across all
+runs.
 
 ## Configuration Files
 

--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -455,6 +455,12 @@ def load_partitions(
         resample_id : int
             Identifier of the current resample, taken from
             ``range(resamples)`` or from the supplied list of ids.
+        train_index : ndarray of shape (n_train,)
+            0-based indices of the training rows within the original
+            dataset array.
+        test_index : ndarray of shape (n_test,)
+            0-based indices of the test rows within the original
+            dataset array.
         n_classes : int
             Number of ordinal classes.
         DESCR : str
@@ -503,6 +509,8 @@ def load_partitions(
                 target_names=target_names,
                 dataset_name=str(name),
                 resample_id=int(resample_id),
+                train_index=np.flatnonzero(train_mask),
+                test_index=np.flatnonzero(~train_mask),
                 n_classes=n_classes,
                 DESCR=(
                     f"{name} resample {resample_id}: "

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -307,6 +307,8 @@ def test_partition_bunch_contract(tmp_path):
         "target_names",
         "dataset_name",
         "resample_id",
+        "train_index",
+        "test_index",
         "n_classes",
         "DESCR",
     }
@@ -327,6 +329,31 @@ def test_partition_bunch_contract(tmp_path):
     assert bunch.resample_id == 0
     # DESCR is a non-empty string
     assert isinstance(bunch.DESCR, str) and len(bunch.DESCR) > 0
+
+
+def test_partition_index_contract():
+    """train_index/test_index are integer, ascending, disjoint and complete."""
+    for bunch in load_partitions("era", resamples=3):
+        for index, data in (
+            (bunch.train_index, bunch.data_train),
+            (bunch.test_index, bunch.data_test),
+        ):
+            assert isinstance(index, np.ndarray)
+            assert np.issubdtype(index.dtype, np.integer)
+            assert len(index) == data.shape[0]
+            assert np.all(np.diff(index) > 0)
+        n_total = bunch.data_train.shape[0] + bunch.data_test.shape[0]
+        combined = np.concatenate([bunch.train_index, bunch.test_index])
+        assert np.array_equal(np.sort(combined), np.arange(n_total))
+
+
+def test_partition_index_matches_source_rows():
+    """train_index/test_index select the same rows as data_train/test."""
+    raw = load_dataset("era")
+    bunches = list(load_partitions("era", resamples=3))
+    for bunch in bunches:
+        np.testing.assert_array_equal(raw.data[bunch.train_index], bunch.data_train)
+        np.testing.assert_array_equal(raw.data[bunch.test_index], bunch.data_test)
 
 
 def _setup_missing_csv(tmp_path):

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -269,6 +269,8 @@ class Benchmark:
                         dataset_name=dataset_name,
                         classifier_name=label,
                         resample_id=b.resample_id,
+                        train_index=b.train_index,
+                        test_index=b.test_index,
                     )
                     self._results.save(result)
 

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import OrderedDict
 from time import time
 from typing import Any, cast
@@ -20,6 +21,21 @@ def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) ->
     """Compute a single ordinal metric by name."""
     scorer = cast(Any, get_ordinal_scorer(metric_name.strip()))
     return scorer._score_func(y_true, y_pred, **scorer._kwargs)
+
+
+def _predict_proba_or_none(estimator: Any, inputs: np.ndarray) -> np.ndarray | None:
+    """Return class probabilities, or ``None`` when the estimator cannot."""
+    if not hasattr(estimator, "predict_proba"):
+        return None
+    try:
+        return estimator.predict_proba(inputs)
+    except AttributeError as exc:
+        warnings.warn(
+            f"predict_proba raised AttributeError; probabilities are omitted: {exc}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
 
 
 class Experiment:
@@ -281,13 +297,13 @@ class Experiment:
             train_metrics["time_train"] = optimal_estimator.refit_time_
             test_metrics["time_test"] = elapsed
 
-        # Compute class probabilities when available.
+        # Compute class probabilities on each split when supported
+        estimator = optimal_estimator.best_estimator_
+        train_y_proba = _predict_proba_or_none(estimator, train_inputs)
         y_proba = None
-        if y_test is not None and hasattr(
-            optimal_estimator.best_estimator_, "predict_proba"
-        ):
+        if y_test is not None:
             assert test_inputs is not None
-            y_proba = optimal_estimator.best_estimator_.predict_proba(test_inputs)
+            y_proba = _predict_proba_or_none(estimator, test_inputs)
 
         # Build and return the ExperimentResult; no persistence here.
         return ExperimentResult(
@@ -300,9 +316,10 @@ class Experiment:
             train_metrics=train_metrics,
             test_metrics=test_metrics,
             best_params=optimal_estimator.best_params_,
-            best_model=optimal_estimator.best_estimator_,
+            best_model=estimator,
             train_true_y=y_train,
             test_true_y=y_test,
             train_index=train_index,
             test_index=test_index,
+            train_y_proba=train_y_proba,
         )

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -135,6 +135,8 @@ class Experiment:
         dataset_name: str,
         classifier_name: str,
         resample_id: int,
+        train_index: np.ndarray | None = None,
+        test_index: np.ndarray | None = None,
     ) -> ExperimentResult:
         """Run the configuration on a single train/test partition.
 
@@ -168,6 +170,16 @@ class Experiment:
 
         resample_id : int
             Partition index, forwarded to the returned ``ExperimentResult``.
+
+        train_index : ndarray of shape (n_train_samples,) or None, default=None
+            Zero-based positions of the training samples in the original
+            dataset array; forwarded to the returned ``ExperimentResult`` and
+            used as the ``Pattern ID`` column.
+
+        test_index : ndarray of shape (n_test_samples,) or None, default=None
+            Zero-based positions of the test samples in the original dataset
+            array; forwarded to the returned ``ExperimentResult`` and used as
+            the ``Pattern ID`` column.
 
         Returns
         -------
@@ -291,4 +303,6 @@ class Experiment:
             best_model=optimal_estimator.best_estimator_,
             train_true_y=y_train,
             test_true_y=y_test,
+            train_index=train_index,
+            test_index=test_index,
         )

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -52,12 +52,24 @@ class ExperimentResult:
         Fitted estimator selected during cross-validation or direct fit.
 
     train_true_y : ndarray of shape (n_train_samples,) or None, default=None
-        True class labels for the training partition. When provided, predictions
-        CSV files include a ``y_true`` column alongside ``y_pred``.
+        True class labels for the training partition, used to derive the
+        ``Target`` column of the training predictions file.
 
     test_true_y : ndarray of shape (n_test_samples,) or None, default=None
-        True class labels for the test partition. When provided, the test
-        predictions CSV file includes a ``y_true`` column alongside ``y_pred``.
+        True class labels for the test partition, used to derive the
+        ``Target`` column of the test predictions file.
+
+    train_index : ndarray of shape (n_train_samples,) or None, default=None
+        Zero-based positions of the training samples in the original,
+        unsplit dataset array. Written as the ``Pattern ID`` column of the
+        training predictions file. ``None`` falls back to a partition-local
+        ``range(n_train_samples)`` at write time.
+
+    test_index : ndarray of shape (n_test_samples,) or None, default=None
+        Zero-based positions of the test samples in the original, unsplit
+        dataset array. Written as the ``Pattern ID`` column of the test
+        predictions file. ``None`` falls back to a partition-local
+        ``range(n_test_samples)`` at write time.
 
     """
 
@@ -73,6 +85,38 @@ class ExperimentResult:
     best_model: BaseEstimator
     train_true_y: np.ndarray | None = None
     test_true_y: np.ndarray | None = None
+    train_index: np.ndarray | None = None
+    test_index: np.ndarray | None = None
+
+
+def _write_split_files(
+    seed_dir: Path,
+    split: str,
+    *,
+    index: np.ndarray | None,
+    true_y: np.ndarray,
+    predicted_y: np.ndarray,
+    classes: np.ndarray,
+) -> None:
+    """Encode one split's labels and write its predictions file."""
+    if not np.isin(true_y, classes).all():
+        raise ValueError(
+            f"'{split}' true labels contain classes unknown to the fitted model."
+        )
+    if not np.isin(predicted_y, classes).all():
+        raise ValueError(
+            f"'{split}' predicted labels contain classes unknown to the fitted model."
+        )
+    pattern_id = index if index is not None else np.arange(predicted_y.shape[0])
+    target = np.searchsorted(classes, true_y)
+    prediction = np.searchsorted(classes, predicted_y)
+
+    columns: dict[str, object] = {
+        "Pattern ID": pattern_id,
+        "Target": target,
+        "Prediction": prediction,
+    }
+    pd.DataFrame(columns).to_csv(seed_dir / f"{split}_predictions.csv", index=False)
 
 
 class Results:
@@ -99,14 +143,20 @@ class Results:
             <dataset_name>/
                 report.csv
                 params.json
-                predictions/
-                    train_<resample_id>.csv
-                    test_<resample_id>.csv
+                predictions_by_seed/
+                    seed_<resample_id>/
+                        train_predictions.csv
+                        test_predictions.csv
                 models/
                     <resample_id>.joblib
 
-    The root-level ``train_summary.csv`` and ``test_summary.csv`` files are
-    written by ``save_summary`` and are absent until it is called.
+    Each ``*_predictions.csv`` has columns ``Pattern ID``, ``Target`` and
+    ``Prediction``. ``Target`` and ``Prediction`` are zero-based class
+    indices into ``best_model.classes_``; ``Pattern ID`` is the sample's
+    position in the original dataset array, or its position within the
+    partition when no sample indices were recorded. The root-level
+    ``train_summary.csv`` and ``test_summary.csv`` files are written by
+    ``save_summary`` and are absent until it is called.
 
     """
 
@@ -119,7 +169,7 @@ class Results:
         *,
         save_model: bool = True,
     ) -> None:
-        """Store information obtained from the run of one partition.
+        """Write one partition's per-seed predictions, report row and model.
 
         Parameters
         ----------
@@ -131,6 +181,14 @@ class Results:
 
         Raises
         ------
+        ValueError
+            If ``result`` lacks the true labels required for the ``Target``
+            column (``train_true_y``, or ``test_true_y`` when test
+            predictions are present), or if a true or predicted label is
+            not one of ``best_model.classes_``. Files already written for a
+            preceding split are left in place; nothing else is recorded for
+            the partition.
+
         OSError
             If the folder cannot be created.
 
@@ -141,22 +199,46 @@ class Results:
         >>> results.save(result)  # doctest: +SKIP
 
         """
-        base_dir, models_dir, pred_dir = self._ensure_dirs(
-            result.classifier_name, result.dataset_name, save_model=save_model
+        if result.train_true_y is None:
+            raise ValueError(
+                "'result.train_true_y' is required to write the 'Target' "
+                "column of the training predictions file."
+            )
+        if result.test_predicted_y is not None and result.test_true_y is None:
+            raise ValueError(
+                "'result.test_true_y' is required to write the 'Target' "
+                "column of the test predictions file."
+            )
+
+        base_dir, models_dir, seed_dir = self._ensure_dirs(
+            result.classifier_name,
+            result.dataset_name,
+            result.resample_id,
+            save_model=save_model,
         )
 
-        # Write model and prediction CSVs
+        classes = np.asarray(result.best_model.classes_)
+        _write_split_files(
+            seed_dir,
+            "train",
+            index=result.train_index,
+            true_y=result.train_true_y,
+            predicted_y=result.train_predicted_y,
+            classes=classes,
+        )
+        if result.test_predicted_y is not None:
+            assert result.test_true_y is not None
+            _write_split_files(
+                seed_dir,
+                "test",
+                index=result.test_index,
+                true_y=result.test_true_y,
+                predicted_y=result.test_predicted_y,
+                classes=classes,
+            )
+
         if save_model:
             joblib.dump(result.best_model, models_dir / f"{result.resample_id}.joblib")
-        train_df = pd.DataFrame({"y_pred": result.train_predicted_y})
-        if result.train_true_y is not None:
-            train_df.insert(0, "y_true", result.train_true_y)
-        train_df.to_csv(pred_dir / f"train_{result.resample_id}.csv", index=False)
-        if result.test_predicted_y is not None:
-            test_df = pd.DataFrame({"y_pred": result.test_predicted_y})
-            if result.test_true_y is not None:
-                test_df.insert(0, "y_true", result.test_true_y)
-            test_df.to_csv(pred_dir / f"test_{result.resample_id}.csv", index=False)
 
         self._append_report_row(result, base_dir)
 
@@ -169,21 +251,26 @@ class Results:
         json_path.write_text(json.dumps(params, indent=2), encoding="utf-8")
 
     def _ensure_dirs(
-        self, classifier_name: str, dataset_name: str, *, save_model: bool
+        self,
+        classifier_name: str,
+        dataset_name: str,
+        resample_id: int,
+        *,
+        save_model: bool,
     ) -> tuple[Path, Path, Path]:
-        """Create required sub-directories and return ``(base_dir, models_dir, pred_dir)``."""
+        """Create required sub-directories and return their paths."""
         base = self._experiment_folder / classifier_name / dataset_name
-        pred_dir = base / "predictions"
+        seed_dir = base / "predictions_by_seed" / f"seed_{resample_id}"
         models_dir = base / "models"
         try:
-            pred_dir.mkdir(parents=True, exist_ok=True)
+            seed_dir.mkdir(parents=True, exist_ok=True)
             if save_model:
                 models_dir.mkdir(exist_ok=True)
         except OSError:
             raise OSError(
                 f"Could not create folder {base} (or subfolders) to store results."
             )
-        return base, models_dir, pred_dir
+        return base, models_dir, seed_dir
 
     def _append_report_row(self, result: ExperimentResult, base_dir: Path) -> None:
         """Append one metrics row to ``report.csv``."""

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -177,7 +176,7 @@ class Results:
         <classifier_name>/
             <dataset_name>/
                 report.csv
-                params.json
+                hyperparameter_configuration.csv
                 predictions_by_seed/
                     seed_<resample_id>/
                         train_predictions.csv
@@ -197,7 +196,10 @@ class Results:
     ``Prediction`` is their argmax index, which may differ from the
     estimator's own decision rule reflected in ``report.csv``. Each
     ``*_confusion_matrix.txt`` holds the confusion matrix of the same
-    file's ``Target`` and ``Prediction`` columns. The root-level
+    file's ``Target`` and ``Prediction`` columns.
+    ``hyperparameter_configuration.csv`` records the best parameters per
+    seed with the ``clf__`` pipeline prefix stripped; its ``Seed`` column
+    always holds the resample identifier. The root-level
     ``train_summary.csv`` and ``test_summary.csv`` files are written by
     ``save_summary`` and are absent until it is called.
 
@@ -212,7 +214,7 @@ class Results:
         *,
         save_model: bool = True,
     ) -> None:
-        """Write per-seed predictions, confusion matrices, report and model.
+        """Write per-seed files, the report row, hyperparameters and model.
 
         Parameters
         ----------
@@ -289,14 +291,7 @@ class Results:
             joblib.dump(result.best_model, models_dir / f"{result.resample_id}.joblib")
 
         self._append_report_row(result, base_dir)
-
-        # Upsert params entry in params.json
-        json_path = base_dir / "params.json"
-        params: dict[str, Any] = {}
-        if json_path.is_file():
-            params = json.loads(json_path.read_text(encoding="utf-8"))
-        params[str(result.resample_id)] = dict(result.best_params)
-        json_path.write_text(json.dumps(params, indent=2), encoding="utf-8")
+        self._upsert_hyperparameters(result, base_dir)
 
     def _ensure_dirs(
         self,
@@ -331,6 +326,26 @@ class Results:
             existing.index = existing.index.astype(str)
             df = pd.concat([existing, df])
         df.to_csv(csv_path)
+
+    def _upsert_hyperparameters(self, result: ExperimentResult, base_dir: Path) -> None:
+        """Upsert one seed's row in the hyperparameter configuration CSV."""
+        row: dict[str, Any] = {
+            k.removeprefix("clf__"): v for k, v in result.best_params.items()
+        }
+        # Set Seed last so no same-named parameter can shadow the upsert key
+        row["Seed"] = result.resample_id
+
+        csv_path = base_dir / "hyperparameter_configuration.csv"
+        df = pd.DataFrame([row])
+        if csv_path.is_file():
+            existing = pd.read_csv(csv_path)
+            existing = existing[existing["Seed"] != result.resample_id]
+            df = pd.concat([existing, df], ignore_index=True)
+
+        columns = ["Seed"] + sorted(c for c in df.columns if c != "Seed")
+        df = df[columns].sort_values("Seed").reset_index(drop=True)
+        # Restore integer dtypes upcast to float by the NaN column union
+        df.convert_dtypes().to_csv(csv_path, index=False)
 
     @classmethod
     def load(cls, experiment_folder: str | Path) -> Results:

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -36,8 +36,9 @@ class ExperimentResult:
         was available.
 
     y_proba : ndarray of shape (n_test_samples, n_classes) or None
-        Class probability estimates on the test partition. ``None`` if the
-        estimator does not support ``predict_proba``.
+        Class probability estimates on the test partition, columns ordered
+        by ``best_model.classes_``. ``None`` when no test partition is
+        available or the estimator cannot provide probabilities.
 
     train_metrics : dict
         Metric values computed on the training partition, including timing.
@@ -71,6 +72,12 @@ class ExperimentResult:
         predictions file. ``None`` falls back to a partition-local
         ``range(n_test_samples)`` at write time.
 
+    train_y_proba : ndarray of shape (n_train_samples, n_classes) or None, \
+            default=None
+        Class-probability estimates on the training partition, columns
+        ordered by ``best_model.classes_``. ``None`` when the estimator
+        cannot provide probabilities.
+
     """
 
     dataset_name: str
@@ -87,6 +94,14 @@ class ExperimentResult:
     test_true_y: np.ndarray | None = None
     train_index: np.ndarray | None = None
     test_index: np.ndarray | None = None
+    train_y_proba: np.ndarray | None = None
+
+
+def _format_proba_column(proba: np.ndarray) -> list[str]:
+    """Render probability rows as single-line ``"[p0, p1, ...]"`` cells."""
+    return [
+        "[" + ", ".join(repr(float(p)) for p in row) + "]" for row in np.asarray(proba)
+    ]
 
 
 def _write_split_files(
@@ -96,6 +111,7 @@ def _write_split_files(
     index: np.ndarray | None,
     true_y: np.ndarray,
     predicted_y: np.ndarray,
+    proba: np.ndarray | None,
     classes: np.ndarray,
 ) -> None:
     """Encode one split's labels and write its predictions file."""
@@ -103,19 +119,27 @@ def _write_split_files(
         raise ValueError(
             f"'{split}' true labels contain classes unknown to the fitted model."
         )
-    if not np.isin(predicted_y, classes).all():
-        raise ValueError(
-            f"'{split}' predicted labels contain classes unknown to the fitted model."
-        )
     pattern_id = index if index is not None else np.arange(predicted_y.shape[0])
     target = np.searchsorted(classes, true_y)
-    prediction = np.searchsorted(classes, predicted_y)
 
-    columns: dict[str, object] = {
-        "Pattern ID": pattern_id,
-        "Target": target,
-        "Prediction": prediction,
-    }
+    columns: dict[str, object] = {"Pattern ID": pattern_id, "Target": target}
+    if proba is not None:
+        if proba.shape != (true_y.shape[0], classes.size):
+            raise ValueError(
+                f"'{split}' probabilities have shape {proba.shape}; expected "
+                f"({true_y.shape[0]}, {classes.size})."
+            )
+        columns["Prediction probabilities"] = _format_proba_column(proba)
+        # Derive the prediction as the argmax index of the probabilities
+        prediction = np.argmax(proba, axis=1)
+    else:
+        if not np.isin(predicted_y, classes).all():
+            raise ValueError(
+                f"'{split}' predicted labels contain classes unknown to the "
+                "fitted model."
+            )
+        prediction = np.searchsorted(classes, predicted_y)
+    columns["Prediction"] = prediction
     pd.DataFrame(columns).to_csv(seed_dir / f"{split}_predictions.csv", index=False)
 
 
@@ -150,11 +174,15 @@ class Results:
                 models/
                     <resample_id>.joblib
 
-    Each ``*_predictions.csv`` has columns ``Pattern ID``, ``Target`` and
-    ``Prediction``. ``Target`` and ``Prediction`` are zero-based class
-    indices into ``best_model.classes_``; ``Pattern ID`` is the sample's
-    position in the original dataset array, or its position within the
-    partition when no sample indices were recorded. The root-level
+    Each ``*_predictions.csv`` has columns ``Pattern ID``, ``Target``, an
+    optional ``Prediction probabilities`` column (present only when
+    probability estimates are available), and ``Prediction``. ``Target``
+    and ``Prediction`` are zero-based class indices into
+    ``best_model.classes_``; ``Pattern ID`` is the sample's position in the
+    original dataset array, or its position within the partition when no
+    sample indices were recorded. When probabilities are present,
+    ``Prediction`` is their argmax index, which may differ from the
+    estimator's own decision rule reflected in ``report.csv``. The root-level
     ``train_summary.csv`` and ``test_summary.csv`` files are written by
     ``save_summary`` and are absent until it is called.
 
@@ -184,10 +212,11 @@ class Results:
         ValueError
             If ``result`` lacks the true labels required for the ``Target``
             column (``train_true_y``, or ``test_true_y`` when test
-            predictions are present), or if a true or predicted label is
-            not one of ``best_model.classes_``. Files already written for a
-            preceding split are left in place; nothing else is recorded for
-            the partition.
+            predictions are present), if a true or predicted label is not
+            one of ``best_model.classes_``, or if a probability matrix does
+            not hold one row per sample and one column per class. Files
+            already written for a preceding split are left in place;
+            nothing else is recorded for the partition.
 
         OSError
             If the folder cannot be created.
@@ -224,6 +253,7 @@ class Results:
             index=result.train_index,
             true_y=result.train_true_y,
             predicted_y=result.train_predicted_y,
+            proba=result.train_y_proba,
             classes=classes,
         )
         if result.test_predicted_y is not None:
@@ -234,6 +264,7 @@ class Results:
                 index=result.test_index,
                 true_y=result.test_true_y,
                 predicted_y=result.test_predicted_y,
+                proba=result.y_proba,
                 classes=classes,
             )
 

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,7 @@ import joblib
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
+from sklearn.metrics import confusion_matrix
 
 
 @dataclass(frozen=True)
@@ -113,8 +115,9 @@ def _write_split_files(
     predicted_y: np.ndarray,
     proba: np.ndarray | None,
     classes: np.ndarray,
+    resample_id: int,
 ) -> None:
-    """Encode one split's labels and write its predictions file."""
+    """Encode one split's labels and write its per-seed output files."""
     if not np.isin(true_y, classes).all():
         raise ValueError(
             f"'{split}' true labels contain classes unknown to the fitted model."
@@ -141,6 +144,14 @@ def _write_split_files(
         prediction = np.searchsorted(classes, predicted_y)
     columns["Prediction"] = prediction
     pd.DataFrame(columns).to_csv(seed_dir / f"{split}_predictions.csv", index=False)
+
+    cm = confusion_matrix(target, prediction, labels=np.arange(classes.size))
+    body = np.array2string(
+        cm, separator=", ", threshold=cm.size, max_line_width=sys.maxsize
+    )
+    (seed_dir / f"{split}_confusion_matrix.txt").write_text(
+        f"Seed {resample_id}\n{'=' * 21}\n{body}\n", encoding="utf-8"
+    )
 
 
 class Results:
@@ -171,6 +182,8 @@ class Results:
                     seed_<resample_id>/
                         train_predictions.csv
                         test_predictions.csv
+                        train_confusion_matrix.txt
+                        test_confusion_matrix.txt
                 models/
                     <resample_id>.joblib
 
@@ -182,7 +195,9 @@ class Results:
     original dataset array, or its position within the partition when no
     sample indices were recorded. When probabilities are present,
     ``Prediction`` is their argmax index, which may differ from the
-    estimator's own decision rule reflected in ``report.csv``. The root-level
+    estimator's own decision rule reflected in ``report.csv``. Each
+    ``*_confusion_matrix.txt`` holds the confusion matrix of the same
+    file's ``Target`` and ``Prediction`` columns. The root-level
     ``train_summary.csv`` and ``test_summary.csv`` files are written by
     ``save_summary`` and are absent until it is called.
 
@@ -197,7 +212,7 @@ class Results:
         *,
         save_model: bool = True,
     ) -> None:
-        """Write one partition's per-seed predictions, report row and model.
+        """Write per-seed predictions, confusion matrices, report and model.
 
         Parameters
         ----------
@@ -255,6 +270,7 @@ class Results:
             predicted_y=result.train_predicted_y,
             proba=result.train_y_proba,
             classes=classes,
+            resample_id=result.resample_id,
         )
         if result.test_predicted_y is not None:
             assert result.test_true_y is not None
@@ -266,6 +282,7 @@ class Results:
                 predicted_y=result.test_predicted_y,
                 proba=result.y_proba,
                 classes=classes,
+                resample_id=result.resample_id,
             )
 
         if save_model:

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -189,7 +189,8 @@ def test_run_and_summarize_bundled_dataset(tmp_path):
     df = pd.read_csv(pair_dir / "report.csv", index_col=0)
     assert df.shape[0] == 3
 
-    assert (pair_dir / "params.json").is_file()
+    assert (pair_dir / "hyperparameter_configuration.csv").is_file()
+    assert not (pair_dir / "params.json").exists()
 
     pred_dir = pair_dir / "predictions_by_seed"
     train_preds = sorted(pred_dir.glob("seed_*/train_predictions.csv"))

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -44,7 +44,8 @@ def csv_ds_dir(tmp_path):
     rng = np.random.default_rng(7)
     n = 60
     X = rng.standard_normal((n, 4))
-    y = np.repeat([0, 1, 2], n // 3)
+    # Interleave classes so both mask halves contain every class
+    y = np.tile([0, 1, 2], n // 3)
     rows = np.hstack([X, y.reshape(-1, 1)])
     np.savetxt(tmp_path / "smallds.csv", rows, delimiter=",", fmt="%.6f")
     mask0 = [True] * (n // 2) + [False] * (n // 2)
@@ -190,15 +191,15 @@ def test_run_and_summarize_bundled_dataset(tmp_path):
 
     assert (pair_dir / "params.json").is_file()
 
-    pred_dir = pair_dir / "predictions"
-    train_preds = sorted(pred_dir.glob("train_*.csv"))
-    test_preds = sorted(pred_dir.glob("test_*.csv"))
+    pred_dir = pair_dir / "predictions_by_seed"
+    train_preds = sorted(pred_dir.glob("seed_*/train_predictions.csv"))
+    test_preds = sorted(pred_dir.glob("seed_*/test_predictions.csv"))
     assert len(train_preds) == 3
     assert len(test_preds) == 3
 
-    # resample_id stems on prediction filenames are ints (0, 1, 2)
-    ids_from_files = sorted(int(f.stem.split("_")[1]) for f in train_preds)
-    assert ids_from_files == [0, 1, 2]
+    # Check per-seed directory names carry the resample_id (0, 1, 2)
+    ids_from_dirs = sorted(int(f.parent.name.split("_")[1]) for f in train_preds)
+    assert ids_from_dirs == [0, 1, 2]
 
     # report.csv must contain one <metric>_train and one <metric>_test column
     assert "mean_absolute_error_train" in df.columns
@@ -269,12 +270,16 @@ def test_run_mask_path_train_test_sizes_match_masks(tmp_path, csv_ds_dir):
     )
     b.run()
 
-    pred_dir = results_dir / "SVM" / "smallds" / "predictions"
+    seed_dir = results_dir / "SVM" / "smallds" / "predictions_by_seed" / "seed_0"
     # Each mask splits n=60 half-and-half: 30 train / 30 test
-    train_0 = pd.read_csv(pred_dir / "train_0.csv")
-    test_0 = pd.read_csv(pred_dir / "test_0.csv")
+    train_0 = pd.read_csv(seed_dir / "train_predictions.csv")
+    test_0 = pd.read_csv(seed_dir / "test_predictions.csv")
     assert len(train_0) == 30
     assert len(test_0) == 30
+
+    # Check Pattern ID carries the original row positions defined by mask 0
+    np.testing.assert_array_equal(train_0["Pattern ID"].values, np.arange(30))
+    np.testing.assert_array_equal(test_0["Pattern ID"].values, np.arange(30, 60))
 
 
 def test_run_resamples_below_two_raises(tmp_path):

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -123,6 +123,31 @@ def test_run_identity_passthrough(split_with_test):
     assert result.resample_id == 42
 
 
+def test_run_forwards_partition_indices(split_with_test):
+    """train_index/test_index round-trip onto the result; default None."""
+    X_train, y_train, X_test, y_test = split_with_test
+    train_index = np.arange(X_train.shape[0])
+    test_index = np.arange(X_test.shape[0])
+
+    result = _make_experiment().run(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        dataset_name="ds",
+        classifier_name="cfg",
+        resample_id=0,
+        train_index=train_index,
+        test_index=test_index,
+    )
+    npt.assert_array_equal(result.train_index, train_index)
+    npt.assert_array_equal(result.test_index, test_index)
+
+    default_result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
+    assert default_result.train_index is None
+    assert default_result.test_index is None
+
+
 @pytest.mark.parametrize("has_test", [True, False])
 def test_run_test_present_vs_absent(split_with_test, split_train_only, has_test):
     """With test data: test_predicted_y is an array and metrics are finite; without: None and NaN."""

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -223,19 +223,49 @@ def test_run_metric_keys_for_each_eval_metric(split_with_test):
         assert name + "_test" in result.test_metrics
 
 
-def test_run_y_proba_absent_without_predict_proba(split_with_test):
-    """y_proba is None when the fitted estimator has no predict_proba."""
+def test_run_proba_absent_without_predict_proba(split_with_test):
+    """Both proba fields are None when the estimator has no predict_proba."""
     X_train, y_train, X_test, y_test = split_with_test
     result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
 
     assert result.y_proba is None
+    assert result.train_y_proba is None
 
 
-def test_run_y_proba_present_with_predict_proba(split_with_test):
-    """y_proba is populated when the estimator supports predict_proba."""
+def test_run_proba_present_with_predict_proba(split_with_test):
+    """Both proba fields are populated when predict_proba is supported."""
     X_train, y_train, X_test, y_test = split_with_test
     conf = ModelConfig(SVC(), param_grid={"probability": [True]})
     result = _call_run(_make_experiment(conf), X_train, y_train, X_test, y_test)
 
+    n_classes = np.unique(y_train).size
     assert result.y_proba is not None
-    assert result.y_proba.shape[0] == X_test.shape[0]
+    assert result.y_proba.shape == (X_test.shape[0], n_classes)
+    assert result.train_y_proba is not None
+    assert result.train_y_proba.shape == (X_train.shape[0], n_classes)
+
+
+def test_run_no_test_labels_skips_test_proba(split_with_test):
+    """y_proba stays None when y_test is None even if X_test is given."""
+    X_train, y_train, X_test, _ = split_with_test
+    conf = ModelConfig(SVC(), param_grid={"probability": [True]})
+    result = _call_run(_make_experiment(conf), X_train, y_train, X_test, None)
+
+    assert result.y_proba is None
+    assert result.train_y_proba is not None
+
+
+def test_run_proba_none_when_predict_proba_raises(split_with_test, monkeypatch):
+    """A call-time AttributeError from predict_proba warns and yields None."""
+    X_train, y_train, X_test, y_test = split_with_test
+
+    def raise_attribute_error(self, X):
+        """Raise as meta-estimators without probabilistic members do."""
+        raise AttributeError("predict_proba is unavailable")
+
+    monkeypatch.setattr(SVC, "predict_proba", raise_attribute_error)
+    with pytest.warns(RuntimeWarning, match="probabilities are omitted"):
+        result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
+
+    assert result.train_y_proba is None
+    assert result.y_proba is None

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -1,7 +1,5 @@
 """Tests for the Results class."""
 
-import json
-
 import joblib
 import numpy as np
 import numpy.testing as npt
@@ -109,9 +107,15 @@ def test_save(tmp_path):
     assert df.shape == (2, 4)
     assert list(df.columns) == ["ccr_train", "mae_train", "ccr_test", "mae_test"]
 
-    params = json.loads((pair_dir / "params.json").read_text())
-    assert params["0"] == {"C": 0.1, "gamma": 1}
-    assert params["1"] == {"C": 1, "gamma": 1}
+    assert not (pair_dir / "params.json").exists()
+    hyper = pd.read_csv(pair_dir / "hyperparameter_configuration.csv")
+    assert list(hyper.columns) == ["Seed", "C", "gamma"]
+    row_0 = hyper[hyper["Seed"] == 0].iloc[0]
+    assert row_0["C"] == 0.1
+    assert row_0["gamma"] == 1
+    row_1 = hyper[hyper["Seed"] == 1].iloc[0]
+    assert row_1["C"] == 1
+    assert row_1["gamma"] == 1
 
     models_dir = pair_dir / "models"
     assert (models_dir / "0.joblib").is_file()
@@ -422,8 +426,8 @@ def test_save_pattern_id_fallback(tmp_path, with_indices):
     npt.assert_array_equal(test_df["Pattern ID"].values, expected_test)
 
 
-def test_save_multiple_partitions_and_params_upsert(tmp_path):
-    """Repeated saves accumulate report rows and upsert params.json."""
+def test_save_multiple_partitions_and_hyperparameter_upsert(tmp_path):
+    """Repeated saves accumulate report rows and upsert hyperparameters."""
     r = Results(tmp_path)
     for i in range(3):
         r.save(
@@ -460,8 +464,94 @@ def test_save_multiple_partitions_and_params_upsert(tmp_path):
         save_model=False,
     )
 
-    params = json.loads((tmp_path / "clf" / "ds" / "params.json").read_text())
-    assert params["0"]["C"] == 1.0
+    hyper = pd.read_csv(tmp_path / "clf" / "ds" / "hyperparameter_configuration.csv")
+    seed_0 = hyper[hyper["Seed"] == 0]
+    assert len(seed_0) == 1
+    assert seed_0.iloc[0]["C"] == 1.0
+    # Check rows stay sorted by Seed after the out-of-order upsert
+    npt.assert_array_equal(hyper["Seed"].values, [0, 1, 2])
+
+
+def test_hyperparameters_prefix_strip_and_union(tmp_path):
+    """The clf__ prefix is stripped and missing params union to NaN."""
+    r = Results(tmp_path)
+    r.save(
+        _make_result(
+            partition=0,
+            dataset="ds",
+            configuration="clf",
+            best_params={"clf__gamma": 1},
+            train_metrics={"mae_train": 0.1},
+            test_metrics={"mae_test": 0.1},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=np.array([1]),
+        ),
+        save_model=False,
+    )
+    r.save(
+        _make_result(
+            partition=1,
+            dataset="ds",
+            configuration="clf",
+            best_params={"clf__gamma": 0.3, "clf__alpha": 2},
+            train_metrics={"mae_train": 0.2},
+            test_metrics={"mae_test": 0.2},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=np.array([1]),
+        ),
+        save_model=False,
+    )
+
+    hyper = pd.read_csv(tmp_path / "clf" / "ds" / "hyperparameter_configuration.csv")
+    # Check columns are Seed first, then alphabetical (not insertion order)
+    assert list(hyper.columns) == ["Seed", "alpha", "gamma"]
+    npt.assert_array_equal(hyper["Seed"].values, [0, 1])
+    assert pd.isna(hyper[hyper["Seed"] == 0].iloc[0]["alpha"])
+    assert hyper[hyper["Seed"] == 1].iloc[0]["alpha"] == 2
+
+    # Check integer values survive the NaN column union unquoted
+    raw = (tmp_path / "clf" / "ds" / "hyperparameter_configuration.csv").read_text()
+    assert "2.0" not in raw
+
+
+def test_hyperparameters_empty_params(tmp_path):
+    """Empty best_params yields a one-column CSV holding only Seed."""
+    Results(tmp_path).save(
+        _make_result(
+            partition=0,
+            dataset="ds",
+            configuration="clf",
+            best_params={},
+            train_metrics={"mae_train": 0.1},
+            test_metrics={"mae_test": 0.1},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=np.array([1]),
+        ),
+        save_model=False,
+    )
+
+    hyper = pd.read_csv(tmp_path / "clf" / "ds" / "hyperparameter_configuration.csv")
+    assert list(hyper.columns) == ["Seed"]
+
+
+def test_hyperparameters_seed_param_cannot_shadow_key(tmp_path):
+    """A parameter literally named Seed cannot overwrite the Seed column."""
+    Results(tmp_path).save(
+        _make_result(
+            partition=5,
+            dataset="ds",
+            configuration="clf",
+            best_params={"Seed": 999},
+            train_metrics={"mae_train": 0.1},
+            test_metrics={"mae_test": 0.1},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=np.array([1]),
+        ),
+        save_model=False,
+    )
+
+    hyper = pd.read_csv(tmp_path / "clf" / "ds" / "hyperparameter_configuration.csv")
+    npt.assert_array_equal(hyper["Seed"].values, [5])
 
 
 def test_load(tmp_path):

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -10,15 +10,16 @@ import pytest
 from sklearn.svm import SVC
 
 from skordinal.experiments import ExperimentResult, Results
+from skordinal.experiments._results import _format_proba_column
 
 
-def _fitted_svc(classes=(1, 2, 3)):
+def _fitted_svc(classes=(1, 2, 3), probability=False):
     """Return an SVC fitted so that ``classes_`` equals ``classes``."""
     labels = np.asarray(classes)
     rng = np.random.default_rng(0)
     features = rng.standard_normal((labels.size * 4, 4))
     targets = np.tile(labels, 4)
-    return SVC().fit(features, targets)
+    return SVC(probability=probability).fit(features, targets)
 
 
 def _make_result(
@@ -178,6 +179,50 @@ def test_save_model_false(tmp_path):
     assert (pair_dir / "predictions_by_seed" / "seed_0").exists()
 
 
+def test_save_proba_written_to_disk(tmp_path):
+    """Probability columns are persisted in both prediction files."""
+    rng = np.random.default_rng(0)
+    estimator = _fitted_svc(probability=True)
+    q = estimator.classes_.size
+
+    raw_train = rng.random((3, q))
+    raw_test = rng.random((4, q))
+    train_y_proba = raw_train / raw_train.sum(axis=1, keepdims=True)
+    y_proba = raw_test / raw_test.sum(axis=1, keepdims=True)
+    result = ExperimentResult(
+        dataset_name="toy",
+        classifier_name="conf_1",
+        resample_id=0,
+        train_predicted_y=np.array([1, 2, 3]),
+        test_predicted_y=np.array([1, 2, 3, 1]),
+        y_proba=y_proba,
+        train_metrics={"ccr_train": 0.9},
+        test_metrics={"ccr_test": 0.8},
+        best_params={"C": 1},
+        best_model=estimator,
+        train_true_y=np.array([1, 2, 3]),
+        test_true_y=np.array([1, 2, 3, 1]),
+        train_y_proba=train_y_proba,
+    )
+    Results(tmp_path).save(result, save_model=False)
+
+    seed_dir = tmp_path / "conf_1" / "toy" / "predictions_by_seed" / "seed_0"
+    for name, proba in (
+        ("train_predictions.csv", train_y_proba),
+        ("test_predictions.csv", y_proba),
+    ):
+        df = pd.read_csv(seed_dir / name)
+        assert "Prediction probabilities" in df.columns
+        assert set(df["Target"]) <= set(range(q))
+        # Check Prediction equals the argmax index of the probabilities
+        npt.assert_array_equal(df["Prediction"].values, np.argmax(proba, axis=1))
+        for cell, source in zip(df["Prediction probabilities"], proba):
+            parsed = np.fromstring(cell.strip("[]"), sep=",")
+            assert parsed.shape == (q,)
+            npt.assert_allclose(parsed, source)
+            npt.assert_allclose(parsed.sum(), 1.0, atol=1e-8)
+
+
 def test_save_requires_true_labels(tmp_path):
     """save raises ValueError when a split lacks its true labels."""
     base = dict(
@@ -229,6 +274,37 @@ def test_save_rejects_unknown_labels(tmp_path, overrides, match):
         Results(tmp_path).save(_make_result(**kwargs))
     # Check the failed save left no model behind
     assert not (tmp_path / "clf" / "toy" / "models" / "0.joblib").exists()
+
+
+def test_save_rejects_misshaped_proba(tmp_path):
+    """A probability matrix without one column per class raises."""
+    result = ExperimentResult(
+        dataset_name="toy",
+        classifier_name="clf",
+        resample_id=0,
+        train_predicted_y=np.array([1, 2, 3]),
+        test_predicted_y=None,
+        y_proba=None,
+        train_metrics={},
+        test_metrics={},
+        best_params={},
+        best_model=_fitted_svc(),
+        train_true_y=np.array([1, 2, 3]),
+        train_y_proba=np.full((3, 2), 0.5),
+    )
+    with pytest.raises(ValueError, match="probabilities have shape"):
+        Results(tmp_path).save(result, save_model=False)
+
+
+def test_format_proba_column_cells_round_trip():
+    """Wide probability cells stay single-line and parse back exactly."""
+    rng = np.random.default_rng(0)
+    raw = rng.random((3, 20))
+    proba = raw / raw.sum(axis=1, keepdims=True)
+
+    for cell, row in zip(_format_proba_column(proba), proba):
+        assert "\n" not in cell
+        npt.assert_array_equal(np.fromstring(cell.strip("[]"), sep=","), row)
 
 
 def test_save_no_test_partition(tmp_path):

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -6,9 +6,19 @@ import joblib
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
+import pytest
 from sklearn.svm import SVC
 
 from skordinal.experiments import ExperimentResult, Results
+
+
+def _fitted_svc(classes=(1, 2, 3)):
+    """Return an SVC fitted so that ``classes_`` equals ``classes``."""
+    labels = np.asarray(classes)
+    rng = np.random.default_rng(0)
+    features = rng.standard_normal((labels.size * 4, 4))
+    targets = np.tile(labels, 4)
+    return SVC().fit(features, targets)
 
 
 def _make_result(
@@ -19,13 +29,19 @@ def _make_result(
     train_metrics: dict,
     test_metrics: dict,
     train_predicted_y: np.ndarray,
-    test_predicted_y: np.ndarray,
+    test_predicted_y: np.ndarray | None,
     estimator=None,
     train_true_y=None,
     test_true_y=None,
+    train_index=None,
+    test_index=None,
 ) -> ExperimentResult:
     if estimator is None:
-        estimator = SVC()
+        estimator = _fitted_svc()
+    if train_true_y is None:
+        train_true_y = train_predicted_y
+    if test_true_y is None and test_predicted_y is not None:
+        test_true_y = test_predicted_y
     return ExperimentResult(
         dataset_name=dataset,
         classifier_name=configuration,
@@ -39,6 +55,8 @@ def _make_result(
         best_model=estimator,
         train_true_y=train_true_y,
         test_true_y=test_true_y,
+        train_index=train_index,
+        test_index=test_index,
     )
 
 
@@ -53,8 +71,8 @@ def _make_pair_csv(base, classifier, dataset, rows):
 
 
 def test_save(tmp_path):
-    """Two partitions produce the expected on-disk layout: report.csv, params.json, models, predictions."""
-    estimator = SVC()
+    """Two partitions produce the full per-seed on-disk layout."""
+    estimator = _fitted_svc()
     results = Results(tmp_path)
 
     result_0 = _make_result(
@@ -98,47 +116,51 @@ def test_save(tmp_path):
     assert (models_dir / "1.joblib").is_file()
     assert isinstance(joblib.load(models_dir / "0.joblib"), SVC)
 
-    pred_dir = pair_dir / "predictions"
-    train_0 = pd.read_csv(pred_dir / "train_0.csv")
-    assert list(train_0.columns) == ["y_pred"]
-    npt.assert_array_equal(train_0["y_pred"].values, result_0.train_predicted_y)
+    # Check the old flat predictions/ directory is gone in the new layout
+    assert not (pair_dir / "predictions").exists()
 
-    test_0 = pd.read_csv(pred_dir / "test_0.csv")
-    assert list(test_0.columns) == ["y_pred"]
-    npt.assert_array_equal(test_0["y_pred"].values, result_0.test_predicted_y)
+    seed_dir = pair_dir / "predictions_by_seed" / "seed_0"
+    train_0 = pd.read_csv(seed_dir / "train_predictions.csv")
+    assert list(train_0.columns) == ["Pattern ID", "Target", "Prediction"]
+
+    test_0 = pd.read_csv(seed_dir / "test_predictions.csv")
+    assert list(test_0.columns) == ["Pattern ID", "Target", "Prediction"]
 
 
-def test_save_with_true_labels(tmp_path):
-    """When true labels are provided, y_true appears first in prediction CSVs."""
-    train_true = np.array([1, 2, 3, 1, 2])
-    test_true = np.array([1, 2, 3])
+def test_save_encodes_labels_zero_based(tmp_path):
+    """Target/Prediction are searchsorted indices into 1-based classes_."""
+    estimator = _fitted_svc()
+    npt.assert_array_equal(estimator.classes_, np.array([1, 2, 3]))
+
+    test_true = np.array([1, 2, 3, 1])
+    test_pred = np.array([2, 2, 3, 1])
     result = _make_result(
         partition=0,
         dataset="toy",
         configuration="clf",
         best_params={},
-        train_metrics={"acc_train": 0.8},
-        test_metrics={"acc_test": 0.7},
-        train_predicted_y=np.array([1, 2, 2, 1, 2]),
-        test_predicted_y=np.array([1, 2, 2]),
-        train_true_y=train_true,
+        train_metrics={"acc_train": 1.0},
+        test_metrics={"acc_test": 1.0},
+        train_predicted_y=np.array([2, 2, 3]),
+        test_predicted_y=test_pred,
+        estimator=estimator,
+        train_true_y=np.array([1, 2, 3]),
         test_true_y=test_true,
     )
     Results(tmp_path).save(result, save_model=False)
 
-    pred_dir = tmp_path / "clf" / "toy" / "predictions"
+    seed_dir = tmp_path / "clf" / "toy" / "predictions_by_seed" / "seed_0"
+    train_df = pd.read_csv(seed_dir / "train_predictions.csv")
+    npt.assert_array_equal(train_df["Target"].values, np.array([0, 1, 2]))
+    npt.assert_array_equal(train_df["Prediction"].values, np.array([1, 1, 2]))
 
-    train_df = pd.read_csv(pred_dir / "train_0.csv")
-    assert list(train_df.columns) == ["y_true", "y_pred"]
-    npt.assert_array_equal(train_df["y_true"].values, train_true)
-
-    test_df = pd.read_csv(pred_dir / "test_0.csv")
-    assert list(test_df.columns) == ["y_true", "y_pred"]
-    npt.assert_array_equal(test_df["y_true"].values, test_true)
+    test_df = pd.read_csv(seed_dir / "test_predictions.csv")
+    npt.assert_array_equal(test_df["Target"].values, np.array([0, 1, 2, 0]))
+    npt.assert_array_equal(test_df["Prediction"].values, np.array([1, 1, 2, 0]))
 
 
 def test_save_model_false(tmp_path):
-    """save_model=False must not create a models/ folder."""
+    """save_model=False writes the seed dir but no models/ folder."""
     result = _make_result(
         partition=0,
         dataset="toy",
@@ -153,53 +175,113 @@ def test_save_model_false(tmp_path):
 
     pair_dir = tmp_path / "conf_1" / "toy"
     assert not (pair_dir / "models").exists()
-    assert (pair_dir / "predictions").exists()
+    assert (pair_dir / "predictions_by_seed" / "seed_0").exists()
 
 
-def test_save_proba_not_written_to_disk(tmp_path):
-    """y_proba is stored in ExperimentResult but not written to disk."""
-    y_proba = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3]])
-    result = ExperimentResult(
-        dataset_name="toy",
-        classifier_name="conf_1",
-        resample_id=0,
-        train_predicted_y=np.array([1, 2]),
-        test_predicted_y=np.array([1, 2]),
-        y_proba=y_proba,
-        train_metrics={"ccr_train": 0.9},
-        test_metrics={"ccr_test": 0.8},
-        best_params={"C": 1},
-        best_model=SVC(),
-    )
-    Results(tmp_path).save(result, save_model=False)
-
-    pred_dir = tmp_path / "conf_1" / "toy" / "predictions"
-    assert list(pred_dir.glob("proba*")) == []
-
-
-def test_save_no_test_partition(tmp_path):
-    """When test_predicted_y is None, no test CSV is written."""
-    result = ExperimentResult(
+def test_save_requires_true_labels(tmp_path):
+    """save raises ValueError when a split lacks its true labels."""
+    base = dict(
         dataset_name="toy",
         classifier_name="clf",
         resample_id=0,
         train_predicted_y=np.array([1, 2, 3]),
-        test_predicted_y=None,
+        test_predicted_y=np.array([1, 2]),
         y_proba=None,
-        train_metrics={"ccr_train": 0.9},
+        train_metrics={},
         test_metrics={},
         best_params={},
-        best_model=SVC(),
+        best_model=_fitted_svc(),
+    )
+
+    no_train = ExperimentResult(**base, test_true_y=np.array([1, 2]))
+    with pytest.raises(ValueError, match="train_true_y"):
+        Results(tmp_path).save(no_train, save_model=False)
+
+    no_test = ExperimentResult(**base, train_true_y=np.array([1, 2, 3]))
+    with pytest.raises(ValueError, match="test_true_y"):
+        Results(tmp_path).save(no_test, save_model=False)
+
+
+@pytest.mark.parametrize(
+    "overrides, match",
+    [
+        ({"train_true_y": np.array([1, 2, 4])}, "'train' true labels"),
+        ({"test_true_y": np.array([1, 2, 4])}, "'test' true labels"),
+        ({"test_predicted_y": np.array([1, 2, 4])}, "'test' predicted labels"),
+    ],
+)
+def test_save_rejects_unknown_labels(tmp_path, overrides, match):
+    """A label absent from classes_ raises instead of mis-encoding."""
+    kwargs = dict(
+        partition=0,
+        dataset="toy",
+        configuration="clf",
+        best_params={},
+        train_metrics={"acc_train": 1.0},
+        test_metrics={"acc_test": 1.0},
+        train_predicted_y=np.array([1, 2, 3]),
+        test_predicted_y=np.array([1, 2, 3]),
+        train_true_y=np.array([1, 2, 3]),
+        test_true_y=np.array([1, 2, 3]),
+    )
+    kwargs.update(overrides)
+    with pytest.raises(ValueError, match=match):
+        Results(tmp_path).save(_make_result(**kwargs))
+    # Check the failed save left no model behind
+    assert not (tmp_path / "clf" / "toy" / "models" / "0.joblib").exists()
+
+
+def test_save_no_test_partition(tmp_path):
+    """When test_predicted_y is None, no test files are written."""
+    result = _make_result(
+        partition=0,
+        dataset="toy",
+        configuration="clf",
+        best_params={},
+        train_metrics={"ccr_train": 0.9},
+        test_metrics={},
+        train_predicted_y=np.array([1, 2, 3]),
+        test_predicted_y=None,
     )
     Results(tmp_path).save(result, save_model=False)
 
-    pred_dir = tmp_path / "clf" / "toy" / "predictions"
-    assert (pred_dir / "train_0.csv").is_file()
-    assert not (pred_dir / "test_0.csv").exists()
+    seed_dir = tmp_path / "clf" / "toy" / "predictions_by_seed" / "seed_0"
+    assert (seed_dir / "train_predictions.csv").is_file()
+    assert not (seed_dir / "test_predictions.csv").exists()
+
+
+@pytest.mark.parametrize("with_indices", [False, True])
+def test_save_pattern_id_fallback(tmp_path, with_indices):
+    """Pattern ID echoes the given indices and falls back to range(n)."""
+    train_index = np.array([10, 11, 12, 13]) if with_indices else None
+    test_index = np.array([40, 41]) if with_indices else None
+    Results(tmp_path).save(
+        _make_result(
+            partition=0,
+            dataset="toy",
+            configuration="clf",
+            best_params={},
+            train_metrics={"acc_train": 1.0},
+            test_metrics={"acc_test": 1.0},
+            train_predicted_y=np.array([1, 2, 3, 1]),
+            test_predicted_y=np.array([1, 2]),
+            train_index=train_index,
+            test_index=test_index,
+        ),
+        save_model=False,
+    )
+
+    seed_dir = tmp_path / "clf" / "toy" / "predictions_by_seed" / "seed_0"
+    train_df = pd.read_csv(seed_dir / "train_predictions.csv")
+    test_df = pd.read_csv(seed_dir / "test_predictions.csv")
+    expected_train = train_index if with_indices else np.arange(4)
+    expected_test = test_index if with_indices else np.arange(2)
+    npt.assert_array_equal(train_df["Pattern ID"].values, expected_train)
+    npt.assert_array_equal(test_df["Pattern ID"].values, expected_test)
 
 
 def test_save_multiple_partitions_and_params_upsert(tmp_path):
-    """Saving multiple partitions accumulates rows in report.csv; saving the same id twice overwrites its params entry."""
+    """Repeated saves accumulate report rows and upsert params.json."""
     r = Results(tmp_path)
     for i in range(3):
         r.save(

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -7,10 +7,11 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
+from sklearn.metrics import confusion_matrix
 from sklearn.svm import SVC
 
 from skordinal.experiments import ExperimentResult, Results
-from skordinal.experiments._results import _format_proba_column
+from skordinal.experiments._results import _format_proba_column, _write_split_files
 
 
 def _fitted_svc(classes=(1, 2, 3), probability=False):
@@ -323,7 +324,72 @@ def test_save_no_test_partition(tmp_path):
 
     seed_dir = tmp_path / "clf" / "toy" / "predictions_by_seed" / "seed_0"
     assert (seed_dir / "train_predictions.csv").is_file()
+    assert (seed_dir / "train_confusion_matrix.txt").is_file()
     assert not (seed_dir / "test_predictions.csv").exists()
+    assert not (seed_dir / "test_confusion_matrix.txt").exists()
+
+
+def test_save_writes_confusion_matrices(tmp_path):
+    """Each seed dir gets train and test confusion-matrix text files."""
+    estimator = _fitted_svc()
+    test_true = np.array([1, 1, 2, 2, 3, 3])
+    test_pred = np.array([1, 2, 2, 3, 3, 3])
+    result = _make_result(
+        partition=0,
+        dataset="toy",
+        configuration="clf",
+        best_params={},
+        train_metrics={"acc_train": 1.0},
+        test_metrics={"acc_test": 1.0},
+        train_predicted_y=np.array([1, 2, 3]),
+        test_predicted_y=test_pred,
+        estimator=estimator,
+        train_true_y=np.array([1, 2, 3]),
+        test_true_y=test_true,
+    )
+    Results(tmp_path).save(result, save_model=False)
+
+    seed_dir = tmp_path / "clf" / "toy" / "predictions_by_seed" / "seed_0"
+    for name in ("train_confusion_matrix.txt", "test_confusion_matrix.txt"):
+        lines = (seed_dir / name).read_text().split("\n")
+        assert lines[0] == "Seed 0"
+        assert lines[1] == "=" * 21
+
+    # Check the body matches the labelled confusion matrix of the saved CSV
+    q = estimator.classes_.size
+    test_df = pd.read_csv(seed_dir / "test_predictions.csv")
+    expected = confusion_matrix(
+        test_df["Target"], test_df["Prediction"], labels=np.arange(q)
+    )
+    text = (seed_dir / "test_confusion_matrix.txt").read_text()
+    assert text.endswith("\n")
+    body = text.split("\n", 2)[2].rstrip("\n")
+    assert body == np.array2string(expected, separator=", ")
+
+
+def test_confusion_matrix_not_elided_for_many_classes(tmp_path):
+    """A large confusion matrix is written in full, without summarising."""
+    labels = np.arange(40)
+    _write_split_files(
+        tmp_path,
+        "train",
+        index=None,
+        true_y=labels,
+        predicted_y=labels,
+        proba=None,
+        classes=labels,
+        resample_id=0,
+    )
+
+    body = (
+        (tmp_path / "train_confusion_matrix.txt")
+        .read_text()
+        .split("\n", 2)[2]
+        .rstrip("\n")
+    )
+    assert "..." not in body
+    # Check the matrix keeps one physical line per row (no wrapping)
+    assert body.count("\n") == 39
 
 
 @pytest.mark.parametrize("with_indices", [False, True])


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`Results` now writes predictions under `<classifier>/<dataset>/predictions_by_seed/seed_<N>/`. Each seed folder holds `train_predictions.csv` and `test_predictions.csv` with columns `Pattern ID`, `Target`, an optional `Prediction probabilities` column present when the estimator supports `predict_proba`, and `Prediction`. A confusion-matrix text file accompanies each split. `Target` and `Prediction` are zero-based class indices. When probabilities are present, `Prediction` is their argmax index. The best hyperparameters move from `params.json` to `hyperparameter_configuration.csv`, one row per seed. The dataset loader now yields `train_index` and `test_index` to populate `Pattern ID`. `report.csv`, the summaries and the saved models are unchanged.