### PR TITLE
ENH: Add probability predictions to NNOP and NNPOM

### DIFF
--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -15,6 +15,7 @@ from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
 from skordinal.utils._sklearn_compat import validate_data
+from skordinal.utils.extmath import cumproba_to_proba, repair_cumproba
 from skordinal.utils.validation import check_ordinal_targets
 
 
@@ -267,6 +268,78 @@ class NNOP(ClassifierMixin, BaseEstimator):
         y_pred = self.classes_[a3.min(axis=1).astype(int) - 1]
 
         return y_pred
+
+    def predict_cumproba(self, X: ArrayLike) -> np.ndarray:
+        """Cumulative class probabilities for each sample.
+
+        The ``n_classes - 1`` output neurons independently estimate
+        ``P(y <= k | x)`` under the ordered-partitions coding, so the
+        raw outputs are not guaranteed to be non-decreasing across
+        ``k``.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        cumproba : ndarray of shape (n_samples, n_classes - 1)
+            Entry ``[i, k]`` is the estimated probability that sample
+            ``i`` belongs to class ``k`` or lower. Isotonic repair
+            enforces that each row is non-decreasing.
+
+        Raises
+        ------
+        NotFittedError
+            If the model is not fitted yet.
+
+        ValueError
+            If input is invalid.
+
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        return repair_cumproba(self._cumproba(X))
+
+    def predict_proba(self, X: ArrayLike) -> np.ndarray:
+        """Class probability estimates for each sample.
+
+        Derives class probabilities from the repaired cumulative
+        probability estimates via finite differencing.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Row-stochastic matrix of class probability estimates.
+
+        Raises
+        ------
+        NotFittedError
+            If the model is not fitted yet.
+
+        ValueError
+            If input is invalid.
+
+        Notes
+        -----
+        Because ``predict`` follows the canonical NNOP decision rule of
+        picking the first class whose raw cumulative estimate exceeds
+        0.5 (a median/first-crossing rule), rather than the argmax of
+        this method's output, ``classes_[argmax(predict_proba(X),
+        axis=1)]`` is not in general equal to ``predict(X)``. Users
+        needing calibrated, argmax-consistent probabilities should wrap
+        the estimator with ``sklearn.calibration.CalibratedClassifierCV``.
+
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        return cumproba_to_proba(self._cumproba(X), repair=True)
 
     def _cumproba(self, X: np.ndarray) -> np.ndarray:
         """Compute raw cumulative probabilities on pre-validated X."""

--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -8,6 +8,7 @@ from numbers import Integral, Real
 import numpy as np
 import scipy
 from numpy.typing import ArrayLike
+from scipy.special import expit
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
 from sklearn.utils import check_random_state
 from sklearn.utils._param_validation import Interval
@@ -227,6 +228,12 @@ class NNOP(ClassifierMixin, BaseEstimator):
     def predict(self, X: ArrayLike) -> np.ndarray:
         """Perform classification on samples in X.
 
+        The predicted class is the first class whose (raw, unrepaired)
+        cumulative estimate ``P(y <= k | x)`` exceeds 0.5 (the
+        median/first-crossing rule). This is not in general the same
+        class as ``classes_[argmax(predict_proba(X), axis=1)]``; see the
+        Notes on ``predict_proba``.
+
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
@@ -251,21 +258,22 @@ class NNOP(ClassifierMixin, BaseEstimator):
         n_samples = X.shape[0]
         n_classes = len(self.classes_)
 
-        a1 = np.append(np.ones((n_samples, 1)), X, axis=1)
-        z2 = np.append(np.ones((n_samples, 1)), np.matmul(a1, self.theta1_.T), axis=1)
-
-        a2 = 1.0 / (1.0 + np.exp(-z2))
-        projected = np.matmul(a2, self.theta2_.T)
-        projected = 1.0 / (1.0 + np.exp(-projected))
-
+        cumproba = self._cumproba(X)
         a3 = np.multiply(
-            np.where(np.append(projected, np.ones((n_samples, 1)), axis=1) > 0.5, 1, 0),
+            np.where(np.append(cumproba, np.ones((n_samples, 1)), axis=1) > 0.5, 1, 0),
             np.tile(np.arange(1, n_classes + 1), (n_samples, 1)),
         )
         a3[np.where(a3 == 0)] = n_classes + 1
         y_pred = self.classes_[a3.min(axis=1).astype(int) - 1]
 
         return y_pred
+
+    def _cumproba(self, X: np.ndarray) -> np.ndarray:
+        """Compute raw cumulative probabilities on pre-validated X."""
+        X_bias = np.hstack([np.ones((X.shape[0], 1)), X])
+        z2 = X_bias @ self.theta1_.T
+        a2 = np.hstack([np.ones((z2.shape[0], 1)), expit(z2)])
+        return expit(a2 @ self.theta2_.T)
 
     def _unpack_parameters(
         self,

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -14,7 +14,12 @@ from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
 from skordinal.utils._sklearn_compat import validate_data
-from skordinal.utils.extmath import params_to_thresholds, thresholds_grad
+from skordinal.utils.extmath import (
+    cumproba_to_proba,
+    params_to_thresholds,
+    repair_cumproba,
+    thresholds_grad,
+)
 from skordinal.utils.validation import check_ordinal_targets
 
 
@@ -82,7 +87,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
     theta2_ : ndarray of shape (1, n_hidden)
         Output layer weights (without bias, the biases will be the thresholds)
 
-    thresholds_ : ndarray of shape (n_classes - 1, 1)
+    thresholds_ : ndarray of shape (1, n_classes - 1)
         Class thresholds parameters
 
     References
@@ -274,6 +279,74 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         y_pred = self.classes_[a3.argmax(1)]
 
         return y_pred
+
+    def predict_cumproba(self, X: ArrayLike) -> np.ndarray:
+        """Cumulative class probabilities for each sample.
+
+        Computes ``P(y <= k | x) = sigmoid(threshold_k - f(x))`` for
+        each ordinal threshold ``k``, where ``f(x)`` is the network's
+        scalar projection. Rows are non-decreasing by construction
+        (ordered thresholds and a monotone sigmoid).
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        cumproba : ndarray of shape (n_samples, n_classes - 1)
+            Entry ``[i, k]`` is the estimated probability that sample
+            ``i`` belongs to class ``k`` or lower.
+
+        Raises
+        ------
+        NotFittedError
+            If the model is not fitted yet.
+
+        ValueError
+            If input is invalid.
+
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        return repair_cumproba(self._cumproba(X))
+
+    def predict_proba(self, X: ArrayLike) -> np.ndarray:
+        """Class probability estimates for each sample.
+
+        Derives class probabilities from the cumulative probability
+        estimates via finite differencing.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Non-negative class probabilities; each row sums to 1.0.
+
+        Raises
+        ------
+        NotFittedError
+            If the model is not fitted yet.
+
+        ValueError
+            If input is invalid.
+
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        return cumproba_to_proba(self._cumproba(X), repair=True)
+
+    def _cumproba(self, X: np.ndarray) -> np.ndarray:
+        """Compute raw cumulative probabilities on pre-validated X."""
+        a1 = np.append(np.ones((X.shape[0], 1)), X, axis=1)
+        a2 = expit(np.matmul(a1, self.theta1_.T))
+        projected = np.matmul(a2, self.theta2_.T)
+        return expit(self.thresholds_ - projected)
 
     def _unpack_parameters(
         self,

--- a/skordinal/classifiers/tests/test_nnop.py
+++ b/skordinal/classifiers/tests/test_nnop.py
@@ -8,6 +8,7 @@ import pytest
 from sklearn.exceptions import NotFittedError
 
 from skordinal.classifiers import NNOP
+from skordinal.datasets import make_ordinal_classification
 
 
 @pytest.fixture
@@ -20,6 +21,19 @@ def X():
 def y():
     """Create sample target variables for testing."""
     return np.array([0, 1, 1, 0, 1])
+
+
+@pytest.fixture
+def ordinal_data():
+    """Create a synthetic 3-class ordinal dataset for behavioural tests."""
+    return make_ordinal_classification(
+        n_samples=90,
+        n_features=4,
+        n_classes=3,
+        n_informative=4,
+        noise=0.1,
+        random_state=0,
+    )
 
 
 @pytest.mark.parametrize(
@@ -232,3 +246,45 @@ def test_nnop_predict_uses_trained_unit_bias():
     # trained forward crosses 0.5 at the first output -> class 0; the old
     # buggy forward stayed below 0.5 there and would fall through to class 1
     np.testing.assert_array_equal(clf.predict(probe), [0])
+
+
+def test_nnop_proba_and_cumproba_well_formed(ordinal_data):
+    """predict_proba/predict_cumproba are well-formed."""
+    X, y = ordinal_data
+    clf = NNOP(n_hidden=4, max_iter=50, random_state=0).fit(X, y)
+    n_classes = len(clf.classes_)
+
+    proba = clf.predict_proba(X)
+    assert proba.shape == (X.shape[0], n_classes)
+    assert np.all(proba >= 0.0)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
+
+    cumproba = clf.predict_cumproba(X)
+    assert cumproba.shape == (X.shape[0], n_classes - 1)
+    assert np.all(cumproba >= 0.0) and np.all(cumproba <= 1.0)
+    assert np.all(np.diff(cumproba, axis=1) >= 0)
+
+
+def test_nnop_predict_cumproba_repairs_non_monotone_raw_row():
+    """predict_cumproba repairs a non-monotone raw row into non-decreasing."""
+    clf = NNOP(n_hidden=1, max_iter=1).fit(
+        np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]]),
+        np.array([0, 0, 1, 1, 2, 2]),
+    )
+    # Overwrite fitted state so the two independent output sigmoids invert:
+    # column 0 evaluates higher than column 1, violating monotonicity by
+    # construction. A real fit cannot guarantee this row shape, but it
+    # isolates the repair-routing behaviour under test
+    clf.theta1_ = np.zeros((1, 2))
+    clf.theta2_ = np.array([[5.0, 0.0], [-5.0, 0.0]])
+
+    probe = np.array([[0.0]])
+    raw = clf._cumproba(probe)
+    assert raw[0, 0] > raw[0, 1]  # confirm the raw row is non-monotone
+
+    cumproba = clf.predict_cumproba(probe)
+    assert np.all(np.diff(cumproba, axis=1) >= 0)
+
+    proba = clf.predict_proba(probe)
+    assert np.all(proba >= 0.0)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)

--- a/skordinal/classifiers/tests/test_nnop.py
+++ b/skordinal/classifiers/tests/test_nnop.py
@@ -204,3 +204,31 @@ def test_nnop_random_state_accepts_random_state_instance(X, y):
     ).fit(X, y)
 
     np.testing.assert_array_equal(rs_seed.theta1_, rs_instance.theta1_)
+
+
+def test_nnop_predict_uses_trained_unit_bias():
+    """predict evaluates the trained unit hidden bias, not sigmoid(1)."""
+    clf = NNOP(n_hidden=1, max_iter=1).fit(
+        np.array([[0.0], [1.0], [2.0], [3.0]]), np.array([0, 0, 1, 1])
+    )
+    # Overwrite fitted state: zero input-to-hidden weights make the hidden
+    # activation constant (0.5), isolating the bias-column treatment -- the
+    # sole difference between the old and the trained forward -- from the
+    # real hidden-unit contribution
+    clf.theta1_ = np.zeros((1, 2))
+    clf.theta2_ = np.array([[10.0, -16.0]])
+
+    probe = np.array([[0.0]])
+    trained_cumproba = clf._cumproba(probe)
+
+    # the old (buggy) forward passed the hidden bias unit through the
+    # sigmoid, i.e. it contributed sigmoid(1.0) instead of the trained
+    # forward's 1.0
+    old_bias_activation = 1.0 / (1.0 + np.exp(-1.0))
+    old_z3 = old_bias_activation * 10.0 + 0.5 * -16.0
+    old_cumproba = 1.0 / (1.0 + np.exp(-old_z3))
+    assert old_cumproba < 0.5 < trained_cumproba[0, 0]
+
+    # trained forward crosses 0.5 at the first output -> class 0; the old
+    # buggy forward stayed below 0.5 there and would fall through to class 1
+    np.testing.assert_array_equal(clf.predict(probe), [0])

--- a/skordinal/classifiers/tests/test_nnpom.py
+++ b/skordinal/classifiers/tests/test_nnpom.py
@@ -9,6 +9,7 @@ from scipy.optimize import check_grad
 from sklearn.exceptions import NotFittedError
 
 from skordinal.classifiers import NNPOM
+from skordinal.datasets import make_ordinal_classification
 
 
 @pytest.fixture
@@ -21,6 +22,19 @@ def X():
 def y():
     """Create sample target variables for testing."""
     return np.array([0, 1, 1, 0, 1])
+
+
+@pytest.fixture
+def ordinal_data():
+    """Create a synthetic 3-class ordinal dataset for behavioural tests."""
+    return make_ordinal_classification(
+        n_samples=90,
+        n_features=4,
+        n_classes=3,
+        n_informative=4,
+        noise=0.1,
+        random_state=0,
+    )
 
 
 @pytest.mark.parametrize(
@@ -248,3 +262,23 @@ def test_nnpom_cost_function_gradient_matches_finite_difference():
 
     err = check_grad(cost, grad, x0)
     assert err < 1e-4
+
+
+def test_nnpom_proba_and_cumproba_well_formed(ordinal_data):
+    """predict_proba/predict_cumproba are well-formed and match predict."""
+    X, y = ordinal_data
+    clf = NNPOM(n_hidden=4, max_iter=50, random_state=0).fit(X, y)
+    n_classes = len(clf.classes_)
+
+    proba = clf.predict_proba(X)
+    assert proba.shape == (X.shape[0], n_classes)
+    assert np.all(proba >= 0.0)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
+
+    cumproba = clf.predict_cumproba(X)
+    assert cumproba.shape == (X.shape[0], n_classes - 1)
+    assert np.all(cumproba >= 0.0) and np.all(cumproba <= 1.0)
+    assert np.all(np.diff(cumproba, axis=1) >= 0)
+
+    expected_pred = clf.classes_[proba.argmax(axis=1)]
+    np.testing.assert_array_equal(clf.predict(X), expected_pred)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `predict_proba` and `predict_cumproba` to NNOP and NNPOM, matching the probability surface already offered by POM, KDLOR, and ELMOP. Both derive class probabilities from monotonic cumulative estimates. NNPOM probabilities are argmax-consistent with `predict`; NNOP uses its median (first-crossing) decision rule, so `argmax(predict_proba)` need not equal `predict`, as its docstring notes.

This also fixes an NNOP bug: `predict` ran the hidden bias node through the sigmoid instead of the 1.0 used during training, so it evaluated a different network than the one fitted. NNOP predictions change as a result.