### PR TITLE
ENH: Add POM proportional odds model

### DIFF
--- a/skordinal/classifiers/__init__.py
+++ b/skordinal/classifiers/__init__.py
@@ -7,6 +7,7 @@ from ._nnop import NNOP
 from ._nnpom import NNPOM
 from ._orboost import ORBoost
 from ._ordinal_decomposition import OrdinalDecomposition
+from ._pom import POM
 from ._redsvm import REDSVM
 from ._regressor_wrapper import RegressorWrapper
 from ._svorex import SVOREX
@@ -19,6 +20,7 @@ __all__ = [
     "NNPOM",
     "ORBoost",
     "OrdinalDecomposition",
+    "POM",
     "REDSVM",
     "RegressorWrapper",
     "SVOREX",

--- a/skordinal/classifiers/_pom.py
+++ b/skordinal/classifiers/_pom.py
@@ -1,0 +1,473 @@
+"""Proportional Odds Model (POM) for ordinal classification."""
+
+import math
+import warnings
+from numbers import Integral, Real
+
+import numpy as np
+import scipy.optimize
+import scipy.special
+from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.utils.class_weight import compute_sample_weight
+from sklearn.utils.validation import check_is_fitted
+
+from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.extmath import (
+    cumproba_to_proba,
+    params_to_thresholds,
+    repair_cumproba,
+    thresholds_grad,
+    thresholds_to_params,
+)
+from skordinal.utils.validation import check_ordinal_targets
+
+# Saturation bounds for the complementary-log-log link: exp(-exp(30))
+# underflows to 0 on float64, and exp(-exp(-500)) is indistinguishable from
+# 1.  The bounds also guard the density exp(z - exp(z)) against
+# inner-exp(z) overflow, not only the CDF.  Reused (negated) for loglog
+# via the z -> -z tail symmetry between the two links
+_CLOGLOG_Z_MIN = -500.0
+_CLOGLOG_Z_MAX = 30.0
+
+# Per-class probability floor used in the objective
+_PROBA_FLOOR = 1e-12
+
+
+class POM(ClassifierMixin, BaseEstimator):
+    """Proportional Odds Model for ordinal classification.
+
+    POM [1]_ postulates a shared linear projection ``f(x) = w^T x`` and
+    ``K-1`` ordered thresholds ``b_1 <= ... <= b_{K-1}`` fitted jointly by
+    maximum likelihood. The cumulative class probability is modelled as
+    ``P(Y <= k | x) = G(b_k - w^T x)`` where ``G`` is the inverse-link
+    function selected by the ``link`` parameter. See [2]_ for a survey of
+    ordinal regression methods.
+
+    Parameters
+    ----------
+    link : str, default="logit"
+        Inverse-link function ``G``. One of ``{"logit", "probit",
+        "cloglog", "loglog", "cauchit"}``.
+
+        - ``"logit"``: standard logistic CDF, equivalent to the standard
+          proportional-odds model.
+        - ``"probit"``: standard normal CDF.
+        - ``"cloglog"``: complementary log-log CDF
+          ``G(z) = 1 - exp(-exp(z))``.
+        - ``"loglog"``: log-log (Gumbel) CDF ``G(z) = exp(-exp(-z))``.
+        - ``"cauchit"``: Cauchy CDF ``G(z) = 0.5 + arctan(z) / pi``.
+
+    alpha : float, default=0.0
+        L2 regularisation strength applied to ``w`` only; thresholds are
+        unpenalised. Must be >= 0. When ``alpha=0`` the model maximises
+        the pure log-likelihood.
+
+    solver : {"lbfgs", "newton-cg", "bfgs"}, default="lbfgs"
+        Optimisation algorithm forwarded to
+        ``scipy.optimize.minimize``. All solvers consume the analytic
+        objective gradient.
+
+        - ``"lbfgs"``: limited-memory BFGS (``"L-BFGS-B"``). The
+          default; low memory cost, suitable for many features.
+        - ``"newton-cg"``: Newton conjugate gradient. Uses curvature
+          information; converges in fewer iterations on
+          well-conditioned problems.
+        - ``"bfgs"``: full BFGS. Maintains a dense Hessian
+          approximation; best when the number of features is small.
+
+    max_iter : int, default=1000
+        Maximum number of solver iterations.
+
+    tol : float, default=1e-5
+        Convergence tolerance forwarded to the solver (``ftol`` and ``gtol``
+        for ``"lbfgs"``, ``gtol`` for ``"bfgs"``, ``xtol`` for
+        ``"newton-cg"``). Must be strictly positive.
+
+    class_weight : dict, "balanced", or None, default=None
+        Per-class weights applied to each sample's loss contribution.
+        Supply a dict ``{class_label: weight}`` to set weights manually,
+        or ``"balanced"`` to let the estimator compute weights
+        proportional to ``n_samples / (n_classes * np.bincount(y))``.
+        ``None`` assigns weight 1 to every sample.  The L2 penalty on
+        ``w`` is not affected.
+
+    Attributes
+    ----------
+    classes_ : ndarray of shape (n_classes,)
+        Unique ordinal class labels seen during ``fit``, in ascending
+        order.
+
+    n_features_in_ : int
+        Number of features seen during ``fit``.
+
+    feature_names_in_ : ndarray of shape (n_features_in_,), dtype object
+        Feature names seen during ``fit``.  Defined only when ``X`` is a
+        ``pandas.DataFrame``.
+
+    coef_ : ndarray of shape (n_features_in_,)
+        Linear projection weights ``w``. No bias term — the per-class
+        biases are absorbed into ``thresholds_``.
+
+    thresholds_ : ndarray of shape (n_classes - 1,)
+        Fitted ordered thresholds ``b_1 <= ... <= b_{K-1}``.
+
+    n_iter_ : int
+        Number of solver iterations executed during ``fit``.
+
+    loss_ : float
+        Final objective value (negative log-likelihood plus L2 penalty)
+        at termination; set even when the solver does not converge.
+
+    Notes
+    -----
+    The chosen ``solver`` optimises the packed parameter vector ``[w; t]``
+    where ``w`` is the linear projection and ``t`` is the unconstrained
+    reparametrisation of the thresholds (``b[0] = t[0]``,
+    ``b[k] = t[0] + t[1]^2 + ... + t[k]^2`` for ``k >= 1``), which
+    guarantees they remain non-decreasing throughout optimisation.
+
+    The objective is the weighted negative log-likelihood plus an L2
+    penalty on ``w``:
+
+    .. math::
+
+        J(w, t) = -\\frac{1}{n} \\sum_{i=1}^{n} \\log h_{y_i}(x_i)
+                  + \\frac{\\alpha}{2n} \\|w\\|^2
+
+    where ``h_k(x) = P(Y = k | x)`` is obtained from the cumulative-link
+    differences.  The formula is shown unweighted; ``class_weight``
+    multiplies each sample's term.
+
+    On linearly separable data with ``alpha=0`` the estimate is not
+    finite (coefficients may diverge); set ``alpha > 0`` to regularise.
+
+    Standardising features (zero mean, unit variance) is recommended:
+    extreme feature scales interact poorly with the fixed solver
+    tolerance and can silently degrade the fit.
+
+    References
+    ----------
+    .. [1] P. McCullagh, "Regression models for ordinal data",
+       Journal of the Royal Statistical Society. Series B (Methodological),
+       vol. 42, no. 2, pp. 109-142, 1980.
+
+    .. [2] P. A. Gutiérrez, M. Pérez-Ortiz, J. Sánchez-Monedero,
+       F. Fernández-Navarro, and C. Hervás-Martínez, "Ordinal regression
+       methods: survey and experimental study," IEEE Transactions on
+       Knowledge and Data Engineering, vol. 28, no. 1, 2016.
+       https://doi.org/10.1109/TKDE.2015.2457911
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.classifiers import POM
+    >>> rng = np.random.default_rng(0)
+    >>> y = np.repeat([1, 2, 3, 4], 20)
+    >>> X = y[:, None] + 0.3 * rng.standard_normal((80, 4))
+    >>> clf = POM(link="logit", alpha=0.1).fit(X, y)
+    >>> clf.predict(X[::16])  # doctest: +SKIP
+    array([1, 1, 2, 3, 4])
+    """
+
+    _parameter_constraints: dict = {
+        "link": [StrOptions({"logit", "probit", "cloglog", "loglog", "cauchit"})],
+        "alpha": [Interval(Real, 0.0, None, closed="left")],
+        "solver": [StrOptions({"lbfgs", "newton-cg", "bfgs"})],
+        "max_iter": [Interval(Integral, 1, None, closed="left")],
+        "tol": [Interval(Real, 0.0, None, closed="neither")],
+        "class_weight": [StrOptions({"balanced"}), dict, None],
+    }
+
+    def __init__(
+        self,
+        link="logit",
+        alpha=0.0,
+        solver="lbfgs",
+        max_iter=1000,
+        tol=1e-5,
+        class_weight=None,
+    ):
+        self.link = link
+        self.alpha = alpha
+        self.solver = solver
+        self.max_iter = max_iter
+        self.tol = tol
+        self.class_weight = class_weight
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y):
+        """Fit the Proportional Odds Model to training data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training patterns.
+
+        y : array-like of shape (n_samples,)
+            Ordinal target labels. Must contain at least 2 unique classes.
+
+        Returns
+        -------
+        self : POM
+            Fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` contains fewer than 2 unique classes.
+        """
+        X, y = validate_data(self, X, y, dtype=np.float64)
+        self.classes_, y_enc = check_ordinal_targets(y)
+        sample_weight = compute_sample_weight(self.class_weight, y)
+
+        n_samples, n_features = X.shape
+        n_classes = len(self.classes_)
+
+        params0 = self._init_params(n_features, n_classes)
+
+        # Select the scipy method and forward tol to the tolerance key(s)
+        # that method understands (avoiding unknown-option warnings)
+        options = {"maxiter": self.max_iter}
+        if self.solver == "lbfgs":
+            method = "L-BFGS-B"
+            options["ftol"] = self.tol
+            options["gtol"] = self.tol
+        elif self.solver == "bfgs":
+            method = "BFGS"
+            options["gtol"] = self.tol
+        else:
+            method = "Newton-CG"
+            options["xtol"] = self.tol
+
+        result = scipy.optimize.minimize(
+            fun=self._objective,
+            x0=params0,
+            args=(X, y_enc, sample_weight, n_features, n_classes),
+            method=method,
+            jac=True,
+            options=options,
+        )
+
+        if not result.success:
+            warnings.warn(
+                f"POM did not converge (stopped after {result.nit} "
+                f"iterations: {result.message}). Consider increasing "
+                "max_iter, setting alpha > 0, or standardising X.",
+                ConvergenceWarning,
+                stacklevel=2,
+            )
+
+        self.coef_ = result.x[:n_features]
+        self.thresholds_ = params_to_thresholds(result.x[n_features:])
+        self.n_iter_ = int(result.nit)
+        self.loss_ = float(result.fun)
+
+        return self
+
+    def predict_cumproba(self, X):
+        """Return cumulative class probabilities ``P(Y <= k | x)``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        F : ndarray of shape (n_samples, n_classes - 1)
+            ``F[:, k]`` equals ``P(Y <= k+1 | x)`` for ``k = 0, ..., K-2``.
+            Columns are non-decreasing along the class axis; isotonic repair
+            is applied to enforce strict validity.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return repair_cumproba(self._cumproba(X))
+
+    def predict_proba(self, X):
+        """Return per-class probability estimates.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Non-negative class probabilities; each row sums to 1.0.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return cumproba_to_proba(self._cumproba(X), repair=True)
+
+    def predict(self, X):
+        """Predict ordinal class labels for patterns in X.
+
+        The predicted class is ``classes_[argmax(predict_proba(X),
+        axis=1)]``, the class with the highest estimated probability.
+        Exact probability ties resolve to the lower class, i.e. the
+        first occurrence in ``classes_``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted class labels drawn from ``self.classes_``.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        proba = cumproba_to_proba(self._cumproba(X), repair=True)
+        return self.classes_[proba.argmax(axis=1)]
+
+    def _cumproba(self, X):
+        """Compute raw cumulative probabilities on pre-validated X."""
+        f = X @ self.coef_  # (n,)
+        eta = self.thresholds_[np.newaxis, :] - f[:, np.newaxis]  # (n, K-1)
+        # Predict path only needs the CDF; skip the density computation
+        return self._link_cdf_pdf(eta, need_pdf=False)[0]
+
+    def _link_cdf_pdf(self, z, need_pdf=True):
+        """Evaluate the inverse-link CDF and, optionally, its density."""
+        if self.link == "logit":
+            s = scipy.special.expit(z)
+            if not need_pdf:
+                return s, None
+            return s, s * (1.0 - s)
+        if self.link == "probit":
+            cdf = scipy.special.ndtr(z)
+            if not need_pdf:
+                return cdf, None
+            pdf = np.exp(-0.5 * z**2) / math.sqrt(2.0 * math.pi)
+            return cdf, pdf
+        if self.link == "cloglog":
+            z_clamp = np.clip(z, _CLOGLOG_Z_MIN, _CLOGLOG_Z_MAX)
+            ez = np.exp(z_clamp)
+            cdf = -np.expm1(-ez)
+            if not need_pdf:
+                return cdf, None
+            pdf = np.exp(z_clamp - ez)
+            return cdf, pdf
+        if self.link == "loglog":
+            z_clamp = np.clip(z, -_CLOGLOG_Z_MAX, -_CLOGLOG_Z_MIN)
+            enz = np.exp(-z_clamp)
+            cdf = np.exp(-enz)
+            if not need_pdf:
+                return cdf, None
+            pdf = np.exp(-z_clamp - enz)
+            return cdf, pdf
+        # cauchit
+        cdf = 0.5 + np.arctan(z) / math.pi
+        if not need_pdf:
+            return cdf, None
+        pdf = 1.0 / (math.pi * (1.0 + z**2))
+        return cdf, pdf
+
+    def _objective(
+        self,
+        params,
+        X,
+        y_enc,
+        sample_weight,
+        n_features,
+        n_classes,
+    ):
+        """Compute the NLL + L2 objective and its gradient."""
+        w = params[:n_features]
+        t = params[n_features:]
+        thresholds = params_to_thresholds(t)  # (K-1,)
+        n_samples = X.shape[0]
+
+        f = X @ w  # (n,)
+
+        # Gather-only evaluation: each sample's likelihood needs at most
+        # two link values (the cumulative bounds around its own class),
+        # so avoid building the full (n, K-1) cdf/pdf grid
+        # The upper cdf is fixed at 1 for y == K-1 and the lower at 0
+        # for y == 0; the masks keep those rows out of the link gathers
+        hi_mask = y_enc < n_classes - 1
+        lo_mask = y_enc > 0
+        idx_hi = np.minimum(y_enc, n_classes - 2)
+        idx_lo = np.maximum(y_enc - 1, 0)
+
+        cdf_hi, pdf_hi = self._link_cdf_pdf(thresholds[idx_hi] - f)
+        cdf_lo, pdf_lo = self._link_cdf_pdf(thresholds[idx_lo] - f)
+        cdf_hi = np.where(hi_mask, cdf_hi, 1.0)
+        cdf_lo = np.where(lo_mask, cdf_lo, 0.0)
+
+        # True-class probability per sample (raw, before floor)
+        h_true_raw = cdf_hi - cdf_lo
+        clamped = h_true_raw <= _PROBA_FLOOR
+        h_true = np.maximum(h_true_raw, _PROBA_FLOOR)
+
+        # Objective: weighted NLL + L2
+        J = -(sample_weight * np.log(h_true)).sum() / n_samples
+        J += self.alpha / (2.0 * n_samples) * np.dot(w, w)
+
+        # Error derivative -sample_weight/h_true where not clamped, 0
+        # elsewhere.  Where h_true <= _PROBA_FLOOR the floor is active
+        # (flat region), so the subgradient is zero — zeroing e_true
+        # keeps the analytic gradient consistent with the clamped
+        # objective
+        e_true = np.where(clamped, 0.0, -sample_weight / h_true)
+
+        g_hi = np.where(hi_mask, e_true * pdf_hi, 0.0)
+        g_lo = np.where(lo_mask, -e_true * pdf_lo, 0.0)
+
+        s = -(g_hi + g_lo)  # (n,)
+        grad_w = X.T @ s / n_samples + (self.alpha / n_samples) * w
+
+        # Gradient w.r.t. the ordered thresholds: scatter each sample's
+        # contribution back onto the (at most two) thresholds it touched
+        grad_b = (
+            np.bincount(idx_hi, weights=g_hi, minlength=n_classes - 1)
+            + np.bincount(idx_lo, weights=g_lo, minlength=n_classes - 1)
+        )[: n_classes - 1] / n_samples
+
+        # Chain rule through the cumsum-of-squares threshold reparametrisation
+        grad_t = thresholds_grad(t, grad_b)
+
+        return float(J), np.concatenate([grad_w, grad_t])
+
+    def _init_params(self, n_features, n_classes):
+        """Build the deterministic initial parameter vector."""
+        w = np.zeros(n_features)
+
+        # Equal-class-mass quantile spacing under w=0
+        quantiles = np.arange(1, n_classes) / n_classes  # (K-1,)
+
+        if self.link == "logit":
+            b_init = np.log(quantiles / (1.0 - quantiles))
+        elif self.link == "probit":
+            b_init = scipy.special.ndtri(quantiles)
+        elif self.link == "cloglog":
+            b_init = np.log(-np.log1p(-quantiles))
+        elif self.link == "loglog":
+            b_init = -np.log(-np.log(quantiles))
+        else:
+            # cauchit
+            b_init = np.tan(math.pi * (quantiles - 0.5))
+
+        t = thresholds_to_params(b_init)
+
+        return np.concatenate([w, t])

--- a/skordinal/classifiers/tests/test_pom.py
+++ b/skordinal/classifiers/tests/test_pom.py
@@ -1,0 +1,426 @@
+"""Tests for the POM classifier."""
+
+import inspect
+import re
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.optimize
+from sklearn.exceptions import ConvergenceWarning, NotFittedError
+from sklearn.utils.class_weight import compute_class_weight
+
+from skordinal.classifiers import POM
+from skordinal.datasets import make_ordinal_classification
+
+_ALL_LINKS = ["logit", "probit", "cloglog", "cauchit", "loglog"]
+
+
+@pytest.fixture
+def X():
+    """Create sample feature patterns for testing."""
+    return np.array(
+        [
+            [0.0, 0.0],
+            [0.1, 0.1],
+            [-0.1, 0.2],
+            [2.0, 2.0],
+            [2.1, 1.9],
+            [1.9, 2.1],
+            [4.0, 4.0],
+            [4.1, 3.9],
+            [3.9, 4.1],
+        ]
+    )
+
+
+@pytest.fixture
+def y():
+    """Create sample target variables for testing."""
+    return np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+
+
+@pytest.fixture
+def ordinal_data():
+    """Create a synthetic 3-class ordinal dataset for behavioural tests."""
+    return make_ordinal_classification(
+        n_samples=90,
+        n_features=4,
+        n_classes=3,
+        n_informative=4,
+        noise=0.1,
+        random_state=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("alpha", -1),
+        ("max_iter", 0),
+        ("tol", 0),
+        ("link", "bogus"),
+        ("solver", "adam"),
+        ("class_weight", "unknown"),
+    ],
+)
+def test_pom_hyperparameter_value_validation(X, y, param_name, invalid_value):
+    """Test that POM raises ValueError for invalid hyperparameter values."""
+    classifier = POM(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("link", 42),
+        ("alpha", "strong"),
+        ("solver", 3),
+        ("max_iter", 1.5),
+        ("tol", "eps"),
+        ("class_weight", 1.0),
+    ],
+)
+def test_pom_hyperparameter_type_validation(X, y, param_name, invalid_value):
+    """Test that POM raises ValueError for invalid hyperparameter types."""
+    classifier = POM(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+def test_pom_fit_returns_self(X, y):
+    """fit should return self for sklearn compatibility."""
+    classifier = POM()
+    model = classifier.fit(X, y)
+    assert model is classifier
+
+
+def test_pom_fit_input_validation(X, y):
+    """Test that input data is validated."""
+    X_invalid = X[:-1, :-1]
+    y_invalid = y[:-1]
+
+    classifier = POM()
+    with pytest.raises(ValueError):
+        classifier.fit(X, y_invalid)
+
+    with pytest.raises(ValueError):
+        classifier.fit([], y)
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, [])
+
+    with pytest.raises(ValueError):
+        classifier.fit(X_invalid, y)
+
+
+def test_pom_sets_fitted_attributes_after_fit(X, y):
+    """Test that POM exposes fitted attributes aligned with sklearn style."""
+    clf = POM().fit(X, y)
+
+    for attr in [
+        "classes_",
+        "n_features_in_",
+        "coef_",
+        "thresholds_",
+        "n_iter_",
+        "loss_",
+    ]:
+        assert hasattr(clf, attr), f"Missing fitted attribute: {attr}"
+
+    assert isinstance(clf.classes_, np.ndarray) and np.array_equal(
+        clf.classes_, np.unique(y)
+    )
+    assert isinstance(clf.n_features_in_, int) and clf.n_features_in_ == X.shape[1]
+    assert clf.coef_.shape == (X.shape[1],)
+    assert clf.thresholds_.shape == (len(np.unique(y)) - 1,)
+    assert type(clf.n_iter_) is int
+    assert type(clf.loss_) is float
+    assert np.isfinite(clf.loss_)
+    assert clf.loss_ >= 0.0
+
+
+def test_pom_predict_invalid_input_raises_error(X, y):
+    """Test that invalid input raises an error."""
+    classifier = POM()
+    classifier.fit(X, y)
+
+    with pytest.raises(ValueError):
+        classifier.predict([])
+
+
+def test_pom_predict_raises_if_not_fitted(X):
+    """Test that predict raises NotFittedError if called before fit."""
+    classifier = POM()
+    with pytest.raises(NotFittedError):
+        classifier.predict(X)
+
+
+def test_pom_feature_names_in_when_dataframe(X, y):
+    """Test that feature_names_in_ is set when X is a DataFrame."""
+    df = pd.DataFrame(X, columns=["f0", "f1"])
+    classifier = POM().fit(df, y)
+
+    assert hasattr(classifier, "feature_names_in_")
+    np.testing.assert_array_equal(
+        classifier.feature_names_in_, np.array(["f0", "f1"], dtype=object)
+    )
+
+
+def test_pom_parameter_constraints_match_init_params():
+    """Test that _parameter_constraints keys match __init__ parameters."""
+    init_params = set(inspect.signature(POM.__init__).parameters) - {"self"}
+    assert set(POM._parameter_constraints) == init_params
+
+
+def test_pom_predict_rejects_wrong_n_features(X, y):
+    """Test that predict rejects input with mismatched n_features."""
+    classifier = POM().fit(X, y)
+    with pytest.raises(ValueError):
+        classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_pom_label_roundtrip(labels):
+    """Test that POM preserves arbitrary ordinal labels through fit/predict."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = POM()
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_pom_deterministic_two_fits(X, y):
+    """Two fits on the same data give bit-identical coef_ and thresholds_."""
+    clf_a = POM().fit(X, y)
+    clf_b = POM().fit(X, y)
+
+    np.testing.assert_array_equal(clf_a.coef_, clf_b.coef_)
+    np.testing.assert_array_equal(clf_a.thresholds_, clf_b.thresholds_)
+
+
+@pytest.mark.parametrize("link", _ALL_LINKS)
+def test_pom_link_fit_predict_thresholds_ordered(ordinal_data, link):
+    """fit converges without warning; predict is accurate; thresholds valid."""
+    X, y = ordinal_data
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ConvergenceWarning)
+        clf = POM(link=link).fit(X, y)
+
+    assert set(clf.predict(X)).issubset(set(clf.classes_))
+    assert np.all(np.diff(clf.thresholds_) >= 0)
+    # the fixture is well-separated 3-class data; every link should fit it
+    # accurately, so a wrong predict path (e.g. flipped eta sign) stands out
+    assert (clf.predict(X) == y).mean() >= 0.85
+
+
+def test_pom_alpha_regularisation_reduces_coef_norm(ordinal_data):
+    """Higher alpha yields a coef_ with a smaller L2 norm than alpha=0."""
+    X, y = ordinal_data
+    clf_noreg = POM(alpha=0.0).fit(X, y)
+    clf_reg = POM(alpha=10.0).fit(X, y)
+
+    assert np.linalg.norm(clf_reg.coef_) < np.linalg.norm(clf_noreg.coef_)
+
+
+def test_pom_class_weight_balanced_differs_from_none_and_matches_dict():
+    """class_weight='balanced' differs from None and matches a dict."""
+    X, y = make_ordinal_classification(
+        n_samples=90,
+        n_features=4,
+        n_classes=3,
+        n_informative=4,
+        weights=[0.1, 0.3, 0.6],
+        random_state=1,
+    )
+
+    clf_none = POM(alpha=1.0).fit(X, y)
+    clf_bal = POM(alpha=1.0, class_weight="balanced").fit(X, y)
+    assert not (
+        np.allclose(clf_bal.coef_, clf_none.coef_)
+        and np.allclose(clf_bal.thresholds_, clf_none.thresholds_)
+    )
+
+    weights = compute_class_weight("balanced", classes=clf_bal.classes_, y=y)
+    cw_dict = dict(zip(clf_bal.classes_, weights))
+    clf_dict = POM(alpha=1.0, class_weight=cw_dict).fit(X, y)
+
+    np.testing.assert_allclose(clf_dict.coef_, clf_bal.coef_, atol=1e-8)
+    np.testing.assert_allclose(clf_dict.thresholds_, clf_bal.thresholds_, atol=1e-8)
+
+
+def test_pom_proba_and_cumproba_well_formed(ordinal_data):
+    """predict_proba/predict_cumproba are well-formed and match predict."""
+    X, y = ordinal_data
+    clf = POM().fit(X, y)
+    n_classes = len(clf.classes_)
+
+    proba = clf.predict_proba(X)
+    assert proba.shape == (X.shape[0], n_classes)
+    assert np.all(proba >= 0.0)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
+
+    cumproba = clf.predict_cumproba(X)
+    assert cumproba.shape == (X.shape[0], n_classes - 1)
+    assert np.all(cumproba >= 0.0) and np.all(cumproba <= 1.0)
+    assert np.all(np.diff(cumproba, axis=1) >= 0)
+
+    expected_pred = clf.classes_[proba.argmax(axis=1)]
+    np.testing.assert_array_equal(clf.predict(X), expected_pred)
+
+
+def test_pom_solvers_reach_same_optimum(ordinal_data):
+    """newton-cg and bfgs converge to the same fit as the lbfgs reference."""
+    X, y = ordinal_data
+    ref = POM(solver="lbfgs", tol=1e-8, max_iter=5000).fit(X, y)
+
+    for solver in ("newton-cg", "bfgs"):
+        other = POM(solver=solver, tol=1e-8, max_iter=5000).fit(X, y)
+        np.testing.assert_allclose(other.coef_, ref.coef_, atol=1e-3)
+        np.testing.assert_allclose(other.thresholds_, ref.thresholds_, atol=1e-3)
+
+
+def test_pom_convergence_warning_names_true_iteration_count(ordinal_data):
+    """POM(max_iter=1).fit warns, naming the true n_iter_ in the message."""
+    X, y = ordinal_data
+    with pytest.warns(ConvergenceWarning, match="did not converge") as record:
+        clf = POM(max_iter=1).fit(X, y)
+
+    message = str(record[0].message)
+    assert re.search(rf"stopped after {clf.n_iter_} iterations?\b", message), message
+
+
+def test_pom_convergence_warning_reports_nit_not_max_iter(ordinal_data, monkeypatch):
+    """The warning names the true result.nit, never the max_iter value."""
+    X, y = ordinal_data
+    real_minimize = scipy.optimize.minimize
+
+    def forced_failure(*args, **kwargs):
+        """Run the real optimizer, then force a failed result with nit=7."""
+        result = real_minimize(*args, **kwargs)
+        result.success = False
+        result.nit = 7
+        return result
+
+    monkeypatch.setattr(scipy.optimize, "minimize", forced_failure)
+
+    with pytest.warns(ConvergenceWarning, match="did not converge") as record:
+        clf = POM(max_iter=1000).fit(X, y)
+
+    message = str(record[0].message)
+    assert "7" in message
+    assert "1000" not in message
+    # loss_ must be set even though the solver did not converge
+    assert np.isfinite(clf.loss_)
+
+
+def test_pom_exact_proba_tie_predicts_lower_class(X, y):
+    """An exact predict_proba tie resolves to the lower class."""
+    clf = POM(link="logit").fit(X, y)
+    # Overwrite the fitted state with round numbers so a probe row lands on
+    # an exact floating-point tie, which a real fit cannot guarantee
+    clf.n_features_in_ = 1
+    clf.coef_ = np.array([1.0])
+    clf.thresholds_ = np.array([0.0])
+    clf.classes_ = np.array([0, 1])
+
+    probe = np.array([[0.0]])
+    proba = clf.predict_proba(probe)
+    np.testing.assert_allclose(proba, [[0.5, 0.5]], atol=0.0, rtol=0.0)
+    np.testing.assert_array_equal(clf.predict(probe), clf.classes_[[0]])
+
+
+def test_pom_loglog_matches_reversed_cloglog_fit(ordinal_data):
+    """POM('loglog') on y matches POM('cloglog') on reversed labels."""
+    X, y = ordinal_data
+    n_classes = len(np.unique(y))
+    y_reversed = (n_classes - 1) - y
+
+    # alpha=0.1 keeps both fits away from the flat near-separable regime; the
+    # L2 penalty is sign-symmetric so the reversal identity still holds
+    clf_loglog = POM(link="loglog", alpha=0.1, tol=1e-10, max_iter=5000).fit(X, y)
+    clf_cloglog = POM(link="cloglog", alpha=0.1, tol=1e-10, max_iter=5000).fit(
+        X, y_reversed
+    )
+
+    mapped_coef = -clf_cloglog.coef_
+    mapped_thresholds = -clf_cloglog.thresholds_[::-1]
+
+    np.testing.assert_allclose(clf_loglog.coef_, mapped_coef, atol=1e-4)
+    np.testing.assert_allclose(clf_loglog.thresholds_, mapped_thresholds, atol=1e-4)
+
+
+def _build_pom_objective_callables(link, n, p, K, seed):
+    """Return (fun, jac, params0) for check_grad on POM._objective."""
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p))
+    y_enc = rng.integers(0, K, size=n)
+
+    clf = POM(link=link, alpha=0.3)
+    w = rng.standard_normal(p) * 0.3
+    t = np.zeros(K - 1)
+    t[0] = -1.0
+    if K > 2:
+        t[1:] = 0.5
+    params = np.concatenate([w, t])
+    sample_weight = np.ones(n)
+
+    def fun(params_):
+        """Return the scalar objective value for params_."""
+        value, _ = clf._objective(params_, X, y_enc, sample_weight, p, K)
+        return value
+
+    def jac(params_):
+        """Return the gradient vector for params_."""
+        _, grad = clf._objective(params_, X, y_enc, sample_weight, p, K)
+        return grad
+
+    return fun, jac, params
+
+
+@pytest.mark.parametrize("link", _ALL_LINKS)
+@pytest.mark.parametrize("K", [2, 4])
+def test_pom_objective_gradient_matches_numerical(link, K):
+    """Analytic gradient of _objective matches finite differences."""
+    fun, jac, params = _build_pom_objective_callables(link, n=80, p=3, K=K, seed=42)
+
+    abs_err = scipy.optimize.check_grad(fun, jac, params)
+    g_num = scipy.optimize.approx_fprime(params, fun, 1e-5)
+    rel_err = abs_err / (1.0 + np.max(np.abs(g_num)))
+
+    assert rel_err < 1e-5
+
+
+def test_pom_large_magnitude_x_finite_probabilities():
+    """Large-magnitude inputs still yield finite, normalised probabilities."""
+    X, y = make_ordinal_classification(
+        n_samples=60, n_features=4, n_classes=3, n_informative=4, random_state=0
+    )
+    X = X * 1000.0
+
+    # no RuntimeWarning (e.g. log of a non-positive value) may escape fit
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        classifier = POM().fit(X, y)
+        proba = classifier.predict_proba(X)
+
+    assert np.isfinite(proba).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-12)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds the POM classifier, the proportional odds model for ordinal classification. It fits a shared linear projection and ordered thresholds jointly by maximum likelihood, and supports the logit, probit, cloglog, loglog and cauchit inverse links, an optional L2 penalty, class weights, and a choice of gradient solver. 