### PR TITLE
REF: Validate metric and preprocessing function parameters

### DIFF
--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -1,17 +1,13 @@
 """Metrics for ordinal classification."""
 
-from __future__ import annotations
-
 import numpy as np
 import scipy.stats
-from numpy.typing import ArrayLike, NDArray
 from sklearn.metrics import confusion_matrix, recall_score
 from sklearn.utils import check_array, check_consistent_length
+from sklearn.utils._param_validation import validate_params
 
 
-def _check_metric_inputs(
-    y_true: ArrayLike, y_pred: ArrayLike
-) -> tuple[NDArray, NDArray]:
+def _check_metric_inputs(y_true, y_pred):
     """Coerce metric inputs to 1-D arrays and validate length consistency.
 
     Two-dimensional inputs are interpreted as one-hot encoded labels and
@@ -46,9 +42,7 @@ def _check_metric_inputs(
     return y_true_arr, y_pred_arr
 
 
-def _check_proba_inputs(
-    y_true: ArrayLike, y_proba: ArrayLike, *, sum_atol: float = 1e-6
-) -> tuple[NDArray, NDArray[np.float64]]:
+def _check_proba_inputs(y_true, y_proba, *, sum_atol=1e-6):
     """Validate inputs for probabilistic ordinal metrics.
 
     ``y_true`` may be 1-D class labels or a 2-D one-hot matrix.
@@ -93,13 +87,7 @@ def _check_proba_inputs(
     return y_true_arr, y_proba_arr
 
 
-def _recall_per_class(
-    y_true: NDArray,
-    y_pred: NDArray,
-    *,
-    labels: ArrayLike | None = None,
-    sample_weight: ArrayLike | None = None,
-) -> NDArray[np.float64]:
+def _recall_per_class(y_true, y_pred, *, labels=None, sample_weight=None):
     """Return per-class recall as a 1-D float64 ndarray.
 
     Thin wrapper around :func:`sklearn.metrics.recall_score` with
@@ -138,13 +126,7 @@ def _recall_per_class(
     )
 
 
-def _per_class_mae(
-    y_true: NDArray,
-    y_pred: NDArray,
-    *,
-    labels: ArrayLike | None = None,
-    sample_weight: ArrayLike | None = None,
-) -> NDArray[np.float64]:
+def _per_class_mae(y_true, y_pred, *, labels=None, sample_weight=None):
     """Return per-class mean absolute error as a 1-D float64 ndarray.
 
     Drops rows of the confusion matrix with no support (zero true
@@ -179,12 +161,15 @@ def _per_class_mae(
     return errors[non_zero].sum(axis=1) / support[non_zero]
 
 
-def average_mean_absolute_error(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    *,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     """Compute the average per-class mean absolute error.
 
     For each class with at least one ground-truth sample, the mean
@@ -226,12 +211,15 @@ def average_mean_absolute_error(
     return float(_per_class_mae(y_true, y_pred, sample_weight=sample_weight).mean())
 
 
-def geometric_mean(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    *,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def geometric_mean(y_true, y_pred, *, sample_weight=None):
     """Compute the geometric mean of per-class sensitivities.
 
     Sensitivity (recall) is computed for every class from the confusion
@@ -280,12 +268,15 @@ def geometric_mean(
     return float(pow(np.prod(sensitivities), 1.0 / cm.shape[0]))
 
 
-def gmsec(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    *,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def gmsec(y_true, y_pred, *, sample_weight=None):
     """Geometric mean of the sensitivities of the extreme ordinal classes.
 
     Proposed in :footcite:t:`vargas2024improving` to assess the
@@ -328,12 +319,15 @@ def gmsec(
     return float(np.sqrt(sensitivities[0] * sensitivities[-1]))
 
 
-def mean_extreme_sensitivity(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    *,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def mean_extreme_sensitivity(y_true, y_pred, *, sample_weight=None):
     """Arithmetic mean of the sensitivities of the extreme ordinal classes.
 
     Assesses the balanced performance between the extreme classes of an
@@ -371,12 +365,15 @@ def mean_extreme_sensitivity(
     return float((sensitivities[0] + sensitivities[-1]) / 2.0)
 
 
-def maximum_mean_absolute_error(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    *,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def maximum_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     """Compute the maximum per-class mean absolute error.
 
     Returns the largest per-class MAE across classes with at least one
@@ -417,12 +414,15 @@ def maximum_mean_absolute_error(
     return float(_per_class_mae(y_true, y_pred, sample_weight=sample_weight).max())
 
 
-def minimum_sensitivity(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    *,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def minimum_sensitivity(y_true, y_pred, *, sample_weight=None):
     """Lowest per-class sensitivity.
 
     Returns the minimum recall across all classes present in
@@ -460,12 +460,15 @@ def minimum_sensitivity(
     return float(np.min(sensitivities))
 
 
-def mean_zero_one_error(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    *,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def mean_zero_one_error(y_true, y_pred, *, sample_weight=None):
     """Fraction of misclassified samples (error rate).
 
     Equivalent to ``1 - accuracy``; the complementary measure of the
@@ -502,7 +505,11 @@ def mean_zero_one_error(
     return float(1 - np.diagonal(cm).sum() / cm.sum())
 
 
-def kendalls_tau(y_true: ArrayLike, y_pred: ArrayLike) -> float:
+@validate_params(
+    {"y_true": ["array-like"], "y_pred": ["array-like"]},
+    prefer_skip_nested_validation=True,
+)
+def kendalls_tau(y_true, y_pred):
     """Kendall's tau rank correlation coefficient.
 
     Measures the ordinal association between ``y_true`` and ``y_pred``
@@ -542,12 +549,15 @@ def kendalls_tau(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     return float(corr)
 
 
-def weighted_kappa(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    *,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def weighted_kappa(y_true, y_pred, *, sample_weight=None):
     """Weighted Cohen's kappa with linear ordinal weights.
 
     A version of the kappa statistic that assigns different weights to
@@ -598,7 +608,11 @@ def weighted_kappa(
     return float((po - pe) / (1 - pe))
 
 
-def spearmans_rho(y_true: ArrayLike, y_pred: ArrayLike) -> float:
+@validate_params(
+    {"y_true": ["array-like"], "y_pred": ["array-like"]},
+    prefer_skip_nested_validation=True,
+)
+def spearmans_rho(y_true, y_pred):
     """Spearman's rank correlation coefficient between two ordinal vectors.
 
     A non-parametric measure of monotonic association computed from
@@ -645,12 +659,15 @@ def spearmans_rho(y_true: ArrayLike, y_pred: ArrayLike) -> float:
     return float(num / div)
 
 
-def ranked_probability_score(
-    y_true: ArrayLike,
-    y_proba: ArrayLike,
-    *,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_proba": ["array-like"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     """Ranked probability score for ordinal class probabilities.
 
     Quadratic distance between the cumulative ground-truth indicator
@@ -718,13 +735,16 @@ def ranked_probability_score(
     return float(np.average(per_sample, weights=weights))
 
 
-def accuracy_off1_score(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    *,
-    labels: ArrayLike | None = None,
-    sample_weight: ArrayLike | None = None,
-) -> float:
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "labels": ["array-like", None],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def accuracy_off1_score(y_true, y_pred, *, labels=None, sample_weight=None):
     """1-off accuracy: predictions in adjacent classes count as correct.
 
     A prediction is counted as correct when it lies within one class

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -1,10 +1,7 @@
 """Scorer registry for ordinal classification metrics."""
 
-from __future__ import annotations
-
-from collections.abc import Callable
-
 from sklearn.metrics import accuracy_score, make_scorer, mean_absolute_error
+from sklearn.utils._param_validation import validate_params
 
 from ._metrics import (
     accuracy_off1_score,
@@ -21,7 +18,7 @@ from ._metrics import (
     weighted_kappa,
 )
 
-_SCORERS: dict[str, Callable] = {
+_SCORERS = {
     "neg_average_mean_absolute_error": make_scorer(
         average_mean_absolute_error, greater_is_better=False
     ),
@@ -59,7 +56,8 @@ _SCORERS: dict[str, Callable] = {
 __all__ = ["get_ordinal_scorer", "list_ordinal_scorers"]
 
 
-def get_ordinal_scorer(name: str) -> Callable:
+@validate_params({"name": [str]}, prefer_skip_nested_validation=True)
+def get_ordinal_scorer(name):
     """Return a scikit-learn-compatible scorer by name.
 
     Parameters
@@ -76,8 +74,6 @@ def get_ordinal_scorer(name: str) -> Callable:
 
     Raises
     ------
-    TypeError
-        If ``name`` is not a string.
     ValueError
         If ``name`` is not a registered scorer name.
 
@@ -89,8 +85,6 @@ def get_ordinal_scorer(name: str) -> Callable:
     True
 
     """
-    if not isinstance(name, str):
-        raise TypeError(f"name must be a string, got {type(name)}.")
     key = name.strip()
     if key in _SCORERS:
         return _SCORERS[key]
@@ -99,7 +93,7 @@ def get_ordinal_scorer(name: str) -> Callable:
     )
 
 
-def list_ordinal_scorers() -> list[str]:
+def list_ordinal_scorers():
     """Return the sorted list of registered ordinal scorer names.
 
     Returns

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -5,6 +5,7 @@ import inspect
 import numpy as np
 import numpy.testing as npt
 import pytest
+from sklearn.utils._param_validation import InvalidParameterError
 
 from skordinal.metrics import (
     accuracy_off1_score,
@@ -395,3 +396,10 @@ def test_metric_returns_python_float(fn):
     assert type(result) is float, (
         f"{fn.__name__} returned {type(result).__name__}, expected float"
     )
+
+
+def test_metric_rejects_non_array_like_y_true():
+    """A scalar y_true is rejected at the parameter boundary."""
+    # decorator fires before _check_metric_inputs
+    with pytest.raises(InvalidParameterError):
+        average_mean_absolute_error(1.0, [1, 2])

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -4,6 +4,7 @@ import numpy.testing as npt
 import pytest
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
+from sklearn.utils._param_validation import InvalidParameterError
 
 from skordinal.metrics import (
     accuracy_off1_score,
@@ -137,9 +138,9 @@ def test_gridcv_with_loss_scorer():
     assert gs.best_score_ <= 0
 
 
-def test_get_ordinal_scorer_type_error():
-    """Non-string input raises TypeError."""
-    with pytest.raises(TypeError, match="must be a string"):
+def test_get_ordinal_scorer_rejects_non_string():
+    """A non-string name is rejected at the parameter boundary."""
+    with pytest.raises(InvalidParameterError):
         get_ordinal_scorer(123)
 
 

--- a/skordinal/preprocessing/_coding.py
+++ b/skordinal/preprocessing/_coding.py
@@ -1,9 +1,9 @@
 """Ordinal coding utilities."""
 
-from __future__ import annotations
+from numbers import Integral
 
 import numpy as np
-from numpy.typing import ArrayLike
+from sklearn.utils._param_validation import Interval, StrOptions, validate_params
 
 _VALID_DECOMPOSITIONS = (
     "ordered_partitions",
@@ -13,10 +13,11 @@ _VALID_DECOMPOSITIONS = (
 )
 
 
-def ordinal_to_binary_cumulative(
-    y: ArrayLike,
-    classes: ArrayLike,
-) -> np.ndarray:
+@validate_params(
+    {"y": ["array-like"], "classes": ["array-like"]},
+    prefer_skip_nested_validation=True,
+)
+def ordinal_to_binary_cumulative(y, classes):
     """Encode ordinal targets into K-1 binary cumulative problems.
 
     Column ``k`` represents the binary problem
@@ -67,10 +68,11 @@ def ordinal_to_binary_cumulative(
     return (y[:, None] > classes[:-1]).astype(np.intp)
 
 
-def binary_cumulative_to_ordinal(
-    binary_preds: ArrayLike,
-    classes: ArrayLike,
-) -> np.ndarray:
+@validate_params(
+    {"binary_preds": ["array-like"], "classes": ["array-like"]},
+    prefer_skip_nested_validation=True,
+)
+def binary_cumulative_to_ordinal(binary_preds, classes):
     """Decode K-1 binary predictions back to ordinal class labels.
 
     Accepts either hard ``{0, 1}`` predictions or continuous
@@ -124,10 +126,14 @@ def binary_cumulative_to_ordinal(
     return classes[indices]
 
 
-def build_coding_matrix(
-    n_classes: int,
-    decomposition: str,
-) -> np.ndarray:
+@validate_params(
+    {
+        "n_classes": [Interval(Integral, 3, None, closed="left")],
+        "decomposition": [StrOptions(set(_VALID_DECOMPOSITIONS))],
+    },
+    prefer_skip_nested_validation=True,
+)
+def build_coding_matrix(n_classes, decomposition):
     """Return the coding matrix for an ordinal decomposition strategy.
 
     The resulting matrix has one row per class and one column per
@@ -178,14 +184,6 @@ def build_coding_matrix(
        Classification", in Proc. 12th European Conference on Machine Learning
        (ECML 2001), pp. 145-156, 2001.
     """
-    if not isinstance(n_classes, (int, np.integer)) or n_classes < 3:
-        raise ValueError(f"n_classes must be an integer >= 3; got {n_classes!r}.")
-    if decomposition not in _VALID_DECOMPOSITIONS:
-        raise ValueError(
-            f"decomposition must be one of {list(_VALID_DECOMPOSITIONS)}; "
-            f"got {decomposition!r}."
-        )
-
     K = int(n_classes)
     coding = np.zeros((K, K - 1), dtype=np.intp)
 

--- a/skordinal/preprocessing/tests/test_coding.py
+++ b/skordinal/preprocessing/tests/test_coding.py
@@ -3,6 +3,7 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+from sklearn.utils._param_validation import InvalidParameterError
 
 from skordinal.preprocessing import (
     binary_cumulative_to_ordinal,
@@ -254,3 +255,15 @@ def test_round_trip_encode_decode(K):
         binary_cumulative_to_ordinal(ordinal_to_binary_cumulative(y, classes), classes),
         y,
     )
+
+
+def test_build_coding_matrix_rejects_non_integer_n_classes():
+    """A non-integer n_classes is rejected at the parameter boundary."""
+    with pytest.raises(InvalidParameterError):
+        build_coding_matrix(3.5, "ordered_partitions")
+
+
+def test_encode_rejects_non_array_like_y():
+    """A scalar y is rejected at the parameter boundary."""
+    with pytest.raises(InvalidParameterError):
+        ordinal_to_binary_cumulative(1, np.array([0, 1, 2]))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds scikit-learn's `@validate_params` to the public functions in `metrics/` and `preprocessing/` and drops their static type hints. Numeric results are unchanged. The one behavioural change: `get_ordinal_scorer` on a non-string now raises `InvalidParameterError` (a `ValueError`) instead of `TypeError`.