### PR TITLE
FIX: Require SVOREX degree to be at least 1

### DIFF
--- a/skordinal/classifiers/_svorex.py
+++ b/skordinal/classifiers/_svorex.py
@@ -34,7 +34,8 @@ class SVOREX(ClassifierMixin, BaseEstimator):
         - poly: use Polynomial kernel with order p
 
     degree : int, default=2
-        Set degree in kernel function.
+        Degree of the polynomial kernel; must be at least 1. Ignored by
+        the ``rbf`` and ``linear`` kernels.
 
     tol : float, default=0.001
         Set tolerance of termination criterion.
@@ -66,7 +67,7 @@ class SVOREX(ClassifierMixin, BaseEstimator):
     _parameter_constraints: dict = {
         "C": [Interval(Real, 0.0, None, closed="neither")],
         "kernel": [StrOptions({"rbf", "linear", "poly"})],
-        "degree": [Interval(Integral, 0, None, closed="left")],
+        "degree": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0.0, None, closed="neither")],
         "gamma": [Interval(Real, 0.0, None, closed="neither")],
     }

--- a/skordinal/classifiers/tests/test_svorex.py
+++ b/skordinal/classifiers/tests/test_svorex.py
@@ -54,6 +54,7 @@ def test_svorex_predict_matches_expected(kernel):
         ("C", 0),
         ("C", -1),
         ("degree", -1),
+        ("degree", 0),
         ("tol", 0),
         ("tol", -1e-5),
         ("kernel", "unknown"),


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`SVOREX`'s polynomial-kernel core rejects `degree=0` with a cryptic `- P is invalid` error. The `degree` constraint now requires `>= 1`, so it is rejected with a clear `InvalidParameterError` instead. The bound is deliberately stricter than scikit learn's `SVC`, which tolerates `degree=0`, because the SVOREX core cannot.