### PR TITLE
BLD: Update dependency bounds and metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,18 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "MNT"
+
+  # Maintain the Python runtime dependencies declared in pyproject.toml
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "MNT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,18 @@ authors = [
     {name = "Víctor Manuel Vargas", email = "vvargas@uco.es"},
     {name = "Pedro A. Gutiérrez", email = "pagutierrez@uco.es"},
 ]
+keywords = [
+    "ordinal classification",
+    "ordinal regression",
+    "machine learning",
+    "scikit-learn",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
+    "Operating System :: MacOS",
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Programming Language :: C",
@@ -34,10 +41,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "scikit-learn>=1.3.0",
-    "numpy>=1.21",
-    "pandas>=1.0.1",
-    "scipy>=1.7",
+    "scikit-learn>=1.6",
+    "numpy>=1.23",
+    "pandas>=1.5",
+    "scipy>=1.10",
+    "joblib>=1.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Raises the declared dependency floors to what the code actually requires (notably scikit-learn>=1.6) and declares joblib, previously only a transitive dependency. Adds package keywords and a macOS classifier, and extends dependabot to the Python dependencies, not only GitHub Actions.