### PR TITLE
ENH: Harden experiment results I/O

### DIFF
--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -44,7 +44,9 @@ class Benchmark:
         Names must be recognised by ``skordinal.metrics.get_ordinal_scorer``.
 
     results_path : str or Path
-        Directory where result files are written.
+        Directory where result files are written. Expanded and resolved to
+        an absolute path at construction, so a later working-directory
+        change does not affect where results are written or read.
 
     resamples : int, default=30
         Number of resamples (train/test splits) to load per dataset. Forwarded
@@ -148,7 +150,9 @@ class Benchmark:
         self.data_home: str | Path | None = data_home
         self.datasets: list[str] = list(datasets)
         self.eval_metrics: list[str] = list(eval_metrics)
-        self.results_path: str | Path = results_path
+        # Resolve once so a later chdir cannot split the write and read roots
+        self.results_path = Path(results_path).expanduser().resolve()
+        self._results = Results(self.results_path)
         self.resamples: int = resamples
         self.tuning_metric = tuning_metric
         self.cv = cv
@@ -221,8 +225,6 @@ class Benchmark:
             (no matching path and not present in the bundled collection).
 
         """
-        self._results = Results(Path(self.results_path))
-
         if self.verbose:
             print("\n###############################")
             print("\tRunning Benchmark")

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -88,7 +88,7 @@ def summarize(results_path, *, labels=None, split="test"):
         if label_set is not None and clf not in label_set:
             continue
 
-        df = pd.read_csv(csv_path, index_col=0)
+        df = pd.read_csv(csv_path, index_col=0, float_precision="round_trip")
 
         # Select columns for the requested split
         if split == "test":
@@ -164,7 +164,7 @@ def tabulate_results(results_path, *, metric="mean_absolute_error", split="test"
     rows = []
 
     for clf, ds, csv_path in _iter_pairs(results_path):
-        df = pd.read_csv(csv_path, index_col=0)
+        df = pd.read_csv(csv_path, index_col=0, float_precision="round_trip")
         # Format as "mean +/- std", or "n/a" when metric is absent or all-NaN
         if col not in df.columns or df[col].isna().all():
             cell = "n/a"

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from ._results import _atomic_write
+
 
 def _check_split(split, *, allow_both):
     """Raise ValueError when split is not a recognised value."""
@@ -225,5 +227,5 @@ def save_summary(results_path, *, split="test"):
         f"{outer}_{inner}" if inner else outer for outer, inner in flat.columns
     ]
     out_path = Path(results_path) / f"{split}_summary.csv"
-    flat.to_csv(out_path)
+    _atomic_write(out_path, flat.to_csv())
     return out_path

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -12,6 +14,37 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
 from sklearn.metrics import confusion_matrix
+
+_TEMP_PREFIX = ".skordinal-tmp-"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write text to path atomically via a temp file, fsync and replace."""
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=_TEMP_PREFIX, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def _atomic_dump(path: Path, obj: Any) -> None:
+    """Serialise obj to path atomically via a temp file, fsync and replace."""
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=_TEMP_PREFIX, suffix=".tmp")
+    try:
+        # Close the mkstemp descriptor; joblib opens its own handle by path
+        os.close(fd)
+        joblib.dump(obj, tmp)
+        with open(tmp, "rb") as fh:
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
 
 
 @dataclass(frozen=True)
@@ -142,14 +175,18 @@ def _write_split_files(
             )
         prediction = np.searchsorted(classes, predicted_y)
     columns["Prediction"] = prediction
-    pd.DataFrame(columns).to_csv(seed_dir / f"{split}_predictions.csv", index=False)
+    _atomic_write(
+        seed_dir / f"{split}_predictions.csv",
+        pd.DataFrame(columns).to_csv(index=False),
+    )
 
     cm = confusion_matrix(target, prediction, labels=np.arange(classes.size))
     body = np.array2string(
         cm, separator=", ", threshold=cm.size, max_line_width=sys.maxsize
     )
-    (seed_dir / f"{split}_confusion_matrix.txt").write_text(
-        f"Seed {resample_id}\n{'=' * 21}\n{body}\n", encoding="utf-8"
+    _atomic_write(
+        seed_dir / f"{split}_confusion_matrix.txt",
+        f"Seed {resample_id}\n{'=' * 21}\n{body}\n",
     )
 
 
@@ -288,7 +325,7 @@ class Results:
             )
 
         if save_model:
-            joblib.dump(result.best_model, models_dir / f"{result.resample_id}.joblib")
+            _atomic_dump(models_dir / f"{result.resample_id}.joblib", result.best_model)
 
         self._append_report_row(result, base_dir)
         self._upsert_hyperparameters(result, base_dir)
@@ -325,7 +362,7 @@ class Results:
             existing = pd.read_csv(csv_path, index_col=0)
             existing.index = existing.index.astype(str)
             df = pd.concat([existing, df])
-        df.to_csv(csv_path)
+        _atomic_write(csv_path, df.to_csv())
 
     def _upsert_hyperparameters(self, result: ExperimentResult, base_dir: Path) -> None:
         """Upsert one seed's row in the hyperparameter configuration CSV."""
@@ -345,7 +382,7 @@ class Results:
         columns = ["Seed"] + sorted(c for c in df.columns if c != "Seed")
         df = df[columns].sort_values("Seed").reset_index(drop=True)
         # Restore integer dtypes upcast to float by the NaN column union
-        df.convert_dtypes().to_csv(csv_path, index=False)
+        _atomic_write(csv_path, df.convert_dtypes().to_csv(index=False))
 
     @classmethod
     def load(cls, experiment_folder: str | Path) -> Results:

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -47,6 +47,16 @@ def _atomic_dump(path: Path, obj: Any) -> None:
         raise
 
 
+def _check_path_component(name: Any, what: str) -> None:
+    """Reject a path component that is empty, dotted or holds a separator."""
+    if not isinstance(name, str):
+        raise TypeError(f"{what} must be a str; got {type(name).__name__}.")
+    if name in ("", ".", ".."):
+        raise ValueError(f"{what} must not be empty or a dot segment; got {name!r}.")
+    if any(sep in name for sep in (os.sep, "/", os.altsep) if sep):
+        raise ValueError(f"{what} must not contain a path separator; got {name!r}.")
+
+
 @dataclass(frozen=True)
 class ExperimentResult:
     """Result of running a single classifier on one dataset partition.
@@ -263,8 +273,14 @@ class Results:
 
         Raises
         ------
+        TypeError
+            If ``result.classifier_name`` or ``result.dataset_name`` is not
+            a string.
+
         ValueError
-            If ``result`` lacks the true labels required for the ``Target``
+            If ``result.classifier_name`` or ``result.dataset_name`` is
+            empty, a dot segment, or contains a path separator, if
+            ``result`` lacks the true labels required for the ``Target``
             column (``train_true_y``, or ``test_true_y`` when test
             predictions are present), if a true or predicted label is not
             one of ``best_model.classes_``, or if a probability matrix does
@@ -330,6 +346,12 @@ class Results:
         self._append_report_row(result, base_dir)
         self._upsert_hyperparameters(result, base_dir)
 
+    def _pair_dir(self, classifier_name: str, dataset_name: str) -> Path:
+        """Validate both components and return the classifier/dataset dir."""
+        _check_path_component(classifier_name, "classifier_name")
+        _check_path_component(dataset_name, "dataset_name")
+        return self._experiment_folder / classifier_name / dataset_name
+
     def _ensure_dirs(
         self,
         classifier_name: str,
@@ -339,7 +361,7 @@ class Results:
         save_model: bool,
     ) -> tuple[Path, Path, Path]:
         """Create required sub-directories and return their paths."""
-        base = self._experiment_folder / classifier_name / dataset_name
+        base = self._pair_dir(classifier_name, dataset_name)
         seed_dir = base / "predictions_by_seed" / f"seed_{resample_id}"
         models_dir = base / "models"
         try:
@@ -359,7 +381,7 @@ class Results:
         csv_path = base_dir / "report.csv"
         df = pd.DataFrame([row], index=pd.Index([result.resample_id], dtype=str))
         if csv_path.is_file():
-            existing = pd.read_csv(csv_path, index_col=0)
+            existing = pd.read_csv(csv_path, index_col=0, float_precision="round_trip")
             existing.index = existing.index.astype(str)
             df = pd.concat([existing, df])
         _atomic_write(csv_path, df.to_csv())
@@ -375,7 +397,7 @@ class Results:
         csv_path = base_dir / "hyperparameter_configuration.csv"
         df = pd.DataFrame([row])
         if csv_path.is_file():
-            existing = pd.read_csv(csv_path)
+            existing = pd.read_csv(csv_path, float_precision="round_trip")
             existing = existing[existing["Seed"] != result.resample_id]
             df = pd.concat([existing, df], ignore_index=True)
 
@@ -434,6 +456,15 @@ class Results:
             ``True`` if the per-pair CSV exists **and** contains a row
             whose index equals ``resample_id``.
 
+        Raises
+        ------
+        TypeError
+            If ``classifier_name`` or ``dataset_name`` is not a string.
+
+        ValueError
+            If ``classifier_name`` or ``dataset_name`` is empty, a dot
+            segment, or contains a path separator.
+
         Examples
         --------
         >>> from skordinal.experiments import Results
@@ -442,9 +473,7 @@ class Results:
         False
 
         """
-        csv_path = (
-            self._experiment_folder / classifier_name / dataset_name / "report.csv"
-        )
+        csv_path = self._pair_dir(classifier_name, dataset_name) / "report.csv"
         if not csv_path.is_file():
             return False
         df = pd.read_csv(csv_path, index_col=0)

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -261,7 +261,11 @@ class Results:
         *,
         save_model: bool = True,
     ) -> None:
-        """Write per-seed files, the report row, hyperparameters and model.
+        """Write per-seed files, the model, hyperparameters and the report row.
+
+        The report row is written last and acts as the commit marker read
+        by ``exists``: a save interrupted at any earlier point leaves no
+        row, so a rerun detects the partition as missing and rewrites it.
 
         Parameters
         ----------
@@ -315,6 +319,13 @@ class Results:
             result.resample_id,
             save_model=save_model,
         )
+        # Clear any temp file left by a prior crash before writing new ones
+        for stray in base_dir.rglob(f"{_TEMP_PREFIX}*"):
+            if stray.is_file():
+                stray.unlink(missing_ok=True)
+        # Drop this resample's committed row so a crash mid-write cannot
+        # leave a report row describing predictions no longer on disk
+        self._uncommit_report_row(base_dir, result.resample_id)
 
         classes = np.asarray(result.best_model.classes_)
         _write_split_files(
@@ -343,8 +354,9 @@ class Results:
         if save_model:
             _atomic_dump(models_dir / f"{result.resample_id}.joblib", result.best_model)
 
-        self._append_report_row(result, base_dir)
         self._upsert_hyperparameters(result, base_dir)
+        # Write the report row last: it is the commit marker for exists()
+        self._append_report_row(result, base_dir)
 
     def _pair_dir(self, classifier_name: str, dataset_name: str) -> Path:
         """Validate both components and return the classifier/dataset dir."""
@@ -374,8 +386,24 @@ class Results:
             )
         return base, models_dir, seed_dir
 
+    def _uncommit_report_row(self, base_dir: Path, resample_id: int) -> None:
+        """Drop this resample's row from report.csv before rewriting it."""
+        csv_path = base_dir / "report.csv"
+        if not csv_path.is_file():
+            return
+        df = pd.read_csv(csv_path, index_col=0, float_precision="round_trip")
+        df.index = df.index.astype(str)
+        if str(resample_id) not in df.index:
+            return
+        df = df.drop(index=str(resample_id))
+        if df.empty:
+            # Remove the commit marker entirely so exists() reports False
+            csv_path.unlink()
+            return
+        _atomic_write(csv_path, df.to_csv())
+
     def _append_report_row(self, result: ExperimentResult, base_dir: Path) -> None:
-        """Append one metrics row to ``report.csv``."""
+        """Append one metrics row to report.csv."""
         row: dict[str, Any] = {**result.train_metrics, **result.test_metrics}
 
         csv_path = base_dir / "report.csv"

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -1,6 +1,7 @@
 """Tests for the benchmark runner module."""
 
 import json
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -343,3 +344,30 @@ def test_verbose_false_no_stdout(tmp_path, capsys):
     b.run()
     captured = capsys.readouterr()
     assert captured.out == ""
+
+
+def test_results_path_resolved_once_across_chdir(tmp_path, monkeypatch):
+    """A relative results_path is anchored at construction, not at run."""
+    work_a = tmp_path / "a"
+    work_b = tmp_path / "b"
+    work_a.mkdir()
+    work_b.mkdir()
+    monkeypatch.chdir(work_a)
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path="runs",
+        resamples=3,
+        cv=2,
+        verbose=False,
+        random_state=0,
+    )
+    # results_path is now absolute and anchored under work_a
+    assert Path(b.results_path).is_absolute()
+    assert Path(b.results_path) == (work_a / "runs").resolve()
+    monkeypatch.chdir(work_b)
+    b.run()
+    # Results land under the construction-time root, not the new cwd
+    assert (work_a / "runs" / "SVM" / _BUNDLED_DS / "report.csv").is_file()
+    assert not (work_b / "runs").exists()

--- a/skordinal/experiments/tests/test_evaluation.py
+++ b/skordinal/experiments/tests/test_evaluation.py
@@ -244,3 +244,11 @@ def test_save_summary_empty_folder_raises(tmp_path):
     """save_summary raises ValueError when there are no results."""
     with pytest.raises(ValueError, match="No results"):
         save_summary(tmp_path)
+
+
+def test_summarize_round_trip_precision(tmp_path):
+    """summarize reports a single high-precision metric bit-exact."""
+    value = 0.12345678901234566
+    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": value}])
+    df = summarize(tmp_path, split="test")
+    assert df.loc[("clf", "ds"), ("mae_test", "mean")] == value

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -15,6 +15,7 @@ from skordinal.experiments._results import (
     _TEMP_PREFIX,
     _atomic_dump,
     _atomic_write,
+    _check_path_component,
     _format_proba_column,
     _write_split_files,
 )
@@ -646,3 +647,73 @@ def test_atomic_dump_round_trips_no_temp(tmp_path):
     _atomic_dump(target, {"k": [1, 2, 3]})
     assert joblib.load(target) == {"k": [1, 2, 3]}
     assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
+
+
+@pytest.mark.parametrize("bad", ["", ".", "..", "a/b", f"a{os.sep}b"])
+def test_check_path_component_rejects_bad_strings(bad):
+    """_check_path_component rejects empty, dotted or separator names."""
+    with pytest.raises(ValueError):
+        _check_path_component(bad, "classifier_name")
+
+
+@pytest.mark.parametrize("bad", [3, None, ("x",)])
+def test_check_path_component_rejects_non_str(bad):
+    """_check_path_component rejects a non-string component."""
+    with pytest.raises(TypeError):
+        _check_path_component(bad, "classifier_name")
+
+
+def test_save_rejects_traversal_before_writing(tmp_path):
+    """save raises on a traversal component and writes nothing."""
+    result = _make_result(
+        partition=0,
+        dataset="..",
+        configuration="clf",
+        best_params={},
+        train_metrics={"mae_train": 0.1},
+        test_metrics={"mae_test": 0.1},
+        train_predicted_y=np.array([1]),
+        test_predicted_y=np.array([1]),
+    )
+    with pytest.raises(ValueError):
+        Results(tmp_path).save(result, save_model=False)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_report_row_round_trip_precision(tmp_path):
+    """A high-precision metric survives a later save's report read."""
+    value = 0.12345678901234566
+    r = Results(tmp_path)
+    r.save(
+        _make_result(
+            partition=0,
+            dataset="ds",
+            configuration="clf",
+            best_params={},
+            train_metrics={"mae_train": value},
+            test_metrics={"mae_test": 0.1},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=np.array([1]),
+        ),
+        save_model=False,
+    )
+    # Second save reads report.csv back through the round-trip reader
+    r.save(
+        _make_result(
+            partition=1,
+            dataset="ds",
+            configuration="clf",
+            best_params={},
+            train_metrics={"mae_train": 0.2},
+            test_metrics={"mae_test": 0.2},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=np.array([1]),
+        ),
+        save_model=False,
+    )
+    df = pd.read_csv(
+        tmp_path / "clf" / "ds" / "report.csv",
+        index_col=0,
+        float_precision="round_trip",
+    )
+    assert df.loc[0, "mae_train"] == value

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -1,5 +1,7 @@
 """Tests for the Results class."""
 
+import os
+
 import joblib
 import numpy as np
 import numpy.testing as npt
@@ -9,7 +11,13 @@ from sklearn.metrics import confusion_matrix
 from sklearn.svm import SVC
 
 from skordinal.experiments import ExperimentResult, Results
-from skordinal.experiments._results import _format_proba_column, _write_split_files
+from skordinal.experiments._results import (
+    _TEMP_PREFIX,
+    _atomic_dump,
+    _atomic_write,
+    _format_proba_column,
+    _write_split_files,
+)
 
 
 def _fitted_svc(classes=(1, 2, 3), probability=False):
@@ -586,3 +594,55 @@ def test_exists(tmp_path):
     )
     assert r.exists("SVC", "toy", "0") is True
     assert r.exists("SVC", "toy", "1") is False
+
+
+def test_atomic_write_success_leaves_no_temp(tmp_path):
+    """_atomic_write writes full content and leaves no temp file."""
+    target = tmp_path / "f.csv"
+    _atomic_write(target, "a,b\n1,2\n")
+    assert target.read_text() == "a,b\n1,2\n"
+    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
+
+
+def test_atomic_write_cleans_up_on_failure(tmp_path, monkeypatch):
+    """A failing os.replace unlinks the temp file and re-raises."""
+    monkeypatch.setattr(
+        "skordinal.experiments._results.os.replace",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")),
+    )
+    with pytest.raises(OSError, match="boom"):
+        _atomic_write(tmp_path / "f.csv", "data")
+    assert not (tmp_path / "f.csv").exists()
+    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
+
+
+def test_atomic_write_fsyncs(tmp_path, monkeypatch):
+    """_atomic_write calls os.fsync on the temp file descriptor."""
+    calls = []
+    real_fsync = os.fsync
+    monkeypatch.setattr(
+        "skordinal.experiments._results.os.fsync",
+        lambda fd: calls.append(fd) or real_fsync(fd),
+    )
+    _atomic_write(tmp_path / "f.txt", "x")
+    assert len(calls) == 1
+
+
+def test_atomic_dump_cleans_up_on_failure(tmp_path, monkeypatch):
+    """A failing os.replace unlinks the dump's temp file and re-raises."""
+    monkeypatch.setattr(
+        "skordinal.experiments._results.os.replace",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")),
+    )
+    with pytest.raises(OSError, match="boom"):
+        _atomic_dump(tmp_path / "m.joblib", {"k": 1})
+    assert not (tmp_path / "m.joblib").exists()
+    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
+
+
+def test_atomic_dump_round_trips_no_temp(tmp_path):
+    """_atomic_dump serialises an object recoverable by joblib.load."""
+    target = tmp_path / "m.joblib"
+    _atomic_dump(target, {"k": [1, 2, 3]})
+    assert joblib.load(target) == {"k": [1, 2, 3]}
+    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -717,3 +717,105 @@ def test_report_row_round_trip_precision(tmp_path):
         float_precision="round_trip",
     )
     assert df.loc[0, "mae_train"] == value
+
+
+def test_resave_is_idempotent_no_duplicate_row(tmp_path):
+    """Re-saving the same resample keeps exactly one report row."""
+    r = Results(tmp_path)
+    for _ in range(2):
+        r.save(
+            _make_result(
+                partition=0,
+                dataset="ds",
+                configuration="clf",
+                best_params={},
+                train_metrics={"mae_train": 0.1},
+                test_metrics={"mae_test": 0.1},
+                train_predicted_y=np.array([1]),
+                test_predicted_y=np.array([1]),
+            ),
+            save_model=False,
+        )
+    df = pd.read_csv(tmp_path / "clf" / "ds" / "report.csv", index_col=0)
+    assert df.shape[0] == 1
+
+
+def test_orphan_temp_file_swept_on_save(tmp_path):
+    """A leftover temp file under the pair dir is removed by save."""
+    pair = tmp_path / "clf" / "ds"
+    (pair / "predictions_by_seed" / "seed_0").mkdir(parents=True)
+    stale = pair / f"{_TEMP_PREFIX}leftover.tmp"
+    stale.write_text("junk")
+    Results(tmp_path).save(
+        _make_result(
+            partition=0,
+            dataset="ds",
+            configuration="clf",
+            best_params={},
+            train_metrics={"mae_train": 0.1},
+            test_metrics={"mae_test": 0.1},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=np.array([1]),
+        ),
+        save_model=False,
+    )
+    assert not stale.exists()
+
+
+def test_crash_between_predictions_and_report_not_committed(tmp_path, monkeypatch):
+    """A crash before the report write leaves exists() False; rerun fixes it."""
+    r = Results(tmp_path)
+    kwargs = dict(
+        partition=0,
+        dataset="ds",
+        configuration="clf",
+        best_params={},
+        train_metrics={"mae_train": 0.1},
+        test_metrics={"mae_test": 0.1},
+        train_predicted_y=np.array([1]),
+        test_predicted_y=np.array([1]),
+    )
+    monkeypatch.setattr(
+        Results,
+        "_append_report_row",
+        lambda self, *a, **k: (_ for _ in ()).throw(RuntimeError("crash")),
+    )
+    with pytest.raises(RuntimeError):
+        r.save(_make_result(**kwargs), save_model=False)
+    # Predictions were written but no report row was committed
+    seed = tmp_path / "clf" / "ds" / "predictions_by_seed" / "seed_0"
+    assert (seed / "train_predictions.csv").is_file()
+    assert r.exists("clf", "ds", "0") is False
+    # A normal rerun commits the row
+    monkeypatch.undo()
+    r.save(_make_result(**kwargs), save_model=False)
+    assert r.exists("clf", "ds", "0") is True
+
+
+def test_stale_report_row_uncommitted_on_crash_resave(tmp_path, monkeypatch):
+    """Re-saving a resample uncommits its row; a crash leaves it uncommitted."""
+    r = Results(tmp_path)
+    kwargs = dict(
+        partition=0,
+        dataset="ds",
+        configuration="clf",
+        best_params={},
+        train_metrics={"mae_train": 0.1},
+        test_metrics={"mae_test": 0.1},
+        train_predicted_y=np.array([1]),
+        test_predicted_y=np.array([1]),
+    )
+    r.save(_make_result(**kwargs), save_model=False)
+    assert r.exists("clf", "ds", "0") is True
+    # Crash on re-save after the uncommit but before the recommit
+    monkeypatch.setattr(
+        Results,
+        "_append_report_row",
+        lambda self, *a, **k: (_ for _ in ()).throw(RuntimeError("crash")),
+    )
+    with pytest.raises(RuntimeError):
+        r.save(_make_result(**kwargs), save_model=False)
+    assert r.exists("clf", "ds", "0") is False
+    monkeypatch.undo()
+    r.save(_make_result(**kwargs), save_model=False)
+    assert r.exists("clf", "ds", "0") is True


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Makes the experiments results layer durable and crash-safe. Every result file is written atomically (temp file, fsync, rename), so an interrupted write cannot leave a partially written file. Each save writes its `report.csv` row last as a commit marker and is idempotent on re-run. Classifier and dataset names are validated before any directory is created, blocking path traversal. Metric CSVs round-trip at full float precision. `Benchmark` resolves its results path once, so a later working-directory change cannot split reads from writes.