### PR TITLE
ENH: Add KDLOR kernel discriminant learning for ordinal regression

### DIFF
--- a/skordinal/classifiers/__init__.py
+++ b/skordinal/classifiers/__init__.py
@@ -2,6 +2,7 @@
 
 from ._cost_sensitive_wrapper import CostSensitiveWrapper
 from ._elmop import ELMOP
+from ._kdlor import KDLOR
 from ._nnop import NNOP
 from ._nnpom import NNPOM
 from ._orboost import ORBoost
@@ -13,6 +14,7 @@ from ._svorex import SVOREX
 __all__ = [
     "CostSensitiveWrapper",
     "ELMOP",
+    "KDLOR",
     "NNOP",
     "NNPOM",
     "ORBoost",

--- a/skordinal/classifiers/_kdlor.py
+++ b/skordinal/classifiers/_kdlor.py
@@ -1,0 +1,469 @@
+"""Kernel Discriminant Learning for Ordinal Regression (KDLOR)."""
+
+import warnings
+from numbers import Integral, Real
+
+import numpy as np
+import scipy.linalg
+import scipy.optimize
+from scipy.special import expit
+from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.metrics.pairwise import pairwise_kernels
+from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.utils.validation import check_is_fitted
+
+from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.extmath import cumproba_to_proba, repair_cumproba
+from skordinal.utils.validation import check_ordinal_targets
+
+# Largest KKT residual tolerated before warning on non-convergence
+_KDLOR_KKT_TOLERANCE = 1e-3
+
+
+class KDLOR(ClassifierMixin, BaseEstimator):
+    """Kernel Discriminant Learning for Ordinal Regression.
+
+    KDLOR [1]_ projects training patterns into a one-dimensional kernel
+    discriminant subspace that maximises the margin between adjacent
+    ordinal class means relative to the within-class scatter. The dual
+    of this optimisation is a small convex quadratic programme. Ordered
+    thresholds are placed at the midpoints of adjacent projected class
+    means. See [2]_ for a survey of ordinal regression methods.
+
+    Parameters
+    ----------
+    C : float, default=0.1
+        Equality-constraint right-hand side in the quadratic programme.
+        Because the dual QP is positively homogeneous, ``C`` rescales
+        the whole dual solution, including ``thresholds_``; the class
+        predictions are invariant to it, though ``predict_proba`` is
+        not. Must be strictly positive.
+
+    u : float, default=0.001
+        Ridge added to the within-class scatter matrix, as a fraction
+        of its mean diagonal. Must be strictly positive.
+
+    kernel : {'linear', 'poly', 'rbf', 'sigmoid', 'laplacian'}, default='rbf'
+        Kernel function used to map inputs into feature space. Passed
+        directly to ``sklearn.metrics.pairwise.pairwise_kernels``.
+
+    degree : int, default=3
+        Degree for the polynomial kernel. Ignored by other kernels.
+
+    gamma : {'scale', 'auto'} or float, default='scale'
+        Kernel coefficient.
+
+        - ``'scale'``: ``1 / (n_features * X.var())``. Falls back to
+          ``1.0`` when ``X.var() == 0``.
+        - ``'auto'``: ``1 / n_features``.
+        - float: used as-is. Must be strictly positive.
+
+    coef0 : float, default=0.0
+        Independent term in the polynomial and sigmoid kernels.
+
+    tol : float, default=1e-5
+        Convergence tolerance passed as ``ftol`` to the SLSQP solver.
+
+    max_iter : int, default=200
+        Maximum number of SLSQP iterations passed as ``maxiter`` to
+        the solver.
+
+    Attributes
+    ----------
+    classes_ : ndarray of shape (n_classes,)
+        Unique ordinal class labels seen during ``fit``, in ascending
+        order.
+
+    n_features_in_ : int
+        Number of features seen during ``fit``.
+
+    feature_names_in_ : ndarray of shape (n_features_in_,), dtype object
+        Feature names seen during ``fit``. Defined only when ``X`` is a
+        ``pandas.DataFrame``.
+
+    gamma_ : float
+        Resolved kernel coefficient.
+
+    X_fit_ : ndarray of shape (n_samples, n_features)
+        Training patterns retained for kernel evaluation at predict
+        time.
+
+    dual_coef_ : ndarray of shape (n_samples,)
+        Projection vector expressed in kernel space. The
+        one-dimensional latent projection of a sample is the kernel
+        matrix between that sample and ``X_fit_`` contracted with
+        ``dual_coef_``.
+
+    thresholds_ : ndarray of shape (n_classes - 1,)
+        Ordered decision boundaries; midpoints of adjacent projected
+        class means.
+
+    n_iter_ : int
+        Number of SLSQP iterations performed.
+
+    Notes
+    -----
+    Because the ridge on the within-class scatter matrix scales with
+    that matrix, and the dual QP is positively homogeneous, predictions
+    are invariant to any positive rescaling of the kernel matrix (e.g.
+    rescaling ``X`` under a linear kernel).
+
+    If the SLSQP solver does not converge, a ``ConvergenceWarning`` is
+    emitted only when the Karush-Kuhn-Tucker residual of the dual
+    solution exceeds a small fixed tolerance.
+
+    References
+    ----------
+    .. [1] B.-Y. Sun, J. Li, D. D. Wu, X.-M. Zhang, and W.-B. Li,
+       "Kernel discriminant learning for ordinal regression", IEEE
+       Transactions on Knowledge and Data Engineering, vol. 22, no. 6,
+       pp. 906-910, 2010.
+       https://doi.org/10.1109/TKDE.2009.170
+
+    .. [2] P. A. Gutiérrez, M. Pérez-Ortiz, J. Sánchez-Monedero,
+       F. Fernández-Navarro, and C. Hervás-Martínez, "Ordinal
+       regression methods: survey and experimental study", IEEE
+       Transactions on Knowledge and Data Engineering, vol. 28, no. 1,
+       2016.
+       https://doi.org/10.1109/TKDE.2015.2457911
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.classifiers import KDLOR
+    >>> rng = np.random.default_rng(0)
+    >>> y = np.repeat([1, 2, 3], 30)
+    >>> X = y[:, None] + 0.3 * rng.standard_normal((90, 4))
+    >>> clf = KDLOR(kernel="rbf").fit(X, y)
+    >>> clf.predict(X[::18])  # doctest: +SKIP
+    array([1, 1, 2, 2, 3])
+    """
+
+    _parameter_constraints: dict = {
+        "C": [Interval(Real, 0.0, None, closed="neither")],
+        "u": [Interval(Real, 0.0, None, closed="neither")],
+        "kernel": [StrOptions({"linear", "poly", "rbf", "sigmoid", "laplacian"})],
+        "degree": [Interval(Integral, 1, None, closed="left")],
+        "gamma": [
+            StrOptions({"scale", "auto"}),
+            Interval(Real, 0.0, None, closed="neither"),
+        ],
+        "coef0": [Interval(Real, None, None, closed="neither")],
+        "tol": [Interval(Real, 0.0, None, closed="neither")],
+        "max_iter": [Interval(Integral, 1, None, closed="left")],
+    }
+
+    def __init__(
+        self,
+        *,
+        C=0.1,
+        u=0.001,
+        kernel="rbf",
+        degree=3,
+        gamma="scale",
+        coef0=0.0,
+        tol=1e-5,
+        max_iter=200,
+    ):
+        self.C = C
+        self.u = u
+        self.kernel = kernel
+        self.degree = degree
+        self.gamma = gamma
+        self.coef0 = coef0
+        self.tol = tol
+        self.max_iter = max_iter
+
+    def _kernel_params(self, gamma):
+        """Build kwargs for ``sklearn.metrics.pairwise.pairwise_kernels``."""
+        if self.kernel in ("rbf", "laplacian", "sigmoid"):
+            params = {"gamma": gamma}
+            if self.kernel == "sigmoid":
+                params["coef0"] = self.coef0
+        elif self.kernel == "poly":
+            params = {"gamma": gamma, "degree": self.degree, "coef0": self.coef0}
+        else:
+            # Linear kernel needs no extra parameters
+            params = {}
+        return params
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y):
+        """Fit the KDLOR model to training data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training patterns.
+
+        y : array-like of shape (n_samples,)
+            Ordinal target labels. Must contain at least 2 unique classes.
+
+        Returns
+        -------
+        self : KDLOR
+            Fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` contains fewer than 2 unique classes, or if the
+            kernel and within-class scatter matrices overflow to
+            non-finite values (rescale ``X`` or reduce ``gamma``).
+
+        scipy.linalg.LinAlgError
+            If the within-class scatter matrix remains numerically
+            singular even after the ridge regularisation (in which case
+            increasing ``u`` is recommended).
+        """
+        X, y = validate_data(self, X, y, dtype=np.float64)
+        self.classes_, y_enc = check_ordinal_targets(y)
+
+        n_samples, n_features = X.shape
+        n_classes = len(self.classes_)
+
+        # Resolve gamma to a scalar before passing to pairwise_kernels
+        if self.gamma == "scale":
+            x_var = X.var()
+            gamma_val = 1.0 / (n_features * x_var) if x_var != 0.0 else 1.0
+        elif self.gamma == "auto":
+            gamma_val = 1.0 / n_features
+        else:
+            gamma_val = float(self.gamma)
+
+        self.gamma_ = gamma_val
+        self.X_fit_ = X
+
+        K_train = pairwise_kernels(
+            X, X, metric=self.kernel, **self._kernel_params(gamma_val)
+        )
+
+        # Indicator matmul: E[i, c] = 1 iff y_enc[i] == c
+        # M_sums[:, c] sums K_train columns of class c; M_means divides
+        # by n_c
+        class_counts = np.bincount(y_enc, minlength=n_classes).astype(np.float64)
+        E = np.zeros((n_samples, n_classes), dtype=np.float64)
+        E[np.arange(n_samples), y_enc] = 1.0
+        M_sums = K_train @ E  # (n, K)
+        M_means = M_sums / class_counts  # (n, K)
+        D = M_means[:, 1:] - M_means[:, :-1]  # (n, K-1)
+
+        # Within-class scatter: H = K K^T - sum_c (1/n_c) s_c s_c^T
+        #                          = K K^T - (M_sums / counts) @ M_sums^T
+        H = K_train @ K_train - (M_sums / class_counts) @ M_sums.T
+        # Ridge relative to H's own scale; fall back to an absolute
+        # ridge when H is exactly zero (e.g. constant training data)
+        scale = H.diagonal().mean()
+        if scale <= 0.0:
+            scale = 1.0
+        H[np.diag_indices_from(H)] += self.u * scale
+        # Symmetrise exactly; cho_factor requires it
+        H = (H + H.T) * 0.5
+
+        if not np.isfinite(H).all():
+            raise ValueError(
+                "The within-class scatter matrix contains non-finite values, "
+                "usually from kernel overflow on large inputs.  Rescale X or "
+                "reduce gamma."
+            )
+
+        try:
+            c_factor = scipy.linalg.cho_factor(H, lower=True, check_finite=False)
+        except scipy.linalg.LinAlgError as exc:
+            raise scipy.linalg.LinAlgError(
+                "Within-class scatter matrix H is not positive definite even "
+                "after ridge regularisation.  Try increasing the parameter u "
+                f"(current value: {self.u})."
+            ) from exc
+
+        HinvD = scipy.linalg.cho_solve(c_factor, D, check_finite=False)  # (n, K-1)
+        Q = D.T @ HinvD  # (K-1, K-1)
+        # Symmetrise exactly; the analytic gradient assumes symmetry
+        Q = (Q + Q.T) * 0.5
+
+        alpha, result = self._solve_qp(Q)
+        self.n_iter_ = int(result.nit)
+
+        # dual_coef_ = 0.5 * H^{-1} D @ alpha = 0.5 * HinvD @ alpha
+        self.dual_coef_ = 0.5 * (HinvD @ alpha)  # (n,)
+
+        m_proj = self.dual_coef_ @ M_means  # (K,)
+        self.thresholds_ = (m_proj[1:] + m_proj[:-1]) * 0.5  # (K-1,)
+
+        if n_classes > 2 and not np.all(np.diff(self.thresholds_) > 0):
+            warnings.warn(
+                "KDLOR: thresholds_ are not strictly increasing.  The QP "
+                "solution may be degenerate.  Consider adjusting C or u.",
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+
+        return self
+
+    def _solve_qp(self, Q):
+        """Solve the KDLOR dual QP on the unit simplex and rescale by C."""
+        # Solving on the unit simplex removes the C-dependence of the
+        # objective; dividing by max|Q| brings it to order 1 so the
+        # absolute ftol is meaningful regardless of kernel and data
+        # scale
+        k_minus_1 = Q.shape[0]
+        q_scale = np.abs(Q).max()
+        Q_hat = Q / q_scale if q_scale > 0.0 else Q
+        beta0 = np.full(k_minus_1, 1.0 / k_minus_1, dtype=np.float64)
+        constraints = {
+            "type": "eq",
+            "fun": lambda b: b.sum() - 1.0,
+            "jac": lambda b: np.ones(k_minus_1, dtype=np.float64),
+        }
+        bounds = [(0.0, None)] * k_minus_1
+        result = scipy.optimize.minimize(
+            lambda b, Q: float(0.5 * b @ Q @ b),
+            beta0,
+            args=(Q_hat,),
+            jac=lambda b, Q: Q @ b,
+            method="SLSQP",
+            bounds=bounds,
+            constraints=constraints,
+            options={"ftol": self.tol, "maxiter": self.max_iter},
+        )
+        beta = result.x
+
+        if not result.success:
+            # Complementary slackness: at the optimum Q_hat @ beta is
+            # constant only on the active support (beta > 0); entries
+            # where beta == 0 may sit above that constant, so excluding
+            # them from the residual avoids penalising a boundary
+            # optimum
+            g = Q_hat @ beta
+            support = beta > 1e-9
+            mu = g[support].mean()
+            residual = np.abs(g[support] - mu).max()
+            if not support.all():
+                residual = max(residual, max(0.0, (mu - g[~support]).max()))
+            if residual > _KDLOR_KKT_TOLERANCE:
+                warnings.warn(
+                    f"KDLOR SLSQP did not converge: {result.message}. "
+                    f"KKT residual = {residual:.3e}.",
+                    category=ConvergenceWarning,
+                    stacklevel=3,
+                )
+
+        return beta * self.C, result
+
+    def _project(self, X):
+        """Compute the raw latent projection for pre-validated X."""
+        K_test = pairwise_kernels(
+            X,
+            self.X_fit_,
+            metric=self.kernel,
+            **self._kernel_params(self.gamma_),
+        )  # (m, n)
+        return K_test @ self.dual_coef_  # (m,)
+
+    def predict(self, X):
+        """Predict ordinal class labels via the threshold-counting rule.
+
+        For each sample the predicted class is ``classes_[c]``, where
+        ``c`` is the number of thresholds that the kernel projection
+        ``f(x)`` strictly exceeds. Classes need not be contiguous, so
+        ``c`` is an index into ``classes_``, not a class value. A
+        projection exactly equal to a threshold is not counted (strict
+        ``>``): ties go to the lower class. The result is not in
+        general equal to ``classes_[argmax(predict_proba(X), axis=1)]``
+        — see the Notes on ``predict_proba`` for why.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted class labels drawn from ``self.classes_``.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        projection = self._project(X)  # (m,)
+        wx = projection[:, np.newaxis] - self.thresholds_[np.newaxis, :]  # (m, K-1)
+        labels_enc = (wx > 0).sum(axis=1)  # (m,) in [0, K-1]
+        return self.classes_[labels_enc]
+
+    def _cumproba(self, X):
+        """Compute raw cumulative probabilities on pre-validated X."""
+        projection = self._project(X)
+        return expit(self.thresholds_[np.newaxis, :] - projection[:, np.newaxis])
+
+    def predict_cumproba(self, X):
+        """Cumulative class probabilities for each sample.
+
+        Computes ``P(y <= k | x) = sigmoid(threshold_k - f(x))`` for each
+        ordinal threshold ``k``, where ``f(x)`` is the kernel projection
+        score.
+
+        The sigmoid is not a calibrated probability; see the Notes on
+        ``predict_proba``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input samples.
+
+        Returns
+        -------
+        cumproba : ndarray of shape (n_samples, n_classes - 1)
+            Entry ``[i, k]`` is the estimated probability that sample ``i``
+            belongs to class ``k`` or lower. Isotonic repair enforces that
+            each row is non-decreasing.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return repair_cumproba(self._cumproba(X))
+
+    def predict_proba(self, X):
+        """Class probability estimates for each sample.
+
+        Derives class probabilities from the cumulative probability estimates
+        via finite differencing.
+
+        Notes
+        -----
+        Because KDLOR is a geometric (not probabilistic) model, the sigmoid
+        used in ``predict_cumproba`` has no calibrated temperature. The
+        derived class probabilities are therefore best treated as ordinal
+        scores rather than as calibrated probabilities. In particular,
+        ``classes_[argmax(predict_proba(X), axis=1)]`` is not in general
+        equal to ``predict``: ``predict`` follows the canonical KDLOR rule
+        of counting threshold crossings on the projection axis. Users who
+        need calibrated probabilities should wrap KDLOR with
+        ``sklearn.calibration.CalibratedClassifierCV``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input samples.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Row-stochastic matrix of class probability estimates.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return cumproba_to_proba(self._cumproba(X), repair=True)

--- a/skordinal/classifiers/tests/test_kdlor.py
+++ b/skordinal/classifiers/tests/test_kdlor.py
@@ -1,0 +1,364 @@
+"""Tests for the KDLOR classifier."""
+
+import inspect
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.linalg
+import scipy.optimize
+from sklearn.exceptions import ConvergenceWarning, NotFittedError
+
+from skordinal.classifiers import KDLOR
+
+
+@pytest.fixture
+def X():
+    """Create sample feature patterns for testing."""
+    return np.array(
+        [
+            [0.0, 0.0],
+            [0.1, 0.1],
+            [-0.1, 0.2],
+            [2.0, 2.0],
+            [2.1, 1.9],
+            [1.9, 2.1],
+            [4.0, 4.0],
+            [4.1, 3.9],
+            [3.9, 4.1],
+        ]
+    )
+
+
+@pytest.fixture
+def y():
+    """Create sample target variables for testing."""
+    return np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("C", 0),
+        ("C", -1),
+        ("u", 0),
+        ("u", -1e-5),
+        ("degree", 0),
+        ("tol", 0),
+        ("gamma", 0),
+        ("gamma", -0.1),
+        ("max_iter", 0),
+    ],
+)
+def test_kdlor_hyperparameter_value_validation(X, y, param_name, invalid_value):
+    """Test that KDLOR raises ValueError for invalid hyperparameter values."""
+    classifier = KDLOR(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("C", "high"),
+        ("u", "tight"),
+        ("kernel", 42),
+        ("gamma", "fast"),
+        ("degree", 1.5),
+        ("coef0", "x"),
+        ("tol", "eps"),
+    ],
+)
+def test_kdlor_hyperparameter_type_validation(X, y, param_name, invalid_value):
+    """Test that KDLOR raises ValueError for invalid hyperparameter types."""
+    classifier = KDLOR(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+def test_kdlor_fit_returns_self(X, y):
+    """fit should return self for sklearn compatibility."""
+    classifier = KDLOR()
+    model = classifier.fit(X, y)
+    assert model is classifier
+
+
+def test_kdlor_fit_input_validation(X, y):
+    """Test that input data is validated."""
+    X_invalid = X[:-1, :-1]
+    y_invalid = y[:-1]
+
+    classifier = KDLOR()
+    with pytest.raises(ValueError):
+        classifier.fit(X, y_invalid)
+
+    with pytest.raises(ValueError):
+        classifier.fit([], y)
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, [])
+
+    with pytest.raises(ValueError):
+        classifier.fit(X_invalid, y)
+
+
+def test_kdlor_sets_fitted_attributes_after_fit(X, y):
+    """Test that KDLOR exposes fitted attributes aligned with sklearn style."""
+    clf = KDLOR().fit(X, y)
+
+    for attr in [
+        "classes_",
+        "n_features_in_",
+        "gamma_",
+        "X_fit_",
+        "dual_coef_",
+        "thresholds_",
+        "n_iter_",
+    ]:
+        assert hasattr(clf, attr), f"Missing fitted attribute: {attr}"
+
+    assert isinstance(clf.classes_, np.ndarray) and np.array_equal(
+        clf.classes_, np.unique(y)
+    )
+    assert isinstance(clf.n_features_in_, int) and clf.n_features_in_ == X.shape[1]
+    assert isinstance(clf.gamma_, float) and clf.gamma_ > 0.0
+    assert clf.X_fit_.shape == X.shape
+    assert clf.dual_coef_.shape == (X.shape[0],)
+    assert clf.thresholds_.shape == (len(np.unique(y)) - 1,)
+    assert isinstance(clf.n_iter_, int) and clf.n_iter_ >= 1
+
+
+def test_kdlor_predict_invalid_input_raises_error(X, y):
+    """Test that invalid input raises an error."""
+    classifier = KDLOR()
+    classifier.fit(X, y)
+
+    with pytest.raises(ValueError):
+        classifier.predict([])
+
+
+def test_kdlor_predict_raises_if_not_fitted(X):
+    """Test that predict raises NotFittedError if called before fit."""
+    classifier = KDLOR()
+    with pytest.raises(NotFittedError):
+        classifier.predict(X)
+
+
+def test_kdlor_feature_names_in_when_dataframe(X, y):
+    """Test that feature_names_in_ is set when X is a DataFrame."""
+    df = pd.DataFrame(X, columns=["f0", "f1"])
+    classifier = KDLOR().fit(df, y)
+
+    assert hasattr(classifier, "feature_names_in_")
+    np.testing.assert_array_equal(
+        classifier.feature_names_in_, np.array(["f0", "f1"], dtype=object)
+    )
+
+
+def test_kdlor_parameter_constraints_match_init_params():
+    """Test that _parameter_constraints keys match __init__ parameters."""
+    init_params = set(inspect.signature(KDLOR.__init__).parameters) - {"self"}
+    assert set(KDLOR._parameter_constraints) == init_params
+
+
+def test_kdlor_predict_rejects_wrong_n_features(X, y):
+    """Test that predict rejects input with mismatched n_features."""
+    classifier = KDLOR().fit(X, y)
+    with pytest.raises(ValueError):
+        classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_kdlor_label_roundtrip(labels):
+    """Test that KDLOR preserves ordinal labels through fit and predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = KDLOR(kernel="linear")
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_kdlor_deterministic_two_fits(X, y):
+    """Two fits on the same data give identical dual_coef_ and thresholds_."""
+    clf_a = KDLOR().fit(X, y)
+    clf_b = KDLOR().fit(X, y)
+
+    np.testing.assert_array_equal(clf_a.dual_coef_, clf_b.dual_coef_)
+    np.testing.assert_array_equal(clf_a.thresholds_, clf_b.thresholds_)
+
+
+def test_kdlor_predictions_invariant_to_c(X, y):
+    """Predictions do not depend on C; dual_coef_ scales linearly with it."""
+    ref = KDLOR(C=0.1).fit(X, y)
+
+    for c_val in (1.0, 1000.0):
+        clf = KDLOR(C=c_val).fit(X, y)
+        np.testing.assert_array_equal(clf.predict(X), ref.predict(X))
+        ratio = clf.dual_coef_ / ref.dual_coef_
+        np.testing.assert_allclose(ratio, c_val / 0.1, rtol=1e-6)
+
+
+@pytest.mark.parametrize("kernel", ["linear", "poly", "rbf", "sigmoid", "laplacian"])
+def test_kdlor_thresholds_non_decreasing_across_kernels(X, y, kernel):
+    """thresholds_ are non-decreasing and predict stays within classes_."""
+    classifier = KDLOR(kernel=kernel).fit(X, y)
+
+    assert np.all(np.diff(classifier.thresholds_) >= 0)
+    assert set(classifier.predict(X)).issubset(set(classifier.classes_))
+
+
+@pytest.mark.parametrize(
+    "gamma, expected_gamma",
+    [
+        ("auto", lambda X: 1.0 / X.shape[1]),
+        ("scale", lambda X: 1.0 / (X.shape[1] * X.var())),
+        (0.5, lambda X: 0.5),
+    ],
+    ids=["auto", "scale", "numeric"],
+)
+def test_kdlor_gamma_resolves_to_expected_value(X, y, gamma, expected_gamma):
+    """gamma_ resolves correctly for 'auto', 'scale', and a numeric value."""
+    classifier = KDLOR(gamma=gamma).fit(X, y)
+    np.testing.assert_allclose(classifier.gamma_, expected_gamma(X))
+
+
+def test_kdlor_predict_proba_rows_sum_to_one(X, y):
+    """predict_proba rows are non-negative and sum to one."""
+    classifier = KDLOR().fit(X, y)
+    proba = classifier.predict_proba(X)
+
+    n_classes = len(np.unique(y))
+    assert proba.shape == (X.shape[0], n_classes)
+    assert np.all(proba >= 0.0)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
+
+
+def test_kdlor_predict_cumproba_shape_and_bounds(X, y):
+    """predict_cumproba has shape (n, n_classes - 1), rows non-decreasing."""
+    classifier = KDLOR().fit(X, y)
+    cumproba = classifier.predict_cumproba(X)
+
+    n_classes = len(np.unique(y))
+    assert cumproba.shape == (X.shape[0], n_classes - 1)
+    assert np.all(cumproba >= 0.0) and np.all(cumproba <= 1.0)
+    assert np.all(np.diff(cumproba, axis=1) >= 0)
+
+
+def test_kdlor_singular_scatter_raises_linalg_error():
+    """A near-singular scatter matrix raises at tiny u, fits at default u."""
+    rng = np.random.default_rng(0)
+    X_base = rng.standard_normal((3, 2))
+    # Duplicate each base pattern, then interleave labels so the resulting
+    # kernel matrix collapses to rank 3, making the scatter matrix singular
+    X = np.repeat(X_base, 10, axis=0)
+    y = np.tile(np.array([0, 1, 2]), 10)
+
+    with pytest.raises(scipy.linalg.LinAlgError, match="increasing the parameter u"):
+        KDLOR(u=1e-300).fit(X, y)
+
+    clf = KDLOR().fit(X, y)
+    assert np.all(np.isfinite(clf.dual_coef_))
+
+
+def test_kdlor_convergence_warning_only_at_insufficient_max_iter(X, y):
+    """ConvergenceWarning fires at max_iter=1 on hard data, not by default."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ConvergenceWarning)
+        KDLOR().fit(X, y)
+
+    rng = np.random.default_rng(0)
+    X_hard = rng.standard_normal((100, 4))
+    y_hard = np.tile(np.arange(4), 25)
+
+    with pytest.warns(ConvergenceWarning, match="did not converge"):
+        clf = KDLOR(max_iter=1).fit(X_hard, y_hard)
+    assert clf.n_iter_ <= clf.max_iter
+
+
+def test_kdlor_no_convergence_warning_when_solution_is_kkt_optimal(X, y, monkeypatch):
+    """No ConvergenceWarning when SLSQP reports failure at a KKT-optimal point."""
+    real_minimize = scipy.optimize.minimize
+
+    def force_failure(*args, **kwargs):
+        """Return the real SLSQP solution but flag it as unsuccessful."""
+        result = real_minimize(*args, **kwargs)
+        result.success = False
+        return result
+
+    monkeypatch.setattr(scipy.optimize, "minimize", force_failure)
+    # kernel="linear" on this fixture gives a boundary QP optimum (a zero
+    # dual entry), also exercising the off-support residual term
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ConvergenceWarning)
+        KDLOR(kernel="linear").fit(X, y)
+
+
+def test_kdlor_kernel_scale_invariance_linear_kernel(X, y):
+    """Rescaling X leaves predictions and thresholds_ unchanged (linear kernel)."""
+    clf = KDLOR(kernel="linear").fit(X, y)
+    clf_scaled = KDLOR(kernel="linear").fit(X * 10.0, y)
+
+    np.testing.assert_array_equal(clf.predict(X), clf_scaled.predict(X * 10.0))
+    # Locks in the relative (not absolute) ridge: an absolute ridge would
+    # shift thresholds_ under rescaling even though predict stays correct
+    np.testing.assert_allclose(clf.thresholds_, clf_scaled.thresholds_, rtol=1e-6)
+
+
+def test_kdlor_constant_x_gamma_scale_fallback():
+    """Constant X triggers the gamma='scale' fallback and predicts class 0."""
+    X = np.full((12, 3), 5.0)
+    y = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3])
+
+    with warnings.catch_warnings():
+        # Constant X collapses the thresholds to a single value, the
+        # expected degenerate case that raises the ordering RuntimeWarning
+        warnings.simplefilter("ignore", RuntimeWarning)
+        clf = KDLOR(kernel="rbf", gamma="scale").fit(X, y)
+
+    np.testing.assert_allclose(clf.gamma_, 1.0)
+    preds = clf.predict(X)
+    np.testing.assert_array_equal(preds, np.zeros(len(y), dtype=preds.dtype))
+
+
+def test_kdlor_poly_kernel_overflow_raises_value_error():
+    """A poly-kernel overflow raises ValueError instead of silent NaN."""
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((9, 3)) * 1e10
+    y = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+
+    with warnings.catch_warnings():
+        # Suppress the expected matmul overflow warning; the ValueError
+        # raised from the non-finite scatter matrix is what is under test
+        warnings.simplefilter("ignore", RuntimeWarning)
+        with pytest.raises(ValueError, match="non-finite"):
+            KDLOR(kernel="poly", gamma=1e10, degree=5).fit(X, y)
+
+
+def test_kdlor_large_magnitude_x_finite_probabilities():
+    """Large-magnitude inputs still yield finite, normalised probabilities."""
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((60, 4)) * 1000.0
+    y = np.tile(np.arange(3), 20)
+
+    classifier = KDLOR().fit(X, y)
+    proba = classifier.predict_proba(X)
+
+    assert np.isfinite(proba).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-12)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds the KDLOR classifier, a kernel discriminant for ordinal targets. It projects patterns onto a one-dimensional axis and assigns labels with ordered thresholds, learning the projection direction by solving a convex quadratic programme. It supports the linear, polynomial, RBF, sigmoid and laplacian kernels and exposes `fit`, `predict`, `predict_proba` and `predict_cumproba`. Predictions are invariant to `C`.